### PR TITLE
fix: align iOS Toast tokens and spacing with Figma design

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
@@ -23,7 +23,7 @@ public enum LemonadeToastVoice: Sendable {
     internal func iconColor(colors: LemonadeSemanticColors) -> Color {
         switch self {
         case .success: return colors.content.contentPositiveOnColor
-        case .error: return colors.content.contentCritical
+        case .error: return colors.content.contentCriticalOnColor
         case .neutral: return colors.content.contentNeutralOnColor
         }
     }
@@ -106,7 +106,7 @@ private struct LemonadeToastView: View {
     }
 
     var body: some View {
-        HStack(spacing: .space.spacing300) {
+        HStack(spacing: .space.spacing200) {
             if let icon = displayIcon {
                 LemonadeUi.Icon(
                     icon: icon,
@@ -118,19 +118,20 @@ private struct LemonadeToastView: View {
 
             Text(label)
                 .font(LemonadeTypography.shared.bodySmallMedium.font)
-                .foregroundStyle(.content.contentAlwaysLight)
+                .foregroundStyle(.content.contentPrimaryInverse)
                 .lineLimit(nil)
+                .padding(.horizontal, .space.spacing100)
         }
         .padding(
             EdgeInsets(
                 top: .space.spacing300,
                 leading: .space.spacing400,
                 bottom: .space.spacing300,
-                trailing: .space.spacing500
+                trailing: .space.spacing400
             )
         )
         .frame(minHeight: .size.size1100)
-        .background(.bg.bgAlwaysDark)
+        .background(.bg.bgDefaultInverse)
         .clipShape(RoundedRectangle(cornerRadius: .radius.radiusFull))
         .lemonadeShadow(.large)
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
## Summary
- Align iOS Toast component with Figma design specs and Android KMP implementation
- Pill padding: `spacing400` on both sides (was `spacing400`/`spacing500`)
- Icon-label gap: `spacing200` (was `spacing300`)
- Label: wrapped in `spacing100` horizontal padding for visual centering
- Background: `bgAlwaysDark` → `bgDefaultInverse`
- Text color: `contentAlwaysLight` → `contentPrimaryInverse`
- Error icon: `contentCritical` → `contentCriticalOnColor`

## Test plan
- [ ] Verify Success/Error/Neutral toasts render with correct colors
- [ ] Verify label is visually centered in the pill
- [ ] Verify icon-label spacing matches Android implementation
- [ ] Verify equal padding on both sides of the pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)