### PR TITLE
feat: add VoiceOver accessibility to all SwiftUI components

### DIFF
--- a/swiftui/Package.swift
+++ b/swiftui/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Lemonade",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v15),
         .macOS(.v12)

--- a/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
@@ -118,6 +118,7 @@ private struct LemonadeBadgeView: View {
                 }
             )
             .clipShape(Capsule())
+            .accessibilityLabel("Badge: \(text)")
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
@@ -95,7 +95,7 @@ private struct LemonadeBadgeView: View {
 
     var body: some View {
         SwiftUI.Text(text)
-            .font(.custom(LemonadeTypography.fontFamily, size: size.fontSize).weight(.semibold))
+            .font(.custom(LemonadeTypography.fontFamily, size: size.fontSize, relativeTo: .caption).weight(.semibold))
             .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
             .lineLimit(1)
             .padding(.horizontal, size.textHorizontalPadding)
@@ -118,7 +118,7 @@ private struct LemonadeBadgeView: View {
                 }
             )
             .clipShape(Capsule())
-            .accessibilityLabel("Badge: \(text)")
+            .accessibilityLabel(lemonadeLocalizedString("lemonade_badge", text))
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeBrandLogo.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBrandLogo.swift
@@ -59,6 +59,7 @@ private struct LemonadeBrandLogoView: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: size.value, height: size.value)
+            .accessibilityLabel(logo.rawValue)
     }
 
     private var logoImage: Image {

--- a/swiftui/Sources/Lemonade/Components/LemonadeCheckbox.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCheckbox.swift
@@ -127,6 +127,8 @@ private struct LemonadeCheckboxWithLabel: View {
         }
         .buttonStyle(PlainButtonStyle())
         .disabled(!enabled)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(status == .checked ? "Checked" : status == .indeterminate ? "Indeterminate" : "Unchecked")
     }
 }
 
@@ -203,6 +205,9 @@ private struct LemonadeCoreCheckbox: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        .accessibilityLabel("Checkbox")
+        .accessibilityValue(status == .checked ? "Checked" : status == .indeterminate ? "Indeterminate" : "Unchecked")
+        .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeCheckbox.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCheckbox.swift
@@ -128,7 +128,13 @@ private struct LemonadeCheckboxWithLabel: View {
         .buttonStyle(PlainButtonStyle())
         .disabled(!enabled)
         .accessibilityElement(children: .combine)
-        .accessibilityValue(status == .checked ? "Checked" : status == .indeterminate ? "Indeterminate" : "Unchecked")
+        .accessibilityValue(
+            status == .checked
+                ? lemonadeLocalizedString("lemonade_checkbox_checked")
+                : status == .indeterminate
+                    ? lemonadeLocalizedString("lemonade_checkbox_indeterminate")
+                    : lemonadeLocalizedString("lemonade_checkbox_unchecked")
+        )
     }
 }
 
@@ -200,13 +206,21 @@ private struct LemonadeCoreCheckbox: View {
             .animation(.easeInOut(duration: 0.15), value: isHovered)
         }
         .frame(height: LemonadeTheme.sizes.size600)
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
         .buttonStyle(PlainButtonStyle())
         .disabled(!enabled)
         .onHover { hovering in
             isHovered = hovering
         }
-        .accessibilityLabel("Checkbox")
-        .accessibilityValue(status == .checked ? "Checked" : status == .indeterminate ? "Indeterminate" : "Unchecked")
+        .accessibilityLabel(lemonadeLocalizedString("lemonade_checkbox"))
+        .accessibilityValue(
+            status == .checked
+                ? lemonadeLocalizedString("lemonade_checkbox_checked")
+                : status == .indeterminate
+                    ? lemonadeLocalizedString("lemonade_checkbox_indeterminate")
+                    : lemonadeLocalizedString("lemonade_checkbox_unchecked")
+        )
         .accessibilityAddTraits(.isButton)
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -276,6 +276,10 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                 onChipClicked()
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(selected ? .isSelected : [])
         .animation(.easeInOut(duration: 0.15), value: selected)
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -235,7 +235,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
             // Counter
             if let counter = counter {
                 SwiftUI.Text("\(counter)")
-                    .font(.custom(LemonadeTypography.fontFamily, size: LemonadeTheme.sizes.size250).weight(.semibold))
+                    .font(.custom(LemonadeTypography.fontFamily, size: LemonadeTheme.sizes.size250, relativeTo: .caption2).weight(.semibold))
                     .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
                     .lineLimit(1)
                     .padding(.horizontal, LemonadeTheme.spaces.spacing100)
@@ -270,7 +270,8 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                 .stroke(borderColor, lineWidth: 1)
         )
         .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
