### PR TITLE
[LDS] update KMP Chip visuals to match Figma

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -361,7 +361,6 @@ private data class ChipProps(
     val backgroundColor: Color,
     val pressedBackgroundColor: Color,
     val contentColor: Color,
-    val actionColor: Color,
 )
 
 @Composable
@@ -371,14 +370,12 @@ private fun getChipProps(selected: Boolean): ChipProps =
             backgroundColor = LocalColors.current.background.bgBrandHigh,
             pressedBackgroundColor = LocalColors.current.interaction.bgBrandHighInteractive,
             contentColor = LocalColors.current.content.contentBrandInverse,
-            actionColor = LocalColors.current.content.contentBrandInverse,
         )
     } else {
         ChipProps(
             backgroundColor = LocalColors.current.background.bgElevated,
             pressedBackgroundColor = LocalColors.current.interaction.bgSubtleInteractive,
             contentColor = LocalColors.current.content.contentPrimary,
-            actionColor = LocalColors.current.content.contentSecondary,
         )
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -235,7 +235,6 @@ internal fun CoreChip(
     val isHover by interactionSource.collectIsHoveredAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    val animatedBorderColor by animateColorAsState(targetValue = props.borderColor)
     val animatedContentColor by animateColorAsState(targetValue = props.contentColor)
     val animatedBackgroundColor by animateColorAsState(
         targetValue = if (isHover || isPressed) {
@@ -265,17 +264,10 @@ internal fun CoreChip(
                     onClick = { onChipClicked?.invoke() },
                     interactionSource = interactionSource,
                     indication = LocalEffects.current.interactionIndication,
-                ).border(
-                    color = animatedBorderColor,
-                    shape = LocalShapes.current.radiusFull,
-                    width = 1.dp,
                 ).background(
                     color = animatedBackgroundColor,
                     shape = LocalShapes.current.radiusFull,
-                ).padding(
-                    horizontal = LocalSpaces.current.spacing200,
-                    vertical = LocalSpaces.current.spacing100,
-                ),
+                ).padding(all = LocalSpaces.current.spacing200),
         ) {
             if (leadingSlot != null) {
                 Box(
@@ -370,7 +362,6 @@ private data class ChipProps(
     val pressedBackgroundColor: Color,
     val contentColor: Color,
     val actionColor: Color,
-    val borderColor: Color,
 )
 
 @Composable
@@ -381,15 +372,13 @@ private fun getChipProps(selected: Boolean): ChipProps =
             pressedBackgroundColor = LocalColors.current.interaction.bgBrandHighInteractive,
             contentColor = LocalColors.current.content.contentBrandInverse,
             actionColor = LocalColors.current.content.contentBrandInverse,
-            borderColor = LocalColors.current.border.borderNeutralMedium,
         )
     } else {
         ChipProps(
-            backgroundColor = LocalColors.current.background.bgDefault,
+            backgroundColor = LocalColors.current.background.bgElevated,
             pressedBackgroundColor = LocalColors.current.interaction.bgSubtleInteractive,
             contentColor = LocalColors.current.content.contentPrimary,
             actionColor = LocalColors.current.content.contentSecondary,
-            borderColor = LocalColors.current.border.borderNeutralMedium,
         )
     }
 

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -3,39 +3,43 @@ import Lemonade
 
 struct ChipDisplayView: View {
     @State private var selectedChips: Set<String> = ["Option 1"]
-
+    
     var body: some View {
-        ScrollView(.vertical) {
-            VStack(alignment: .leading, spacing: 32) {
-                statesSection
-                counterSection
-                iconsSection
-                interactiveSection
-                disabledSection
+        NavigationStack {
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: .space.spacing800) {
+                    statesSection
+                    counterSection
+                    iconsSection
+                    customLeadingSection
+                    interactiveSection
+                    disabledSection
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding()
+                .navigationTitle("Chip")
             }
-            .padding()
         }
-        .navigationTitle("Chip")
     }
-
+    
     private var statesSection: some View {
         sectionView(title: "States") {
             HStack(spacing: 12) {
                 VStack(spacing: 8) {
                     LemonadeUi.Chip(label: "Unselected", selected: false)
-                    Text("Unselected")
-                        .font(.caption)
+                    LemonadeUi.Text("Unselected", font: .bodyXSmallRegular)
+                        .foregroundStyle(.content.contentSecondary)
                 }
-
+                
                 VStack(spacing: 8) {
                     LemonadeUi.Chip(label: "Selected", selected: true)
-                    Text("Selected")
-                        .font(.caption)
+                    LemonadeUi.Text("Selected", font: .bodyXSmallRegular)
+                        .foregroundStyle(.content.contentSecondary)
                 }
             }
         }
     }
-
+    
     private var counterSection: some View {
         sectionView(title: "With Counter") {
             HStack(spacing: 12) {
@@ -44,15 +48,15 @@ struct ChipDisplayView: View {
             }
         }
     }
-
+    
     private var iconsSection: some View {
         sectionView(title: "With Icons") {
-            VStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 12) {
                     LemonadeUi.Chip(label: "Favorites", selected: false, leadingIcon: .heart)
                     LemonadeUi.Chip(label: "Favorites", selected: true, leadingIcon: .heart)
                 }
-
+                
                 HStack(spacing: 12) {
                     LemonadeUi.Chip(label: "Remove", selected: false, trailingIcon: .circleX)
                     LemonadeUi.Chip(label: "Remove", selected: true, trailingIcon: .circleX)
@@ -60,26 +64,42 @@ struct ChipDisplayView: View {
             }
         }
     }
-
+    
+    private var customLeadingSection: some View {
+        sectionView(title: "With Icons") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 12) {
+                    LemonadeUi.Chip(label: "Favorites", selected: false, leadingImage: <#T##Image#>: .heart)
+                    LemonadeUi.Chip(label: "Favorites", selected: true, leadingIcon: .heart)
+                }
+                
+                HStack(spacing: 12) {
+                    LemonadeUi.Chip(label: "Remove", selected: false, trailingIcon: .circleX)
+                    LemonadeUi.Chip(label: "Remove", selected: true, trailingIcon: .circleX)
+                }
+            }
+        }
+    }
+    
     private var interactiveSection: some View {
         sectionView(title: "Interactive Selection") {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Tap to select/deselect:")
                     .font(.subheadline)
-
+                
                 HStack(spacing: 8) {
                     chipButton(option: "Option 1")
                     chipButton(option: "Option 2")
                     chipButton(option: "Option 3")
                 }
-
+                
                 Text("Selected: \(selectedChips.sorted().joined(separator: ", "))")
                     .font(.caption)
                     .foregroundStyle(.content.contentSecondary)
             }
         }
     }
-
+    
     private func chipButton(option: String) -> some View {
         LemonadeUi.Chip(
             label: option,
@@ -93,7 +113,7 @@ struct ChipDisplayView: View {
             }
         )
     }
-
+    
     private var disabledSection: some View {
         sectionView(title: "Disabled") {
             HStack(spacing: 12) {
@@ -102,20 +122,17 @@ struct ChipDisplayView: View {
             }
         }
     }
-
+    
     private func sectionView<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
+            LemonadeUi.Text(title, font: .headingXSmall)
                 .foregroundStyle(.content.contentSecondary)
-
+            
             content()
         }
     }
 }
 
 #Preview {
-    NavigationStack {
-        ChipDisplayView()
-    }
+    ChipDisplayView()
 }

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -66,16 +66,14 @@ struct ChipDisplayView: View {
     }
     
     private var customLeadingSection: some View {
-        sectionView(title: "With Icons") {
+        sectionView(title: "With Custom Leading") {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 12) {
-                    LemonadeUi.Chip(label: "Favorites", selected: false, leadingImage: <#T##Image#>: .heart)
-                    LemonadeUi.Chip(label: "Favorites", selected: true, leadingIcon: .heart)
-                }
-                
-                HStack(spacing: 12) {
-                    LemonadeUi.Chip(label: "Remove", selected: false, trailingIcon: .circleX)
-                    LemonadeUi.Chip(label: "Remove", selected: true, trailingIcon: .circleX)
+                    LemonadeUi.Chip(label: "GBP", selected: false) {
+                        LemonadeUi.CountryFlag(flag: .gBUnitedKingdom)
+                    } trailingContent: {
+                        LemonadeUi.Icon(icon: .chevronDown, contentDescription: nil)
+                    }
                 }
             }
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -198,7 +198,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     @ViewBuilder let leadingContent: () -> LeadingContent
     @ViewBuilder let trailingContent: () -> TrailingContent
 
-    @State private var isPressed = false
+    @GestureState private var isPressed = false
 
     private let minWidth: CGFloat = 64
     private let minHeight: CGFloat = 32
@@ -271,20 +271,17 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         .contentShape(Capsule())
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    if enabled && onChipClicked != nil {
-                        isPressed = true
-                    }
-                }
-                .onEnded { _ in
-                    if isPressed {
-                        isPressed = false
-                        if enabled {
-                            onChipClicked?()
-                        }
-                    }
+                .updating($isPressed) { value, state, _ in
+                    let translation = value.translation
+                    let distance = sqrt(translation.width * translation.width + translation.height * translation.height)
+                    state = distance <= 10 && enabled && onChipClicked != nil
                 }
         )
+        .onTapGesture {
+            if let onChipClicked = onChipClicked, enabled {
+                onChipClicked()
+            }
+        }
         .animation(.easeInOut(duration: 0.15), value: selected)
         .animation(.easeInOut(duration: 0.15), value: isPressed)
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -48,10 +48,10 @@ public extension LemonadeUi {
                     LemonadeUi.Icon(
                         icon: icon,
                         contentDescription: nil,
-                        size: .small,
+                        size: .medium,
                         tint: selected
-                            ? LemonadeTheme.colors.content.contentBrandInverse
-                            : LemonadeTheme.colors.content.contentPrimary
+                        ? LemonadeTheme.colors.content.contentBrandInverse
+                        : LemonadeTheme.colors.content.contentPrimary
                     )
                 }
             },
