### PR TITLE
[SwiftUI] add support to keyboardtype in TextField

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -116,6 +116,9 @@ public extension LemonadeUi {
 
 // MARK: - TextField with TextFieldValue (Cursor Control)
 
+#if canImport(UIKit)
+import UIKit
+
 public extension LemonadeUi {
     /// Text Field component with TextFieldValue for cursor position control.
     /// Use this overload when you need to programmatically control cursor position,
@@ -161,7 +164,8 @@ public extension LemonadeUi {
         placeholderText: String? = nil,
         errorMessage: String? = nil,
         error: Bool = false,
-        enabled: Bool = true
+        enabled: Bool = true,
+        keyboardType: UIKeyboardType = .default
     ) -> some View {
         LemonadeTextFieldValueView<EmptyView, EmptyView>(
             value: value,
@@ -173,6 +177,7 @@ public extension LemonadeUi {
             errorMessage: errorMessage,
             error: error,
             enabled: enabled,
+            keyboardType: keyboardType,
             leadingContent: nil,
             trailingContent: nil
         )
@@ -204,6 +209,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
+        keyboardType: UIKeyboardType = .default,
         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
         @ViewBuilder trailingContent: @escaping () -> TrailingContent
     ) -> some View {
@@ -217,11 +223,13 @@ public extension LemonadeUi {
             errorMessage: errorMessage,
             error: error,
             enabled: enabled,
+            keyboardType: keyboardType,
             leadingContent: leadingContent,
             trailingContent: trailingContent
         )
     }
 }
+#endif
 
 // MARK: - TextFieldWithSelector Component
 
@@ -337,6 +345,7 @@ public extension LemonadeUi {
 
 // MARK: - TextFieldWithSelector with TextFieldValue (Cursor Control)
 
+#if canImport(UIKit)
 public extension LemonadeUi {
     /// A text input with selector using TextFieldValue for cursor position control.
     /// Use this for structured input like phone numbers where you need to format
@@ -461,6 +470,7 @@ public extension LemonadeUi {
         )
     }
 }
+#endif
 
 // MARK: - Internal TextField View
 
@@ -793,6 +803,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
     let errorMessage: String?
     let error: Bool
     let enabled: Bool
+    let keyboardType: UIKeyboardType
     let leadingContent: (() -> LeadingContent)?
     let trailingContent: (() -> TrailingContent)?
 
@@ -879,6 +890,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
                         isEnabled: enabled,
                         textStyle: LemonadeTypography.shared.bodyMediumRegular,
                         textColor: LemonadeTheme.colors.content.contentPrimary,
+                        keyboardType: keyboardType,
                         onValueChange: onValueChange
                     )
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -392,7 +392,8 @@ public extension LemonadeUi {
         placeholderText: String? = nil,
         errorMessage: String? = nil,
         error: Bool = false,
-        enabled: Bool = true
+        enabled: Bool = true,
+        keyboardType: UIKeyboardType = .default
     ) -> some View {
         LemonadeTextFieldWithSelectorValueView<LeadingContent, EmptyView>(
             value: value,
@@ -406,6 +407,7 @@ public extension LemonadeUi {
             errorMessage: errorMessage,
             error: error,
             enabled: enabled,
+            keyboardType: keyboardType,
             trailingContent: nil
         )
     }
@@ -439,6 +441,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
+        keyboardType: UIKeyboardType = .default,
         @ViewBuilder trailingContent: @escaping () -> TrailingContent
     ) -> some View {
         LemonadeTextFieldWithSelectorValueView(
@@ -453,6 +456,7 @@ public extension LemonadeUi {
             errorMessage: errorMessage,
             error: error,
             enabled: enabled,
+            keyboardType: keyboardType,
             trailingContent: trailingContent
         )
     }
@@ -974,6 +978,8 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
 // MARK: - Internal TextField With Selector Value View (Platform-specific)
 
 #if canImport(UIKit)
+import UIKit
+
 // iOS: Full cursor position control via UITextField
 private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, TrailingContent: View>: View {
     @Binding var value: LemonadeTextFieldValue
@@ -987,6 +993,7 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
     let errorMessage: String?
     let error: Bool
     let enabled: Bool
+    let keyboardType: UIKeyboardType
     let trailingContent: (() -> TrailingContent)?
 
     @State private var isFocused = false
@@ -1085,6 +1092,7 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
                             isEnabled: enabled,
                             textStyle: LemonadeTypography.shared.bodyMediumRegular,
                             textColor: LemonadeTheme.colors.content.contentPrimary,
+                            keyboardType: keyboardType,
                             onValueChange: onValueChange
                         )
                     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -14,6 +14,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
     var isEnabled: Bool
     var textStyle: LemonadeTextStyle
     var textColor: Color
+    var keyboardType: UIKeyboardType
     var onValueChange: ((LemonadeTextFieldValue) -> Void)?
     var onEditingChanged: ((Bool) -> Void)?
 
@@ -31,6 +32,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.borderStyle = .none
         textField.backgroundColor = .clear
         textField.isEnabled = isEnabled
+        textField.keyboardType = keyboardType
         textField.text = value.text
 
         // Set initial cursor position (clamped to valid range)
@@ -85,6 +87,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.isEnabled = isEnabled
         textField.font = textStyle.uiFont
         textField.textColor = UIColor(textColor)
+        textField.keyboardType = keyboardType
 
         // Handle focus state
         updateFocus(textField)

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -14,7 +14,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
     var isEnabled: Bool
     var textStyle: LemonadeTextStyle
     var textColor: Color
-    var keyboardType: UIKeyboardType
+    var keyboardType: UIKeyboardType = .default
     var onValueChange: ((LemonadeTextFieldValue) -> Void)?
     var onEditingChanged: ((Bool) -> Void)?
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -87,7 +87,14 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.isEnabled = isEnabled
         textField.font = textStyle.uiFont
         textField.textColor = UIColor(textColor)
-        textField.keyboardType = keyboardType
+
+        // Update keyboard type and reload if changed while focused
+        if textField.keyboardType != keyboardType {
+            textField.keyboardType = keyboardType
+            if textField.isFirstResponder {
+                textField.reloadInputViews()
+            }
+        }
 
         // Handle focus state
         updateFocus(textField)


### PR DESCRIPTION
# Summary
We cant override the keyboard type for Swift TextField 
## Figma component
N/A
## Screenshot
N/A
