### PR TITLE
feat: update Card to use radiusContainerDefault semantic token

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,7 +60,7 @@ private fun CoreCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(shape = RoundedCornerShape(LocalRadius.current.radius400))
+            .clip(shape = LocalShapes.current.semantic.radiusContainerDefault)
             .background(color = background.background),
     ) {
         if (hasHeader) {

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -151,7 +151,7 @@ private struct LemonadeCardView<Content: View, TrailingContent: View>: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(background.color)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius400))
+        .clipShape(LemonadeTheme.shapes.semantic.radiusContainerDefault)
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `radius400` (16dp/16pt) with semantic `radiusContainerDefault` token (24dp/24pt) on Card component
- KMP: `LocalShapes.current.semantic.radiusContainerDefault`
- SwiftUI: `LemonadeTheme.shapes.semantic.radiusContainerDefault`

## Test plan
- [ ] Verify Card renders with 24dp corner radius on Android
- [ ] Verify Card renders with 24pt corner radius on iOS
- [ ] Verify Card appearance in sample app on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)