@@ -62,14 +62,14 @@ public extension LemonadeUi {
                         contentDescription: nil,
                         size: .small,
                         tint: selected
-                            ? LemonadeTheme.colors.content.contentBrandInverse
-                            : LemonadeTheme.colors.content.contentPrimary
+                        ? LemonadeTheme.colors.content.contentBrandInverse
+                        : LemonadeTheme.colors.content.contentPrimary
                     )
                 }
             }
         )
     }
-
+    
     /// A compact element used to display information with a custom leading image.
     ///
     /// ## Usage
@@ -130,14 +130,14 @@ public extension LemonadeUi {
                         contentDescription: nil,
                         size: .small,
                         tint: selected
-                            ? LemonadeTheme.colors.content.contentBrandInverse
-                            : LemonadeTheme.colors.content.contentPrimary
+                        ? LemonadeTheme.colors.content.contentBrandInverse
+                        : LemonadeTheme.colors.content.contentPrimary
                     )
                 }
             }
         )
     }
-
+    
     /// A compact element with fully custom leading and trailing content.
     ///
     /// ## Usage
@@ -197,36 +197,34 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     let onTrailingIconClick: (() -> Void)?
     @ViewBuilder let leadingContent: () -> LeadingContent
     @ViewBuilder let trailingContent: () -> TrailingContent