-        .contentShape(Capsule())
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
         .onTapGesture {
             if let onChipClicked = onChipClicked, enabled {
                 onChipClicked()

--- a/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
@@ -70,6 +70,7 @@ private struct LemonadeCountryFlagView: View {
                         lineWidth: LemonadeTheme.borderWidth.base.border25
                     )
             )
+            .accessibilityLabel(flag.countryName)
     }
 
     private var flagImage: Image {

--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -194,6 +194,7 @@ private struct LemonadeDateRangePickerView: View {
             minDate: effectiveMin,
             maxDate: effectiveMax
         )
+        .accessibilityHint(isSelectingEndDate ? "Select an end date" : "Select a start date")
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -194,7 +194,7 @@ private struct LemonadeDateRangePickerView: View {
             minDate: effectiveMin,
             maxDate: effectiveMax
         )
-        .accessibilityHint(isSelectingEndDate ? "Select an end date" : "Select a start date")
+        .accessibilityHint(isSelectingEndDate ? lemonadeLocalizedString("lemonade_select_end_date") : lemonadeLocalizedString("lemonade_select_start_date"))
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -161,6 +161,8 @@ private struct LemonadeIconButtonView: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: size.sizeData.cornerRadius))
         }
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
         .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
         .onHover { hovering in
             isHovering = hovering

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -137,6 +137,7 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                 }
                 .buttonStyle(ListItemButtonStyle(voice: voice))
                 .disabled(!enabled)
+                .accessibilityAddTraits(.isButton)
             } else {
                 listItemContent
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeRadioButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeRadioButton.swift
@@ -194,12 +194,14 @@ private struct LemonadeCoreRadioButton: View {
             .animation(.easeInOut(duration: 0.15), value: isHovered)
         }
         .frame(width: LemonadeTheme.sizes.size550, height: LemonadeTheme.sizes.size600)
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
         .buttonStyle(PlainButtonStyle())
         .disabled(!enabled)
         .onHover { hovering in
             isHovered = hovering
         }
-        .accessibilityLabel("Radio button")
+        .accessibilityLabel(lemonadeLocalizedString("lemonade_radio_button"))
         .accessibilityAddTraits(checked ? .isSelected : [])
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeRadioButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeRadioButton.swift
@@ -114,6 +114,8 @@ private struct LemonadeRadioButtonWithLabel: View {
         }
         .buttonStyle(PlainButtonStyle())
         .disabled(!enabled)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(checked ? .isSelected : [])
     }
 }
 
@@ -197,6 +199,8 @@ private struct LemonadeCoreRadioButton: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        .accessibilityLabel("Radio button")
+        .accessibilityAddTraits(checked ? .isSelected : [])
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -113,6 +113,7 @@ private struct LemonadeSearchFieldView: View {
                     )
                 }
                 .buttonStyle(PlainButtonStyle())
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(.horizontal, horizontalPadding)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -113,7 +113,7 @@ private struct LemonadeSearchFieldView: View {
                     )
                 }
                 .buttonStyle(PlainButtonStyle())
-                .accessibilityLabel("Clear search")
+                .accessibilityLabel(lemonadeLocalizedString("lemonade_clear_search"))
             }
         }
         .padding(.horizontal, horizontalPadding)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
@@ -147,6 +147,9 @@ private struct LemonadeSelectFieldView<LeadingContent: View>: View {
             ))
             .accessibilityAddTraits(.isButton)
             .accessibilityRemoveTraits(.isStaticText)
+            .accessibilityLabel(label ?? "Select field")
+            .accessibilityValue(selectedValue ?? placeholderText ?? "")
+            .accessibilityHint("Double tap to select")
 
             TextFieldSupportText(supportText: supportText, errorMessage: errorMessage, error: error, enabled: enabled)
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
@@ -147,9 +147,9 @@ private struct LemonadeSelectFieldView<LeadingContent: View>: View {
             ))
             .accessibilityAddTraits(.isButton)
             .accessibilityRemoveTraits(.isStaticText)
-            .accessibilityLabel(label ?? "Select field")
+            .accessibilityLabel(label ?? lemonadeLocalizedString("lemonade_select_field"))
             .accessibilityValue(selectedValue ?? placeholderText ?? "")
-            .accessibilityHint("Double tap to select")
+            .accessibilityHint(lemonadeLocalizedString("lemonade_double_tap_to_select"))
 
             TextFieldSupportText(supportText: supportText, errorMessage: errorMessage, error: error, enabled: enabled)
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSelectListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSelectListItem.swift
@@ -84,7 +84,7 @@ public extension LemonadeUi {
                 }
             }
         )
-        .accessibilityValue(checked ? "Selected" : "Not selected")
+        .accessibilityValue(checked ? lemonadeLocalizedString("lemonade_selected") : lemonadeLocalizedString("lemonade_not_selected"))
     }
 
     /// A list item with the sole purpose of selection without leading slot.

--- a/swiftui/Sources/Lemonade/Components/LemonadeSelectListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSelectListItem.swift
@@ -84,6 +84,7 @@ public extension LemonadeUi {
                 }
             }
         )
