### PR TITLE
Reference CODEOWNER by team instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 * @saltpay/lemonade
 
 # Folder-specific owners
-/flutter/   @Filmaluco @matheuslutero
+/flutter/   @saltpay/lemonade @saltpay/lemonade-flutter


### PR DESCRIPTION
Reference code owner by team instead of GH handle