-
+    
     @State private var isPressed = false
-
-    private let minWidth: CGFloat = 64
-    private let minHeight: CGFloat = 32
-    private let actionsSize: CGFloat = LemonadeTheme.sizes.size400
-
+    
+    private let minWidth: CGFloat = .size.size1600
+    private let minHeight: CGFloat = .size.size800
+    
     private var backgroundColor: Color {
         if isPressed {
             return selected
-                ? LemonadeTheme.colors.interaction.bgBrandHighInteractive
-                : LemonadeTheme.colors.interaction.bgSubtleInteractive
+            ? LemonadeTheme.colors.interaction.bgBrandHighInteractive
+            : LemonadeTheme.colors.interaction.bgSubtleInteractive
         }
         return selected
-            ? LemonadeTheme.colors.background.bgBrandHigh
-            : LemonadeTheme.colors.background.bgElevated
+        ? LemonadeTheme.colors.background.bgBrandHigh
+        : LemonadeTheme.colors.background.bgElevated
     }
-
+    
     private var contentColor: Color {
         selected
-            ? LemonadeTheme.colors.content.contentBrandInverse
-            : LemonadeTheme.colors.content.contentPrimary
+        ? LemonadeTheme.colors.content.contentBrandInverse
+        : LemonadeTheme.colors.content.contentPrimary
     }
