### PR TITLE
feat: scale SymbolContainer Rounded shape radius with size

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SymbolContainerDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SymbolContainerDisplay.kt
@@ -175,6 +175,57 @@ internal fun SymbolContainerDisplay() {
                     )
                 }
             }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        contentDescription = null,
+                        size = SymbolContainerSize.Large,
+                        shape = SymbolContainerShape.Rounded,
+                    )
+                    LemonadeUi.Text(
+                        text = "Rounded L",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        contentDescription = null,
+                        size = SymbolContainerSize.XLarge,
+                        shape = SymbolContainerShape.Rounded,
+                    )
+                    LemonadeUi.Text(
+                        text = "Rounded XL",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        contentDescription = null,
+                        size = SymbolContainerSize.XXLarge,
+                        shape = SymbolContainerShape.Rounded,
+                    )
+                    LemonadeUi.Text(
+                        text = "Rounded XXL",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
+            }
         }
 
         // Voices

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -245,7 +245,7 @@ private fun CoreSymbolContainer(
     badgeSlot: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     val dimensions = size.defaultSymbolContainerPlatformDimensions()
-    val resolvedShape = shape.resolveShape()
+    val resolvedShape = shape.resolveShape(size)
     CompositionLocalProvider(LocalSymbolContainerPlatformDimensions provides dimensions) {
         if (badgeSlot != null) {
             val density = LocalDensity.current
@@ -318,10 +318,18 @@ private val SymbolContainerVoice.containerColor: Color
     }
 
 @Composable
-private fun SymbolContainerShape.resolveShape(): Shape =
+private fun SymbolContainerShape.resolveShape(size: SymbolContainerSize): Shape =
     when (this) {
         SymbolContainerShape.Circle -> LocalShapes.current.radiusFull
-        SymbolContainerShape.Rounded -> LocalShapes.current.radius300
+        SymbolContainerShape.Rounded -> when (size) {
+            SymbolContainerSize.XSmall,
+            SymbolContainerSize.Small,
+            SymbolContainerSize.Medium,
+            -> LocalShapes.current.radius300
+            SymbolContainerSize.Large -> LocalShapes.current.radius400
+            SymbolContainerSize.XLarge -> LocalShapes.current.radius500
+            SymbolContainerSize.XXLarge -> LocalShapes.current.radius600
+        }
     }
 
 private data class SymbolContainerPlatformDimensions(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -322,10 +322,9 @@ private fun SymbolContainerShape.resolveShape(size: SymbolContainerSize): Shape 
     when (this) {
         SymbolContainerShape.Circle -> LocalShapes.current.radiusFull
         SymbolContainerShape.Rounded -> when (size) {
-            SymbolContainerSize.XSmall,
-            SymbolContainerSize.Small,
-            SymbolContainerSize.Medium,
-            -> LocalShapes.current.radius300
+            SymbolContainerSize.XSmall -> LocalShapes.current.radius200
+            SymbolContainerSize.Small -> LocalShapes.current.radius250
+            SymbolContainerSize.Medium -> LocalShapes.current.radius300
             SymbolContainerSize.Large -> LocalShapes.current.radius400
             SymbolContainerSize.XLarge -> LocalShapes.current.radius500
             SymbolContainerSize.XXLarge -> LocalShapes.current.radius600

--- a/swiftui/SampleApp/SymbolContainerDisplayView.swift
+++ b/swiftui/SampleApp/SymbolContainerDisplayView.swift
@@ -98,18 +98,39 @@ struct SymbolContainerDisplayView: View {
 
     // MARK: - Shapes
 
+    private let roundedScalingSizes: [(SymbolContainerSize, String)] = [
+        (.large, "Rounded L"),
+        (.xLarge, "Rounded XL"),
+        (.xxLarge, "Rounded XXL"),
+    ]
+
     private var shapesSection: some View {
         sectionView(title: "Shapes") {
-            HStack(spacing: 16) {
-                ForEach(allShapes, id: \.0) { shape, label in
-                    VStack(spacing: 8) {
-                        LemonadeUi.SymbolContainer(
-                            icon: .heart,
-                            contentDescription: nil,
-                            size: .medium,
-                            shape: shape
-                        )
-                        Text(label).font(.caption)
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 16) {
+                    ForEach(allShapes, id: \.0) { shape, label in
+                        VStack(spacing: 8) {
+                            LemonadeUi.SymbolContainer(
+                                icon: .heart,
+                                contentDescription: nil,
+                                size: .medium,
+                                shape: shape
+                            )
+                            Text(label).font(.caption)
+                        }
+                    }
+                }
+                HStack(spacing: 16) {
+                    ForEach(roundedScalingSizes, id: \.0) { size, label in
+                        VStack(spacing: 8) {
+                            LemonadeUi.SymbolContainer(
+                                icon: .heart,
+                                contentDescription: nil,
+                                size: size,
+                                shape: .rounded
+                            )
+                            Text(label).font(.caption)
+                        }
                     }
                 }
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
@@ -340,7 +340,16 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
         case .circle:
             base.clipShape(Circle())
         case .rounded:
-            base.clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius300))
+            base.clipShape(RoundedRectangle(cornerRadius: roundedRadius(for: size)))
+        }
+    }
+
+    private func roundedRadius(for size: SymbolContainerSize) -> CGFloat {
+        switch size {
+        case .xSmall, .small, .medium: LemonadeTheme.radius.radius300
+        case .large: LemonadeTheme.radius.radius400
+        case .xLarge: LemonadeTheme.radius.radius500
+        case .xxLarge: LemonadeTheme.radius.radius600
         }
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
@@ -346,7 +346,9 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
 
     private func roundedRadius(for size: SymbolContainerSize) -> CGFloat {
         switch size {
-        case .xSmall, .small, .medium: LemonadeTheme.radius.radius300
+        case .xSmall: LemonadeTheme.radius.radius200
+        case .small: LemonadeTheme.radius.radius250
+        case .medium: LemonadeTheme.radius.radius300
         case .large: LemonadeTheme.radius.radius400
         case .xLarge: LemonadeTheme.radius.radius500
         case .xxLarge: LemonadeTheme.radius.radius600


### PR DESCRIPTION
## Summary
- **Rounded shape radius now scales with container size** instead of using a hardcoded `radius300` for all sizes
- Applied to both **KMP** (`SymbolContainer.kt`) and **SwiftUI** (`LemonadeSymbolContainer.swift`)
- Added Rounded shape examples at Large, XLarge, and XXLarge sizes in the KMP display/sample code