### PR TITLE
fix: generate xcodeproj before building xcframework in CI

### DIFF
--- a/swiftui/scripts/build_xcframework.sh
+++ b/swiftui/scripts/build_xcframework.sh
@@ -8,6 +8,13 @@ FRAMEWORK_NAME="Lemonade"
 OUTPUT_DIR="build"
 XCFRAMEWORK_OUTPUT="$OUTPUT_DIR/$FRAMEWORK_NAME.xcframework"
 
+echo "🔧 Generating Xcode project from project.yml..."
+if ! command -v xcodegen &> /dev/null; then
+    echo "Installing XcodeGen..."
+    brew install xcodegen
+fi
+xcodegen generate
+
 echo "🧹 Cleaning previous builds..."
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- The `Lemonade.xcodeproj` is generated by XcodeGen from `project.yml` and is not tracked in git
- CI release workflow fails with `'Lemonade.xcodeproj' does not exist` because it was never generated
- Added `xcodegen generate` step to `build_xcframework.sh` (installs XcodeGen via Homebrew if missing)

## Test plan
- [ ] Trigger a SwiftUI release tag and verify the XCFramework builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)