-
+    
     private var chipContent: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: .space.spacing100) {
             // Leading slot
             leadingContent()
-                .frame(width: actionsSize, height: actionsSize)
-
+            
             // Label
             LemonadeUi.Text(
                 label,
@@ -234,45 +232,40 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                 color: contentColor
             )
             .padding(.horizontal, LemonadeTheme.spaces.spacing100)
-
+            
             // Counter
             if let counter = counter {
-                SwiftUI.Text("\(counter)")
-                    .font(.custom(LemonadeTypography.fontFamily, size: LemonadeTheme.sizes.size250).weight(.semibold))
+                LemonadeUi.Text("\(counter)", font: .bodyXSmallSemiBold)
                     .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
-                    .lineLimit(1)
                     .padding(.horizontal, LemonadeTheme.spaces.spacing100)
-                    .frame(minWidth: 18, minHeight: 16)
-                    .background(LemonadeTheme.colors.background.bgBrand)
+                    .frame(minWidth: .size.size450, minHeight: .size.size400)
+                    .background(.bg.bgBrand)
                     .clipShape(Capsule())
-                    .padding(.horizontal, LemonadeTheme.spaces.spacing100)
+                    .padding(.trailing, .space.spacing100)
             }
-
+            
             // Trailing slot
             if let onTrailingIconClick = onTrailingIconClick {
                 SwiftUI.Button(action: onTrailingIconClick) {
                     trailingContent()
-                        .frame(width: actionsSize, height: actionsSize)
                 }
                 .buttonStyle(PlainButtonStyle())
                 .disabled(!enabled)
-                .padding(.leading, LemonadeTheme.spaces.spacing50)
+                .padding(.trailing, .space.spacing100)
             } else {
                 trailingContent()
-                    .frame(width: actionsSize, height: actionsSize)
-                    .padding(.leading, LemonadeTheme.spaces.spacing50)
             }
         }
-        .padding(LemonadeTheme.spaces.spacing200)
+        .padding(.space.spacing200)
         .frame(minWidth: minWidth, minHeight: minHeight)
         .background(backgroundColor)
-        .clipShape(Capsule())
-        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+        .clipShape(RoundedRectangle(cornerRadius: .radius.radiusFull))
+        .opacity(enabled ? 1.0 : .opacity.opacityDisabled)
         .contentShape(Capsule())
         .animation(.easeInOut(duration: 0.15), value: selected)
         .animation(.easeInOut(duration: 0.15), value: isPressed)
     }
