### PR TITLE
[LDS] add Button slot overloads and Chip label-only/icon-only variants

### DIFF
--- a/flutter/lib/src/components/button.dart
+++ b/flutter/lib/src/components/button.dart
@@ -73,6 +73,7 @@ enum LemonadeButtonSize {
 typedef LemonadeButtonSlotBuilder =
     Widget Function(LemonadeButtonColors colors);
 
+/// {@macro LemonadeButton}
 class LemonadeButton extends StatefulWidget {
   /// {@macro LemonadeButton}
   const LemonadeButton({

--- a/flutter/lib/src/components/button.dart
+++ b/flutter/lib/src/components/button.dart
@@ -26,6 +26,9 @@ enum LemonadeButtonVariant {
 
 /// Sizes available for [LemonadeButton].
 enum LemonadeButtonSize {
+  /// Extra small size
+  xSmall,
+
   /// Small size
   small,
 
@@ -333,6 +336,14 @@ class _LemonadeButtonState extends State<LemonadeButton> {
     LemonadeThemeData theme,
   ) {
     return switch (widget.size) {
+      LemonadeButtonSize.xSmall => _ButtonSizeData(
+        verticalPadding: theme.spaces.spacing100,
+        horizontalPadding: theme.spaces.spacing200,
+        minHeight: buttonTheme.xSmallHeight,
+        minWidth: buttonTheme.xSmallMinWidth,
+        borderRadius: theme.radius.radius250,
+        textStyle: theme.typography.bodySmallSemibold,
+      ),
       LemonadeButtonSize.small => _ButtonSizeData(
         verticalPadding: theme.spaces.spacing200,
         horizontalPadding: theme.spaces.spacing300,

--- a/flutter/lib/src/components/button.dart
+++ b/flutter/lib/src/components/button.dart
@@ -65,6 +65,12 @@ enum LemonadeButtonSize {
 /// See also:
 /// - [LemonadeButtonTheme], for theme configuration
 /// {@endtemplate}
+/// Builder function that receives [LemonadeButtonColors] for variant-aware
+/// custom content inside button slots.
+typedef LemonadeButtonSlotBuilder = Widget Function(
+  LemonadeButtonColors colors,
+);
+
 class LemonadeButton extends StatefulWidget {
   /// {@macro LemonadeButton}
   const LemonadeButton({
@@ -74,12 +80,44 @@ class LemonadeButton extends StatefulWidget {
     this.trailingIcon,
     this.variant = LemonadeButtonVariant.primary,
     this.size = LemonadeButtonSize.large,
+    this.spacedContents = false,
     this.enabled = true,
     this.loading = false,
     this.semanticIdentifier,
     this.semanticLabel,
     super.key,
-  });
+  })  : leadingSlot = null,
+        trailingSlot = null;
+
+  /// Creates a [LemonadeButton] with custom slot builders for leading and
+  /// trailing content.
+  ///
+  /// The slot builders receive [LemonadeButtonColors] so custom content can
+  /// use variant-aware colors.
+  ///
+  /// ## Example
+  /// ```dart
+  /// LemonadeButton.slots(
+  ///   label: 'Custom',
+  ///   onPressed: () {},
+  ///   leadingSlot: (colors) => Icon(Icons.star, color: colors.contentColor),
+  /// )
+  /// ```
+  const LemonadeButton.slots({
+    required this.label,
+    required this.onPressed,
+    this.leadingSlot,
+    this.trailingSlot,
+    this.variant = LemonadeButtonVariant.primary,
+    this.size = LemonadeButtonSize.large,
+    this.spacedContents = false,
+    this.enabled = true,
+    this.loading = false,
+    this.semanticIdentifier,
+    this.semanticLabel,
+    super.key,
+  })  : leadingIcon = null,
+        trailingIcon = null;
 
   /// The label text displayed on the button.
   final String label;
@@ -93,11 +131,21 @@ class LemonadeButton extends StatefulWidget {
   /// Optional icon displayed after the label.
   final LemonadeIcons? trailingIcon;
 
+  /// Optional custom widget builder for leading content.
+  final LemonadeButtonSlotBuilder? leadingSlot;
+
+  /// Optional custom widget builder for trailing content.
+  final LemonadeButtonSlotBuilder? trailingSlot;
+
   /// The button variant. Defaults to [LemonadeButtonVariant.primary].
   final LemonadeButtonVariant variant;
 
   /// The button size. Defaults to [LemonadeButtonSize.large].
   final LemonadeButtonSize size;
+
+  /// When true, arranges content with space between (leading / label / trailing
+  /// spread across the full width). Defaults to false (centered).
+  final bool spacedContents;
 
   /// Whether the button is enabled. Defaults to true.
   final bool enabled;
@@ -178,31 +226,53 @@ class _LemonadeButtonState extends State<LemonadeButton> {
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisAlignment: widget.spacedContents
+                  ? MainAxisAlignment.spaceBetween
+                  : MainAxisAlignment.center,
               children: [
                 if (widget.loading) ...[
                   LemonadeSpinner(
                     color: variantColors.contentColor,
                   ),
                 ] else ...[
-                  if (widget.leadingIcon != null) ...[
+                  if (widget.leadingSlot != null)
+                    widget.leadingSlot!(variantColors)
+                  else if (widget.leadingIcon != null) ...[
                     LemonadeIcon(
                       icon: widget.leadingIcon!,
                       color: variantColors.contentColor,
                     ),
                   ],
-                  Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: spaces.spacing200,
-                    ),
-                    child: Text(
-                      widget.label,
-                      style: sizeData.textStyle.copyWith(
-                        color: variantColors.contentColor,
+                  if (widget.spacedContents)
+                    Expanded(
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: spaces.spacing200,
+                        ),
+                        child: Text(
+                          widget.label,
+                          style: sizeData.textStyle.copyWith(
+                            color: variantColors.contentColor,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    )
+                  else
+                    Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: spaces.spacing200,
+                      ),
+                      child: Text(
+                        widget.label,
+                        style: sizeData.textStyle.copyWith(
+                          color: variantColors.contentColor,
+                        ),
                       ),
                     ),
-                  ),
-                  if (widget.trailingIcon != null) ...[
+                  if (widget.trailingSlot != null)
+                    widget.trailingSlot!(variantColors)
+                  else if (widget.trailingIcon != null) ...[
                     LemonadeIcon(
                       icon: widget.trailingIcon!,
                       size: LemonadeIconSize.small,
@@ -218,39 +288,39 @@ class _LemonadeButtonState extends State<LemonadeButton> {
     );
   }
 
-  _ButtonVariantColors _getVariantColors(LemonadeSemanticColors colors) {
+  LemonadeButtonColors _getVariantColors(LemonadeSemanticColors colors) {
     return switch (widget.variant) {
-      LemonadeButtonVariant.primary => _ButtonVariantColors(
+      LemonadeButtonVariant.primary => LemonadeButtonColors(
         contentColor: colors.content.contentOnBrandHigh,
         backgroundColor: colors.background.bgBrand,
         pressedBackgroundColor: colors.interaction.bgBrandInteractive,
       ),
-      LemonadeButtonVariant.secondary => _ButtonVariantColors(
+      LemonadeButtonVariant.secondary => LemonadeButtonColors(
         contentColor: colors.content.contentPrimaryInverse,
         backgroundColor: colors.background.bgSubtleInverse,
         pressedBackgroundColor: colors.interaction.bgNeutralPressed,
       ),
-      LemonadeButtonVariant.neutralSubtle => _ButtonVariantColors(
+      LemonadeButtonVariant.neutralSubtle => LemonadeButtonColors(
         contentColor: colors.content.contentPrimary,
         backgroundColor: colors.background.bgElevated,
         pressedBackgroundColor: colors.interaction.bgElevatedPressed,
       ),
-      LemonadeButtonVariant.neutralGhost => _ButtonVariantColors(
+      LemonadeButtonVariant.neutralGhost => LemonadeButtonColors(
         contentColor: colors.content.contentPrimary,
         backgroundColor: const Color(0x00000000),
         pressedBackgroundColor: colors.interaction.bgSubtleInteractive,
       ),
-      LemonadeButtonVariant.criticalSubtle => _ButtonVariantColors(
+      LemonadeButtonVariant.criticalSubtle => LemonadeButtonColors(
         contentColor: colors.content.contentCritical,
         backgroundColor: colors.background.bgCriticalSubtle,
         pressedBackgroundColor: colors.interaction.bgCriticalSubtleInteractive,
       ),
-      LemonadeButtonVariant.criticalSolid => _ButtonVariantColors(
+      LemonadeButtonVariant.criticalSolid => LemonadeButtonColors(
         contentColor: colors.content.contentAlwaysLight,
         backgroundColor: colors.background.bgCritical,
         pressedBackgroundColor: colors.interaction.bgCriticalInteractive,
       ),
-      LemonadeButtonVariant.special => _ButtonVariantColors(
+      LemonadeButtonVariant.special => LemonadeButtonColors(
         contentColor: colors.content.contentOnBrandHigh,
         backgroundColor: colors.background.bgBrand,
         pressedBackgroundColor: colors.interaction.bgBrandPressed,
@@ -291,15 +361,24 @@ class _LemonadeButtonState extends State<LemonadeButton> {
   }
 }
 
-class _ButtonVariantColors {
-  const _ButtonVariantColors({
+/// Colors resolved for a specific [LemonadeButtonVariant].
+///
+/// Exposed so that custom slot content can use variant-aware colors.
+class LemonadeButtonColors {
+  /// Creates button variant colors.
+  const LemonadeButtonColors({
     required this.contentColor,
     required this.backgroundColor,
     required this.pressedBackgroundColor,
   });
 
+  /// The color used for text and icon content.
   final Color contentColor;
+
+  /// The default background color.
   final Color backgroundColor;
+
+  /// The background color when the button is pressed.
   final Color pressedBackgroundColor;
 }
 

--- a/flutter/lib/src/components/button.dart
+++ b/flutter/lib/src/components/button.dart
@@ -70,9 +70,8 @@ enum LemonadeButtonSize {
 /// {@endtemplate}
 /// Builder function that receives [LemonadeButtonColors] for variant-aware
 /// custom content inside button slots.
-typedef LemonadeButtonSlotBuilder = Widget Function(
-  LemonadeButtonColors colors,
-);
+typedef LemonadeButtonSlotBuilder =
+    Widget Function(LemonadeButtonColors colors);
 
 class LemonadeButton extends StatefulWidget {
   /// {@macro LemonadeButton}
@@ -89,8 +88,8 @@ class LemonadeButton extends StatefulWidget {
     this.semanticIdentifier,
     this.semanticLabel,
     super.key,
-  })  : leadingSlot = null,
-        trailingSlot = null;
+  }) : leadingSlot = null,
+       trailingSlot = null;
 
   /// Creates a [LemonadeButton] with custom slot builders for leading and
   /// trailing content.
@@ -119,8 +118,8 @@ class LemonadeButton extends StatefulWidget {
     this.semanticIdentifier,
     this.semanticLabel,
     super.key,
-  })  : leadingIcon = null,
-        trailingIcon = null;
+  }) : leadingIcon = null,
+       trailingIcon = null;
 
   /// The label text displayed on the button.
   final String label;
@@ -234,9 +233,7 @@ class _LemonadeButtonState extends State<LemonadeButton> {
                   : MainAxisAlignment.center,
               children: [
                 if (widget.loading) ...[
-                  LemonadeSpinner(
-                    color: variantColors.contentColor,
-                  ),
+                  LemonadeSpinner(color: variantColors.contentColor),
                 ] else ...[
                   if (widget.leadingSlot != null)
                     widget.leadingSlot!(variantColors)

--- a/flutter/lib/src/theme/components/button_theme.dart
+++ b/flutter/lib/src/theme/components/button_theme.dart
@@ -12,6 +12,8 @@ import 'package:lemonade_design_system/lemonade_design_system.dart';
 class LemonadeButtonTheme {
   /// {@macro LemonadeButtonTheme}
   const LemonadeButtonTheme({
+    required this.xSmallHeight,
+    required this.xSmallMinWidth,
     required this.smallHeight,
     required this.smallMinWidth,
     required this.mediumHeight,
@@ -24,6 +26,8 @@ class LemonadeButtonTheme {
   /// based on the provided [tokens].
   factory LemonadeButtonTheme.from(LemonadeTokens tokens) {
     return LemonadeButtonTheme(
+      xSmallHeight: tokens.sizes.size800,
+      xSmallMinWidth: tokens.sizes.size1400,
       smallHeight: tokens.sizes.size1000,
       smallMinWidth: tokens.sizes.size1600,
       mediumHeight: tokens.sizes.size1200,
@@ -41,6 +45,8 @@ class LemonadeButtonTheme {
   ) {
     if (identical(a, b)) return a;
     return LemonadeButtonTheme(
+      xSmallHeight: lerpDouble(a.xSmallHeight, b.xSmallHeight, t)!,
+      xSmallMinWidth: lerpDouble(a.xSmallMinWidth, b.xSmallMinWidth, t)!,
       smallHeight: lerpDouble(a.smallHeight, b.smallHeight, t)!,
       smallMinWidth: lerpDouble(a.smallMinWidth, b.smallMinWidth, t)!,
       mediumHeight: lerpDouble(a.mediumHeight, b.mediumHeight, t)!,
@@ -49,6 +55,12 @@ class LemonadeButtonTheme {
       largeMinWidth: lerpDouble(a.largeMinWidth, b.largeMinWidth, t)!,
     );
   }
+
+  /// The height of an extra small button.
+  final double xSmallHeight;
+
+  /// The minimum width of an extra small button.
+  final double xSmallMinWidth;
 
   /// The height of a small button.
   final double smallHeight;
@@ -70,6 +82,8 @@ class LemonadeButtonTheme {
 
   /// Creates a copy of this theme with the given fields replaced.
   LemonadeButtonTheme copyWith({
+    double? xSmallHeight,
+    double? xSmallMinWidth,
     double? smallHeight,
     double? smallMinWidth,
     double? mediumHeight,
@@ -78,6 +92,8 @@ class LemonadeButtonTheme {
     double? largeMinWidth,
   }) {
     return LemonadeButtonTheme(
+      xSmallHeight: xSmallHeight ?? this.xSmallHeight,
+      xSmallMinWidth: xSmallMinWidth ?? this.xSmallMinWidth,
       smallHeight: smallHeight ?? this.smallHeight,
       smallMinWidth: smallMinWidth ?? this.smallMinWidth,
       mediumHeight: mediumHeight ?? this.mediumHeight,
@@ -91,6 +107,8 @@ class LemonadeButtonTheme {
   LemonadeButtonTheme mergeWith(LemonadeButtonTheme? other) {
     if (other == null) return this;
     return copyWith(
+      xSmallHeight: other.xSmallHeight,
+      xSmallMinWidth: other.xSmallMinWidth,
       smallHeight: other.smallHeight,
       smallMinWidth: other.smallMinWidth,
       mediumHeight: other.mediumHeight,
@@ -104,6 +122,8 @@ class LemonadeButtonTheme {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     return other is LemonadeButtonTheme &&
+        other.xSmallHeight == xSmallHeight &&
+        other.xSmallMinWidth == xSmallMinWidth &&
         other.smallHeight == smallHeight &&
         other.smallMinWidth == smallMinWidth &&
         other.mediumHeight == mediumHeight &&
@@ -114,6 +134,8 @@ class LemonadeButtonTheme {
 
   @override
   int get hashCode => Object.hash(
+    xSmallHeight,
+    xSmallMinWidth,
     smallHeight,
     smallMinWidth,
     mediumHeight,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ButtonDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ButtonDisplay.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,8 +24,47 @@ internal fun ButtonDisplay() {
                     ),
                 ) {
                     ButtonCard {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing100),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            LemonadeButtonSize.entries.forEach { size ->
+                                LemonadeUi.Button(
+                                    label = size.toString(),
+                                    variant = variant,
+                                    size = size,
+                                    onClick = {},
+                                    trailingSlot = { colors ->
+                                        LemonadeUi.VerticalDivider()
+                                        LemonadeUi.Text(
+                                            text = "Action",
+                                            color = colors.contentColor,
+                                            modifier = Modifier.padding(start = LemonadeTheme.spaces.spacing300),
+                                        )
+                                    },
+                                )
+                            }
+
+                            LemonadeUi.Button(
+                                label = "Spaced",
+                                variant = variant,
+                                spacedContents = true,
+                                onClick = {},
+                                modifier = Modifier.fillMaxWidth(),
+                                trailingSlot = { colors ->
+                                    LemonadeUi.VerticalDivider()
+                                    LemonadeUi.Text(
+                                        text = "Action",
+                                        color = colors.contentColor,
+                                        modifier = Modifier.padding(start = LemonadeTheme.spaces.spacing300),
+                                    )
+                                },
+                            )
+                        }
+                    }
+
+                    ButtonCard {
                         LemonadeButtonSize.entries.forEach { size ->
-                            @OptIn(ExperimentalLemonadeComponent::class)
                             LemonadeUi.Button(
                                 label = size.toString(),
                                 onClick = {},
@@ -51,7 +91,6 @@ internal fun ButtonDisplay() {
                     }
 
                     ButtonCard {
-                        @OptIn(ExperimentalLemonadeComponent::class)
                         LemonadeUi.Button(
                             label = "Loading",
                             onClick = {},
@@ -60,7 +99,6 @@ internal fun ButtonDisplay() {
                             loading = true,
                         )
 
-                        @OptIn(ExperimentalLemonadeComponent::class)
                         LemonadeUi.Button(
                             label = "Disabled",
                             onClick = {},

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ButtonDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ButtonDisplay.kt
@@ -70,6 +70,7 @@ internal fun ButtonDisplay() {
                                 onClick = {},
                                 variant = variant,
                                 size = size,
+                                leadingIcon = null,
                             )
                         }
                     }
@@ -97,6 +98,7 @@ internal fun ButtonDisplay() {
                             variant = variant,
                             size = LemonadeButtonSize.Medium,
                             loading = true,
+                            leadingIcon = null,
                         )
 
                         LemonadeUi.Button(
@@ -105,6 +107,7 @@ internal fun ButtonDisplay() {
                             variant = variant,
                             size = LemonadeButtonSize.Medium,
                             enabled = false,
+                            leadingIcon = null,
                         )
                     }
                 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
@@ -102,6 +102,45 @@ internal fun ChipDisplay() {
             }
         }
 
+        // Label Only
+        ChipSection(title = "Label Only") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    LemonadeUi.Chip(label = "Label", selected = false)
+                    LemonadeUi.Chip(label = "Label", selected = true)
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    LemonadeUi.Chip(
+                        label = "Dismiss",
+                        selected = false,
+                        trailingIcon = LemonadeIcons.CircleX,
+                    )
+                    LemonadeUi.Chip(
+                        label = "Dismiss",
+                        selected = true,
+                        trailingIcon = LemonadeIcons.CircleX,
+                    )
+                }
+            }
+        }
+
+        // Icon Only
+        ChipSection(title = "Icon Only") {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+            ) {
+                LemonadeUi.Chip(icon = LemonadeIcons.Heart, selected = false)
+                LemonadeUi.Chip(icon = LemonadeIcons.Heart, selected = true)
+            }
+        }
+
         // Interactive Selection
         ChipSection(title = "Interactive Selection") {
             Column(

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/DividerDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/DividerDisplay.kt
@@ -175,12 +175,14 @@ internal fun DividerDisplay() {
                         label = "Continue with Email",
                         onClick = { },
                         modifier = Modifier.fillMaxWidth(),
+                        leadingIcon = null,
                     )
                     LemonadeUi.HorizontalDivider(label = "OR")
                     LemonadeUi.Button(
                         label = "Continue with Google",
                         onClick = { },
                         modifier = Modifier.fillMaxWidth(),
+                        leadingIcon = null,
                     )
                 }
 

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -19,6 +19,7 @@ internal fun ToastDisplay() {
                         voice = ToastVoice.Success,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Error Toast",
@@ -28,6 +29,7 @@ internal fun ToastDisplay() {
                         voice = ToastVoice.Error,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Neutral Toast",
@@ -37,6 +39,7 @@ internal fun ToastDisplay() {
                         voice = ToastVoice.Neutral,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Neutral with Icon",
@@ -47,6 +50,7 @@ internal fun ToastDisplay() {
                         icon = LemonadeIcons.Link,
                     )
                 },
+                leadingIcon = null,
             )
         }
 
@@ -60,6 +64,7 @@ internal fun ToastDisplay() {
                         duration = ToastDuration.Short,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Medium (6s)",
@@ -70,6 +75,7 @@ internal fun ToastDisplay() {
                         duration = ToastDuration.Medium,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Long (9s)",
@@ -80,6 +86,7 @@ internal fun ToastDisplay() {
                         duration = ToastDuration.Long,
                     )
                 },
+                leadingIcon = null,
             )
         }
 
@@ -94,6 +101,7 @@ internal fun ToastDisplay() {
                         duration = ToastDuration.Short,
                     )
                 },
+                leadingIcon = null,
             )
             LemonadeUi.Button(
                 label = "Tap while visible to replace",
@@ -103,6 +111,7 @@ internal fun ToastDisplay() {
                         voice = ToastVoice.Success,
                     )
                 },
+                leadingIcon = null,
             )
         }
     }

--- a/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/BottomSheetDisplay.kt
+++ b/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/BottomSheetDisplay.kt
@@ -41,6 +41,7 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Open Bottom Sheet",
                 onClick = { showBasicSheet = true },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Secondary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -57,6 +58,7 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Open Without Drag Handle",
                 onClick = { showNoDragHandleSheet = true },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Secondary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -86,6 +88,7 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Close",
                 onClick = { showBasicSheet = false },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Primary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -120,6 +123,7 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Close",
                 onClick = { showNoDragHandleSheet = false },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Primary,
                 size = LemonadeButtonSize.Medium,
             )

--- a/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/DialogDisplay.kt
+++ b/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/DialogDisplay.kt
@@ -40,6 +40,7 @@ internal fun DialogSampleDisplay() {
             LemonadeUi.Button(
                 label = "Open Dialog",
                 onClick = { showBasicDialog = true },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Secondary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -56,6 +57,7 @@ internal fun DialogSampleDisplay() {
             LemonadeUi.Button(
                 label = "Open Non-Dismissable Dialog",
                 onClick = { showNonDismissableDialog = true },
+                leadingIcon = null,
                 variant = LemonadeButtonVariant.Secondary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -92,6 +94,7 @@ internal fun DialogSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Cancel",
                     onClick = { showBasicDialog = false },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Neutral,
                     size = LemonadeButtonSize.Small,
                 )
@@ -99,6 +102,7 @@ internal fun DialogSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Confirm",
                     onClick = { showBasicDialog = false },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Primary,
                     size = LemonadeButtonSize.Small,
                 )
@@ -138,6 +142,7 @@ internal fun DialogSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Close",
                     onClick = { showNonDismissableDialog = false },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Primary,
                     size = LemonadeButtonSize.Small,
                 )

--- a/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/DropdownDisplay.kt
+++ b/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/DropdownDisplay.kt
@@ -48,6 +48,7 @@ internal fun DropdownSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Open Basic Menu",
                     onClick = { basicExpanded = true },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Secondary,
                     size = LemonadeButtonSize.Medium,
                 )
@@ -79,6 +80,7 @@ internal fun DropdownSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Open Menu with Leading Icons",
                     onClick = { leadingIconsExpanded = true },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Secondary,
                     size = LemonadeButtonSize.Medium,
                 )
@@ -113,6 +115,7 @@ internal fun DropdownSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Open Menu with Trailing Icons",
                     onClick = { trailingIconsExpanded = true },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Secondary,
                     size = LemonadeButtonSize.Medium,
                 )
@@ -147,6 +150,7 @@ internal fun DropdownSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Open Menu with Disabled Items",
                     onClick = { disabledItemsExpanded = true },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Secondary,
                     size = LemonadeButtonSize.Medium,
                 )
@@ -184,6 +188,7 @@ internal fun DropdownSampleDisplay() {
                 LemonadeUi.Button(
                     label = "Open Non-Dismissable Menu",
                     onClick = { nonDismissableExpanded = true },
+                    leadingIcon = null,
                     variant = LemonadeButtonVariant.Secondary,
                     size = LemonadeButtonSize.Medium,
                 )

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Button.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Button.kt
@@ -10,6 +10,7 @@ public enum class LemonadeButtonVariant {
 }
 
 public enum class LemonadeButtonSize {
+    XSmall,
     Small,
     Medium,
     Large,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -244,7 +244,6 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
                 shape = LocalShapes.current.radius400,
                 textStyle = LocalTypographies.current.bodyMediumSemiBold,
             )
-
         }
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -109,6 +109,32 @@ public fun LemonadeUi.Button(
     )
 }
 
+/**
+ * Lemonade labeled button component with composable slots. Used for simple click actions with a
+ * text and optional composable leading/trailing content, allowing full customization of the
+ * slot contents instead of predefined icon references.
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.Button(
+ *   label = "click me!",
+ *   onClick = { println("button clicked!") },
+ *   leadingSlot = { colors -> Icon(..., tint = colors.contentColor) },
+ * )
+ * ```
+ * @param label - [String] to be displayed as the Button's label.
+ * @param onClick - Callback to be invoked when the Button is clicked.
+ * @param modifier - [Modifier] to be applied to the Button.
+ * @param leadingSlot - Composable slot shown before the label. Receives [LemonadeButtonColors]
+ * to access variant-aware colors.
+ * @param trailingSlot - Composable slot shown after the label. Receives [LemonadeButtonColors]
+ * to access variant-aware colors.
+ * @param variant - [LemonadeButtonVariant] to style the Button accordingly.
+ * @param size - [LemonadeButtonSize] to size the Button accordingly.
+ * @param spacedContents - [Boolean] flag to space contents evenly across the Button's width.
+ * @param enabled - [Boolean] flag to enable or disable the Button.
+ * @param loading - [Boolean] flag to enable the loading state.
+ * @param interactionSource - [MutableInteractionSource] to be applied to the Button.
+ */
 @Composable
 public fun LemonadeUi.Button(
     label: String,
@@ -373,6 +399,84 @@ private fun LemonadeLabeledRadioButtonPreview(
         onClick = { /* Nothing */ },
         leadingIcon = LemonadeIcons.Heart.takeIf { previewData.leadingIcon },
         trailingIcon = LemonadeIcons.Heart.takeIf { previewData.trailingIcon },
+        enabled = previewData.enabled,
+        loading = previewData.loading,
+        size = previewData.size,
+        variant = previewData.variant,
+    )
+}
+
+private data class SlotButtonPreviewData(
+    val leadingSlot: Boolean,
+    val trailingSlot: Boolean,
+    val enabled: Boolean,
+    val loading: Boolean,
+    val size: LemonadeButtonSize,
+    val variant: LemonadeButtonVariant,
+)
+
+private class SlotButtonPreviewProvider : PreviewParameterProvider<SlotButtonPreviewData> {
+    override val values: Sequence<SlotButtonPreviewData> = buildAllVariants()
+
+    private fun buildAllVariants(): Sequence<SlotButtonPreviewData> =
+        buildList {
+            LemonadeButtonSize.entries.forEach { size ->
+                LemonadeButtonVariant.entries.forEach { variant ->
+                    listOf(true, false).forEach { leadingSlot ->
+                        listOf(true, false).forEach { trailingSlot ->
+                            listOf(true, false).forEach { loading ->
+                                listOf(true, false).forEach { enabled ->
+                                    add(
+                                        SlotButtonPreviewData(
+                                            leadingSlot = leadingSlot,
+                                            trailingSlot = trailingSlot,
+                                            enabled = enabled,
+                                            loading = loading,
+                                            size = size,
+                                            variant = variant,
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }.asSequence()
+}
+
+@LemonadePreview
+@Composable
+private fun LemonadeSlotButtonPreview(
+    @PreviewParameter(SlotButtonPreviewProvider::class)
+    previewData: SlotButtonPreviewData,
+) {
+    @OptIn(ExperimentalLemonadeComponent::class)
+    LemonadeUi.Button(
+        label = "Label",
+        onClick = { /* Nothing */ },
+        leadingSlot = if (previewData.leadingSlot) {
+            { colors ->
+                LemonadeUi.Icon(
+                    icon = LemonadeIcons.Heart,
+                    tint = colors.contentColor,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
+        trailingSlot = if (previewData.trailingSlot) {
+            { colors ->
+                LemonadeUi.Icon(
+                    icon = LemonadeIcons.ChevronRight,
+                    tint = colors.contentColor,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
         enabled = previewData.enabled,
         loading = previewData.loading,
         size = previewData.size,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
@@ -55,11 +56,12 @@ import com.teya.lemonade.core.LemonadeTextStyle
 public fun LemonadeUi.Button(
     label: String,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     leadingIcon: LemonadeIcons? = null,
     trailingIcon: LemonadeIcons? = null,
     variant: LemonadeButtonVariant = LemonadeButtonVariant.Primary,
     size: LemonadeButtonSize = LemonadeButtonSize.Large,
-    modifier: Modifier = Modifier,
+    spacedContents: Boolean = false,
     enabled: Boolean = true,
     loading: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -72,6 +74,7 @@ public fun LemonadeUi.Button(
         interactionSource = interactionSource,
         onClick = onClick,
         loading = loading,
+        spacedContents = spacedContents,
         contentSlot = {
             if (loading) {
                 LemonadeUi.Spinner(
@@ -106,16 +109,69 @@ public fun LemonadeUi.Button(
     )
 }
 
+@Composable
+public fun LemonadeUi.Button(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    leadingSlot: (@Composable RowScope.(LemonadeButtonColors) -> Unit)? = null,
+    trailingSlot: (@Composable RowScope.(LemonadeButtonColors) -> Unit)? = null,
+    variant: LemonadeButtonVariant = LemonadeButtonVariant.Primary,
+    size: LemonadeButtonSize = LemonadeButtonSize.Large,
+    spacedContents: Boolean = false,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    CoreButton(
+        variant = variant,
+        size = size,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        onClick = onClick,
+        loading = loading,
+        spacedContents = spacedContents,
+        contentSlot = {
+            if (loading) {
+                LemonadeUi.Spinner(
+                    tint = variant.variantData.contentColor,
+                )
+            } else {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    leadingSlot?.invoke(this, variant.variantData)
+                }
+
+                LemonadeUi.Text(
+                    text = label,
+                    textStyle = size.contentData.textStyle,
+                    color = variant.variantData.contentColor,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .weight(
+                            weight = 1f,
+                            fill = spacedContents,
+                        ).padding(horizontal = LocalSpaces.current.spacing200),
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    trailingSlot?.invoke(this, variant.variantData)
+                }
+            }
+        },
+    )
+}
+
 @Stable
-private data class LemonadeButtonColors(
-    val contentColor: Color,
-    val solidBackgroundColor: Color,
-    val pressedBackgroundColor: Color,
-    val brushBackgroundColor: Brush? = null,
+public class LemonadeButtonColors internal constructor(
+    public val contentColor: Color,
+    public val solidBackgroundColor: Color,
+    public val pressedBackgroundColor: Color,
+    public val brushBackgroundColor: Brush? = null,
 )
 
 @Stable
-private data class LemonadeButtonContentData(
+private class LemonadeButtonContentData(
     val verticalPadding: Dp,
     val horizontalPadding: Dp,
     val minHeight: Dp,
@@ -214,6 +270,7 @@ private fun CoreButton(
     size: LemonadeButtonSize,
     enabled: Boolean,
     loading: Boolean,
+    spacedContents: Boolean,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
 ) {
@@ -230,7 +287,11 @@ private fun CoreButton(
     Row(
         content = contentSlot,
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = if (spacedContents) {
+            Arrangement.SpaceBetween
+        } else {
+            Arrangement.Center
+        },
         modifier = modifier
             .defaultMinSize(
                 minWidth = size.contentData.minWidth,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -209,6 +209,15 @@ private class LemonadeButtonContentData(
 private val LemonadeButtonSize.contentData: LemonadeButtonContentData
     @Composable get() {
         return when (this) {
+            LemonadeButtonSize.XSmall -> LemonadeButtonContentData(
+                verticalPadding = LocalSpaces.current.spacing100,
+                horizontalPadding = LocalSpaces.current.spacing200,
+                minHeight = LocalSizes.current.size800,
+                minWidth = LocalSizes.current.size1400,
+                shape = LocalShapes.current.radius250,
+                textStyle = LocalTypographies.current.bodySmallSemiBold,
+            )
+
             LemonadeButtonSize.Small -> LemonadeButtonContentData(
                 verticalPadding = LocalSpaces.current.spacing200,
                 horizontalPadding = LocalSpaces.current.spacing300,
@@ -235,6 +244,7 @@ private val LemonadeButtonSize.contentData: LemonadeButtonContentData
                 shape = LocalShapes.current.radius400,
                 textStyle = LocalTypographies.current.bodyMediumSemiBold,
             )
+
         }
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -40,7 +40,40 @@ import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTextStyle
 
-
+/**
+ * A compact element used to display information, trigger actions, or represent selections.
+ * Commonly used for tags, filters, or interactive choices in dense interfaces.
+ * This overload renders a label-only chip without a leading icon.
+ *
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.Chip(
+ *     label = "Label",
+ *     selected = true,
+ * )
+ * ```
+ *
+ * ## Parameters
+ * @param label: The text to be displayed in the chip.
+ * @param selected: Set to 'true' if the chip is in the selected state.
+ * @param modifier: Optional - [Modifier] to be applied to the root container of the chip.
+ * @param trailingIcon: Optional - [LemonadeIcons] to be displayed
+ *  in the trailing position of the chip.
+ * @param counter: Optional - [Int] number to be displayed in the chip
+ *  in case it is counting the amount of a subject.
+ * @param enabled: Optional - controls the enabled state of the chip.
+ *  When `false`, interaction is disabled and it is visually styled
+ *  as such. Defaults to true.
+ * @param onChipClicked: Optional - sets the callback for when
+ *  the chip is clicked. If null the clickable interactions will be
+ *  automatically disabled.
+ * @param onTrailingIconClick: Optional - Callback action triggered
+ *  when the [trailingIcon] is clicked.
+ *  Needs [trailingIcon] to not be null.
+ * @param interactionSource: Optional - [MutableInteractionSource]
+ *  used to observe interaction states like hover and press to drive
+ *  visual feedback.
+ */
 @Composable
 public fun LemonadeUi.Chip(
     label: String,
@@ -81,10 +114,41 @@ public fun LemonadeUi.Chip(
                 textStyle = defaultChipDimensions().labelFontStyle,
                 modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
             )
-        }
+        },
     )
 }
 
+/**
+ * A compact element used to display information, trigger actions, or represent selections.
+ * Commonly used for tags, filters, or interactive choices in dense interfaces.
+ * This overload renders an icon-only chip without a text label.
+ *
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.Chip(
+ *     icon = LemonadeIcons.Heart,
+ *     selected = true,
+ * )
+ * ```
+ *
+ * ## Parameters
+ * @param icon: The [LemonadeIcons] to be displayed in the chip.
+ * @param selected: Set to 'true' if the chip is in the selected state.
+ * @param modifier: Optional - [Modifier] to be applied to the root container of the chip.
+ * @param counter: Optional - [Int] number to be displayed in the chip
+ *  in case it is counting the amount of a subject.
+ * @param enabled: Optional - controls the enabled state of the chip.
+ *  When `false`, interaction is disabled and it is visually styled
+ *  as such. Defaults to true.
+ * @param onChipClicked: Optional - sets the callback for when
+ *  the chip is clicked. If null the clickable interactions will be
+ *  automatically disabled.
+ * @param onTrailingIconClick: Optional - Callback action triggered
+ *  when the trailing icon is clicked.
+ * @param interactionSource: Optional - [MutableInteractionSource]
+ *  used to observe interaction states like hover and press to drive
+ *  visual feedback.
+ */
 @Composable
 public fun LemonadeUi.Chip(
     icon: LemonadeIcons,
@@ -113,7 +177,7 @@ public fun LemonadeUi.Chip(
                 size = LemonadeAssetSize.Small,
                 contentDescription = null,
             )
-        }
+        },
     )
 }
 
@@ -211,7 +275,7 @@ public fun LemonadeUi.Chip(
                 textStyle = defaultChipDimensions().labelFontStyle,
                 modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
             )
-        }
+        },
     )
 }
 
@@ -303,7 +367,7 @@ public fun LemonadeUi.Chip(
                 textStyle = defaultChipDimensions().labelFontStyle,
                 modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
             )
-        }
+        },
     )
 }
 
@@ -530,5 +594,92 @@ private fun ChipPreview(
         counter = previewData.counter,
         leadingIcon = previewData.leadingIcon,
         trailingIcon = previewData.trailingIcon,
+    )
+}
+
+private data class LabelOnlyChipPreviewData(
+    val isSelected: Boolean,
+    val enabled: Boolean,
+    val counter: Int?,
+    val trailingIcon: LemonadeIcons?,
+)
+
+private class LabelOnlyChipPreviewProvider : PreviewParameterProvider<LabelOnlyChipPreviewData> {
+    override val values: Sequence<LabelOnlyChipPreviewData> = buildAllVariants()
+
+    private fun buildAllVariants(): Sequence<LabelOnlyChipPreviewData> =
+        buildList {
+            listOf(true, false).forEach { enabled ->
+                listOf(true, false).forEach { withCounter ->
+                    listOf(true, false).forEach { selected ->
+                        listOf(true, false).forEach { withTrailingIcon ->
+                            add(
+                                LabelOnlyChipPreviewData(
+                                    isSelected = selected,
+                                    enabled = enabled,
+                                    counter = 5.takeIf { withCounter },
+                                    trailingIcon = LemonadeIcons.Airplane.takeIf { withTrailingIcon },
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }.asSequence()
+}
+
+@LemonadePreview
+@Composable
+private fun LabelOnlyChipPreview(
+    @PreviewParameter(LabelOnlyChipPreviewProvider::class)
+    previewData: LabelOnlyChipPreviewData,
+) {
+    LemonadeUi.Chip(
+        label = "Label",
+        selected = previewData.isSelected,
+        enabled = previewData.enabled,
+        counter = previewData.counter,
+        trailingIcon = previewData.trailingIcon,
+    )
+}
+
+private data class IconOnlyChipPreviewData(
+    val isSelected: Boolean,
+    val enabled: Boolean,
+    val counter: Int?,
+)
+
+private class IconOnlyChipPreviewProvider : PreviewParameterProvider<IconOnlyChipPreviewData> {
+    override val values: Sequence<IconOnlyChipPreviewData> = buildAllVariants()
+
+    private fun buildAllVariants(): Sequence<IconOnlyChipPreviewData> =
+        buildList {
+            listOf(true, false).forEach { enabled ->
+                listOf(true, false).forEach { withCounter ->
+                    listOf(true, false).forEach { selected ->
+                        add(
+                            IconOnlyChipPreviewData(
+                                isSelected = selected,
+                                enabled = enabled,
+                                counter = 5.takeIf { withCounter },
+                            ),
+                        )
+                    }
+                }
+            }
+        }.asSequence()
+}
+
+@LemonadePreview
+@Composable
+private fun IconOnlyChipPreview(
+    @PreviewParameter(IconOnlyChipPreviewProvider::class)
+    previewData: IconOnlyChipPreviewData,
+) {
+    LemonadeUi.Chip(
+        icon = LemonadeIcons.Heart,
+        selected = previewData.isSelected,
+        enabled = previewData.enabled,
+        counter = previewData.counter,
     )
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
@@ -38,6 +39,83 @@ import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTextStyle
+
+
+@Composable
+public fun LemonadeUi.Chip(
+    label: String,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    trailingIcon: LemonadeIcons? = null,
+    counter: Int? = null,
+    enabled: Boolean = true,
+    onChipClicked: (() -> Unit)? = null,
+    onTrailingIconClick: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    CoreChip(
+        selected = selected,
+        enabled = enabled,
+        counter = counter,
+        leadingSlot = null,
+        trailingSlot = if (trailingIcon != null) {
+            {
+                LemonadeUi.Icon(
+                    icon = trailingIcon,
+                    tint = LocalChipContentColor.current.invoke(),
+                    size = LemonadeAssetSize.Small,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
+        onChipClicked = onChipClicked,
+        onTrailingIconClick = onTrailingIconClick,
+        modifier = modifier,
+        interactionSource = interactionSource,
+        contentSlot = {
+            LemonadeUi.Text(
+                text = label,
+                color = LocalChipContentColor.current(),
+                textStyle = defaultChipDimensions().labelFontStyle,
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
+            )
+        }
+    )
+}
+
+@Composable
+public fun LemonadeUi.Chip(
+    icon: LemonadeIcons,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+    counter: Int? = null,
+    enabled: Boolean = true,
+    onChipClicked: (() -> Unit)? = null,
+    onTrailingIconClick: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    CoreChip(
+        selected = selected,
+        enabled = enabled,
+        counter = counter,
+        leadingSlot = null,
+        trailingSlot = null,
+        onChipClicked = onChipClicked,
+        onTrailingIconClick = onTrailingIconClick,
+        modifier = modifier,
+        interactionSource = interactionSource,
+        contentSlot = {
+            LemonadeUi.Icon(
+                icon = icon,
+                tint = LocalChipContentColor.current.invoke(),
+                size = LemonadeAssetSize.Small,
+                contentDescription = null,
+            )
+        }
+    )
+}
 
 /**
  * A compact element used to display information, trigger actions, or represent selections.
@@ -89,7 +167,6 @@ public fun LemonadeUi.Chip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CoreChip(
-        label = label,
         selected = selected,
         enabled = enabled,
         counter = counter,
@@ -127,6 +204,14 @@ public fun LemonadeUi.Chip(
         onTrailingIconClick = onTrailingIconClick,
         modifier = modifier,
         interactionSource = interactionSource,
+        contentSlot = {
+            LemonadeUi.Text(
+                text = label,
+                color = LocalChipContentColor.current(),
+                textStyle = defaultChipDimensions().labelFontStyle,
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
+            )
+        }
     )
 }
 
@@ -180,7 +265,6 @@ public fun LemonadeUi.Chip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CoreChip(
-        label = label,
         selected = selected,
         enabled = enabled,
         counter = counter,
@@ -212,16 +296,24 @@ public fun LemonadeUi.Chip(
         onTrailingIconClick = onTrailingIconClick,
         modifier = modifier,
         interactionSource = interactionSource,
+        contentSlot = {
+            LemonadeUi.Text(
+                text = label,
+                color = LocalChipContentColor.current(),
+                textStyle = defaultChipDimensions().labelFontStyle,
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
+            )
+        }
     )
 }
 
 @Suppress("LongMethod", "LongParameterList")
 @Composable
 internal fun CoreChip(
-    label: String,
     selected: Boolean,
     enabled: Boolean,
     counter: Int?,
+    contentSlot: @Composable RowScope.() -> Unit,
     leadingSlot: (@Composable BoxScope.() -> Unit)?,
     trailingSlot: (@Composable BoxScope.() -> Unit)?,
     onChipClicked: (() -> Unit)?,
@@ -244,7 +336,9 @@ internal fun CoreChip(
             props.backgroundColor
         },
     )
-    CompositionLocalProvider(LocalChipContentColor provides { animatedContentColor }) {
+    CompositionLocalProvider(
+        LocalChipContentColor provides { animatedContentColor },
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
@@ -286,12 +380,7 @@ internal fun CoreChip(
                 )
             }
 
-            LemonadeUi.Text(
-                text = label,
-                color = animatedContentColor,
-                textStyle = platformDimensions.labelFontStyle,
-                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing100),
-            )
+            contentSlot(this)
 
             if (counter != null) {
                 Box(

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -59,6 +59,7 @@ public extension LemonadeUi {
         trailingIcon: LemonadeIcon? = nil,
         variant: LemonadeButtonVariant = .primary,
         size: LemonadeButtonSize = .large,
+        spacedContents: Bool = false,
         enabled: Bool = true,
         loading: Bool = false
     ) -> some View {
@@ -69,19 +70,120 @@ public extension LemonadeUi {
             trailingIcon: trailingIcon,
             variant: variant,
             size: size,
+            spacedContents: spacedContents,
             enabled: enabled,
             loading: loading
         )
     }
+
+    // MARK: - Slot-based Button overloads
+
+    /// Creates a button with custom leading and trailing slot content.
+    ///
+    /// The slot closures receive ``LemonadeButtonColors`` so custom content can
+    /// use variant-aware colors.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.Button(
+    ///     label: "Custom",
+    ///     onClick: { },
+    ///     leadingSlot: { colors in
+    ///         Image(systemName: "star.fill")
+    ///             .foregroundColor(colors.contentColor)
+    ///     },
+    ///     trailingSlot: { colors in
+    ///         Image(systemName: "chevron.right")
+    ///             .foregroundColor(colors.contentColor)
+    ///     }
+    /// )
+    /// ```
+    @ViewBuilder
+    static func Button<LeadingContent: View, TrailingContent: View>(
+        label: String,
+        onClick: @escaping () -> Void,
+        variant: LemonadeButtonVariant = .primary,
+        size: LemonadeButtonSize = .large,
+        spacedContents: Bool = false,
+        enabled: Bool = true,
+        loading: Bool = false,
+        @ViewBuilder leadingSlot: @escaping (LemonadeButtonColors) -> LeadingContent,
+        @ViewBuilder trailingSlot: @escaping (LemonadeButtonColors) -> TrailingContent
+    ) -> some View {
+        LemonadeSlotButtonView(
+            label: label,
+            onClick: onClick,
+            variant: variant,
+            size: size,
+            spacedContents: spacedContents,
+            enabled: enabled,
+            loading: loading,
+            leadingSlot: leadingSlot,
+            trailingSlot: trailingSlot
+        )
+    }
+
+    /// Creates a button with only a custom leading slot.
+    @ViewBuilder
+    static func Button<LeadingContent: View>(
+        label: String,
+        onClick: @escaping () -> Void,
+        variant: LemonadeButtonVariant = .primary,
+        size: LemonadeButtonSize = .large,
+        spacedContents: Bool = false,
+        enabled: Bool = true,
+        loading: Bool = false,
+        @ViewBuilder leadingSlot: @escaping (LemonadeButtonColors) -> LeadingContent
+    ) -> some View {
+        Button(
+            label: label,
+            onClick: onClick,
+            variant: variant,
+            size: size,
+            spacedContents: spacedContents,
+            enabled: enabled,
+            loading: loading,
+            leadingSlot: leadingSlot,
+            trailingSlot: { _ in EmptyView() }
+        )
+    }
+
+    /// Creates a button with only a custom trailing slot.
+    @ViewBuilder
+    static func Button<TrailingContent: View>(
+        label: String,
+        onClick: @escaping () -> Void,
+        variant: LemonadeButtonVariant = .primary,
+        size: LemonadeButtonSize = .large,
+        spacedContents: Bool = false,
+        enabled: Bool = true,
+        loading: Bool = false,
+        @ViewBuilder trailingSlot: @escaping (LemonadeButtonColors) -> TrailingContent
+    ) -> some View {
+        Button(
+            label: label,
+            onClick: onClick,
+            variant: variant,
+            size: size,
+            spacedContents: spacedContents,
+            enabled: enabled,
+            loading: loading,
+            leadingSlot: { _ in EmptyView() },
+            trailingSlot: trailingSlot
+        )
+    }
 }
 
-// MARK: - Internal Button Colors
+// MARK: - Button Colors
 
-private struct LemonadeButtonColors {
-    let contentColor: Color
-    let solidBackgroundColor: Color
-    let pressedBackgroundColor: Color
-    let brushBackgroundColors: [Color]?
+/// Colors resolved for a specific ``LemonadeButtonVariant``.
+///
+/// Exposed so that custom slot content can use variant-aware colors.
+public struct LemonadeButtonColors {
+    public let contentColor: Color
+    public let solidBackgroundColor: Color
+    public let pressedBackgroundColor: Color
+    public let brushBackgroundColors: [Color]?
 
     init(
         contentColor: Color,
@@ -145,7 +247,7 @@ private extension LemonadeButtonSize {
 
 // MARK: - Button Variant Extension
 
-private extension LemonadeButtonVariant {
+extension LemonadeButtonVariant {
     var variantData: LemonadeButtonColors {
         switch self {
         case .primary:
@@ -201,6 +303,7 @@ private struct LemonadeButtonView: View {
     let trailingIcon: LemonadeIcon?
     let variant: LemonadeButtonVariant
     let size: LemonadeButtonSize
+    let spacedContents: Bool
     let enabled: Bool
     let loading: Bool
 
@@ -213,7 +316,9 @@ private struct LemonadeButtonView: View {
     var body: some View {
         SwiftUI.Button(action: onClick) {
             HStack(spacing: 0) {
-                Spacer(minLength: 0)
+                if !spacedContents {
+                    Spacer(minLength: 0)
+                }
 
                 if loading {
                     ProgressView()
@@ -228,12 +333,20 @@ private struct LemonadeButtonView: View {
                         )
                     }
 
+                    if spacedContents {
+                        Spacer(minLength: 0)
+                    }
+
                     LemonadeUi.Text(
                         label,
                         textStyle: size.contentData.textStyle,
                         color: variant.variantData.contentColor
                     )
                     .padding(.horizontal, LemonadeTheme.spaces.spacing200)
+
+                    if spacedContents {
+                        Spacer(minLength: 0)
+                    }
 
                     if let trailingIcon = trailingIcon {
                         LemonadeUi.Icon(
@@ -245,7 +358,9 @@ private struct LemonadeButtonView: View {
                     }
                 }
 
-                Spacer(minLength: 0)
+                if !spacedContents {
+                    Spacer(minLength: 0)
+                }
             }
             .padding(.horizontal, size.contentData.horizontalPadding)
             .frame(height: size.contentData.minHeight)
@@ -256,6 +371,90 @@ private struct LemonadeButtonView: View {
                         .fill(backgroundColor)
 
                     if let gradientColors = variant.variantData.brushBackgroundColors {
+                        RoundedRectangle(cornerRadius: size.contentData.cornerRadius)
+                            .fill(
+                                LinearGradient(
+                                    colors: gradientColors,
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                    }
+                }
+            )
+            .clipShape(RoundedRectangle(cornerRadius: size.contentData.cornerRadius))
+        }
+        .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+        .disabled(!enabled || loading)
+        .opacity((enabled || loading) ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+    }
+}
+
+// MARK: - Internal Slot Button View
+
+private struct LemonadeSlotButtonView<LeadingContent: View, TrailingContent: View>: View {
+    let label: String
+    let onClick: () -> Void
+    let variant: LemonadeButtonVariant
+    let size: LemonadeButtonSize
+    let spacedContents: Bool
+    let enabled: Bool
+    let loading: Bool
+    @ViewBuilder let leadingSlot: (LemonadeButtonColors) -> LeadingContent
+    @ViewBuilder let trailingSlot: (LemonadeButtonColors) -> TrailingContent
+
+    @State private var isPressed = false
+
+    private var colors: LemonadeButtonColors { variant.variantData }
+
+    private var backgroundColor: Color {
+        isPressed ? colors.pressedBackgroundColor : colors.solidBackgroundColor
+    }
+
+    var body: some View {
+        SwiftUI.Button(action: onClick) {
+            HStack(spacing: 0) {
+                if !spacedContents {
+                    Spacer(minLength: 0)
+                }
+
+                if loading {
+                    ProgressView()
+                        .tint(colors.contentColor)
+                } else {
+                    leadingSlot(colors)
+
+                    if spacedContents {
+                        Spacer(minLength: 0)
+                    }
+
+                    LemonadeUi.Text(
+                        label,
+                        textStyle: size.contentData.textStyle,
+                        color: colors.contentColor
+                    )
+                    .padding(.horizontal, LemonadeTheme.spaces.spacing200)
+
+                    if spacedContents {
+                        Spacer(minLength: 0)
+                    }
+
+                    trailingSlot(colors)
+                }
+
+                if !spacedContents {
+                    Spacer(minLength: 0)
+                }
+            }
+            .padding(.horizontal, size.contentData.horizontalPadding)
+            .frame(height: size.contentData.minHeight)
+            .frame(minWidth: size.contentData.minWidth)
+            .background(
+                ZStack {
+                    RoundedRectangle(cornerRadius: size.contentData.cornerRadius)
+                        .fill(backgroundColor)
+
+                    if let gradientColors = colors.brushBackgroundColors {
                         RoundedRectangle(cornerRadius: size.contentData.cornerRadius)
                             .fill(
                                 LinearGradient(

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -16,6 +16,7 @@ public enum LemonadeButtonVariant {
 
 /// Button sizes following the Lemonade Design System.
 public enum LemonadeButtonSize {
+    case xSmall
     case small
     case medium
     case large
@@ -214,6 +215,15 @@ private struct LemonadeButtonContentData {
 private extension LemonadeButtonSize {
     var contentData: LemonadeButtonContentData {
         switch self {
+        case .xSmall:
+            return LemonadeButtonContentData(
+                verticalPadding: LemonadeTheme.spaces.spacing100,
+                horizontalPadding: LemonadeTheme.spaces.spacing200,
+                minHeight: LemonadeTheme.sizes.size800,
+                minWidth: LemonadeTheme.sizes.size1400,
+                cornerRadius: LemonadeTheme.radius.radius250,
+                textStyle: LemonadeTypography.shared.bodySmallSemiBold
+            )
         case .small:
             return LemonadeButtonContentData(
                 verticalPadding: LemonadeTheme.spaces.spacing200,


### PR DESCRIPTION
## Summary
- Add new `Button` overload with composable `leadingSlot`/`trailingSlot` lambdas (receiving `LemonadeButtonColors`) for full customization beyond predefined icons
- Add `spacedContents` parameter to `Button` for `SpaceBetween` horizontal arrangement
- Make `LemonadeButtonColors` public so slot consumers can access variant-aware colors
- Add label-only `Chip` overload (no leading icon, optional trailing icon)
- Add icon-only `Chip` overload (no text label)
- Refactor `CoreChip` to accept a `contentSlot` composable instead of a `label` string
- Remove `@ExperimentalLemonadeComponent` opt-ins from Button usages in sample app

## Test plan
- [ ] Verify existing Button and Chip previews render correctly
- [ ] Verify new slot-based Button preview renders with leading/trailing composable content
- [ ] Verify label-only and icon-only Chip previews render correctly
- [ ] Run full test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)