+        .accessibilityValue(checked ? "Selected" : "Not selected")
     }
 
     /// A list item with the sole purpose of selection without leading slot.

--- a/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
@@ -20,6 +20,7 @@ public extension LemonadeUi {
     ) -> some View {
         ProgressView()
             .tint(tint)
+            .accessibilityLabel("Loading")
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSpinner.swift
@@ -20,7 +20,7 @@ public extension LemonadeUi {
     ) -> some View {
         ProgressView()
             .tint(tint)
-            .accessibilityLabel("Loading")
+            .accessibilityLabel(lemonadeLocalizedString("lemonade_loading"))
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeText.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeText.swift
@@ -167,8 +167,13 @@ private struct LemonadeTextView: View {
             return .body
         }
 
-        let size = fontSize ?? style.fontSize
-        return .custom(LemonadeTypography.fontFamily, size: size).weight(style.fontWeight)
+        if let fontSize = fontSize {
+            // Custom size override — still use correct font name and Dynamic Type
+            return .custom(style.fontName, size: fontSize, relativeTo: .body)
+        }
+
+        // Use the style's built-in font which already has Dynamic Type support
+        return style.font
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -190,6 +190,9 @@ private struct LemonadeTileView<AddonContent: View>: View {
                     onClick()
                 }
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(label)
+            .accessibilityAddTraits(onClick != nil ? .isButton : [])
 
             // Addon badge
             if let addon = addon {

--- a/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
+++ b/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
@@ -1,5 +1,18 @@
 import SwiftUI
 
+// MARK: - Localization Helper
+
+/// Internal helper for localized strings within the Lemonade library bundle.
+func lemonadeLocalizedString(_ key: String) -> String {
+    NSLocalizedString(key, bundle: .lemonade, comment: "")
+}
+
+/// Internal helper for localized strings with format arguments within the Lemonade library bundle.
+func lemonadeLocalizedString(_ key: String, _ arguments: CVarArg...) -> String {
+    let format = NSLocalizedString(key, bundle: .lemonade, comment: "")
+    return String(format: format, arguments: arguments)
+}
+
 // MARK: - Conditional View Modifier
 
 extension View {

--- a/swiftui/Sources/Lemonade/Resources/en.lproj/Localizable.strings
+++ b/swiftui/Sources/Lemonade/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,31 @@
+/* Lemonade Design System – Base (English) localization */
+
+/* LemonadeCheckbox */
+"lemonade_checkbox" = "Checkbox";
+"lemonade_checkbox_checked" = "Checked";
+"lemonade_checkbox_unchecked" = "Unchecked";
+"lemonade_checkbox_indeterminate" = "Indeterminate";
+
+/* LemonadeRadioButton */
+"lemonade_radio_button" = "Radio button";
+
+/* LemonadeSearchField */
+"lemonade_clear_search" = "Clear search";
+
+/* LemonadeSelectField */
+"lemonade_select_field" = "Select field";
+"lemonade_double_tap_to_select" = "Double tap to select";
+
+/* LemonadeSelectListItem */
+"lemonade_selected" = "Selected";
+"lemonade_not_selected" = "Not selected";
+
+/* LemonadeSpinner */
+"lemonade_loading" = "Loading";
+
+/* LemonadeBadge */
+"lemonade_badge" = "Badge: %@";
+
+/* LemonadeDatePicker */
+"lemonade_select_end_date" = "Select an end date";
+"lemonade_select_start_date" = "Select a start date";


### PR DESCRIPTION
## Summary

Adds VoiceOver accessibility, Dynamic Type support, localized labels, and 44pt tap targets to all SwiftUI components. Replaces #101 (rebased on main after #100 merge).

### VoiceOver (13 components)
- **Checkbox** — accessibilityValue (Checked/Unchecked/Indeterminate), children combine
- **RadioButton** — .isSelected trait, children combine
- **Chip** — label, .isButton, .isSelected
- **SelectField** — label, value, hint
- **SearchField** — "Clear search" on clear button
- **Badge** — label with text
- **Tile** — label, .isButton when tappable
- **ListItem** — .isButton on clickable items
- **SelectListItem** — value (Selected/Not selected)
- **Spinner** — label "Loading"
- **BrandLogo/CountryFlag** — label with name
- **DatePicker** — hint for range mode

### Dynamic Type
- LemonadeText.resolveFont() now uses style.font (with relativeTo:)
- Chip counter and Badge fonts use relativeTo: .caption/.caption2

### Localized Labels
- 13 hardcoded English strings → NSLocalizedString with Bundle.lemonade
- en.lproj/Localizable.strings created

### Tap Targets (44pt HIG)
- RadioButton, Checkbox, IconButton (small/medium), Chip expanded to 44pt minimum

## Test plan
- [ ] VoiceOver navigation through all components
- [ ] Dynamic Type with largest accessibility text size
- [ ] Tap targets with Accessibility Inspector
- [ ] Dark mode verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)