-
+    
     var body: some View {
         if let onChipClicked = onChipClicked {
             SwiftUI.Button(action: onChipClicked) {
@@ -297,13 +290,13 @@ struct LemonadeChip_Previews: PreviewProvider {
                 LemonadeUi.Chip(label: "Unselected", selected: false)
                 LemonadeUi.Chip(label: "Selected", selected: true)
             }
-
+            
             // With counter
             HStack(spacing: 8) {
                 LemonadeUi.Chip(label: "Label", selected: false, counter: 5)
                 LemonadeUi.Chip(label: "Label", selected: true, counter: 12)
             }
-
+            
             // With icons
             HStack(spacing: 8) {
                 LemonadeUi.Chip(
@@ -317,7 +310,7 @@ struct LemonadeChip_Previews: PreviewProvider {
                     trailingIcon: .circleX
                 )
             }
-
+            
             // With both icons
             LemonadeUi.Chip(
                 label: "Both Icons",
@@ -325,7 +318,7 @@ struct LemonadeChip_Previews: PreviewProvider {
                 leadingIcon: .star,
                 trailingIcon: .circleX
             )
-
+            
             // Disabled
             HStack(spacing: 8) {
                 LemonadeUi.Chip(label: "Disabled", selected: false, enabled: false)

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -205,17 +205,13 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     private var backgroundColor: Color {
         selected
             ? LemonadeTheme.colors.background.bgBrandHigh
-            : LemonadeTheme.colors.background.bgDefault
+            : LemonadeTheme.colors.background.bgElevated
     }
 
     private var contentColor: Color {
         selected
             ? LemonadeTheme.colors.content.contentBrandInverse
             : LemonadeTheme.colors.content.contentPrimary
-    }
-
-    private var borderColor: Color {
-        LemonadeTheme.colors.border.borderNeutralMedium
     }
 
     var body: some View {
@@ -260,15 +256,10 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                     .padding(.leading, LemonadeTheme.spaces.spacing50)
             }
         }
-        .padding(.horizontal, LemonadeTheme.spaces.spacing200)
-        .padding(.vertical, LemonadeTheme.spaces.spacing100)
+        .padding(LemonadeTheme.spaces.spacing200)
         .frame(minWidth: minWidth, minHeight: minHeight)
         .background(backgroundColor)
         .clipShape(Capsule())
-        .overlay(
-            Capsule()
-                .stroke(borderColor, lineWidth: 1)
-        )
         .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(Capsule())
         .onTapGesture {

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -198,7 +198,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     @ViewBuilder let leadingContent: () -> LeadingContent
     @ViewBuilder let trailingContent: () -> TrailingContent
 
-    @GestureState private var isPressed = false
+    @State private var isPressed = false
 
     private let minWidth: CGFloat = 64
     private let minHeight: CGFloat = 32
@@ -221,7 +221,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
             : LemonadeTheme.colors.content.contentPrimary
     }
 
-    var body: some View {
+    private var chipContent: some View {
         HStack(spacing: 0) {
             // Leading slot
             leadingContent()
@@ -269,21 +269,20 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         .clipShape(Capsule())
         .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(Capsule())
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .updating($isPressed) { value, state, _ in
-                    let translation = value.translation
-                    let distance = sqrt(translation.width * translation.width + translation.height * translation.height)
-                    state = distance <= 10 && enabled && onChipClicked != nil
-                }
-        )
-        .onTapGesture {
-            if let onChipClicked = onChipClicked, enabled {
-                onChipClicked()
-            }
-        }
         .animation(.easeInOut(duration: 0.15), value: selected)
         .animation(.easeInOut(duration: 0.15), value: isPressed)
+    }
+
+    var body: some View {
+        if let onChipClicked = onChipClicked {
+            SwiftUI.Button(action: onChipClicked) {
+                chipContent
+            }
+            .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+            .disabled(!enabled)
+        } else {
+            chipContent
+        }
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -198,12 +198,19 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     @ViewBuilder let leadingContent: () -> LeadingContent
     @ViewBuilder let trailingContent: () -> TrailingContent
 
+    @State private var isPressed = false
+
     private let minWidth: CGFloat = 64
     private let minHeight: CGFloat = 32
     private let actionsSize: CGFloat = LemonadeTheme.sizes.size400
 
     private var backgroundColor: Color {
-        selected
+        if isPressed {
+            return selected
+                ? LemonadeTheme.colors.interaction.bgBrandHighInteractive
+                : LemonadeTheme.colors.interaction.bgSubtleInteractive
+        }
+        return selected
             ? LemonadeTheme.colors.background.bgBrandHigh
             : LemonadeTheme.colors.background.bgElevated
     }
@@ -262,12 +269,24 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         .clipShape(Capsule())
         .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(Capsule())
-        .onTapGesture {
-            if let onChipClicked = onChipClicked, enabled {
-                onChipClicked()
-            }
-        }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if enabled && onChipClicked != nil {
+                        isPressed = true
+                    }
+                }
+                .onEnded { _ in
+                    if isPressed {
+                        isPressed = false
+                        if enabled {
+                            onChipClicked?()
+                        }
+                    }
+                }
+        )
         .animation(.easeInOut(duration: 0.15), value: selected)
+        .animation(.easeInOut(duration: 0.15), value: isPressed)
     }
 }
 


### PR DESCRIPTION
## Summary
- Changed unselected background from `bgDefault` to `bgElevated` (subtle warm tint) — KMP & SwiftUI
- Removed `borderNeutralMedium` border from all chip states (selected & unselected) — KMP & SwiftUI
- Unified padding to `spacing200` on all sides (previously `spacing200` horizontal / `spacing100` vertical) — KMP & SwiftUI
- Added pressed state visual feedback to SwiftUI Chip (`bgSubtleInteractive` / `bgBrandHighInteractive`)

No API changes — purely visual update to match the updated Figma design.

<img width="320" height="3120" alt="image" src="https://github.com/user-attachments/assets/224cac99-b48d-421c-9eaa-86d3780fb4da" />

<img width="320" height="2622" alt="image" src="https://github.com/user-attachments/assets/48f43ead-70db-4800-a9ad-255432c63e42" />


## Test plan
- [x] KMP compiles successfully, installed and verified on Pixel 7 Pro emulator
- [x] SwiftUI compiles successfully, installed and verified on iPhone 17 Pro simulator
- [x] All chip states verified: selected, unselected, disabled, with icons, with counter, pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)