### PR TITLE
fix: set explicit cursor color on TextField and SearchField for dark mode

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -22,11 +22,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -26,10 +26,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -97,6 +97,7 @@ internal fun CoreSearchField(
     enabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
+    val contentColor = LocalColors.current.content.contentPrimary
     BasicTextField(
         value = input,
         onValueChange = onInputChanged,
@@ -104,9 +105,9 @@ internal fun CoreSearchField(
         enabled = enabled,
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
-        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
+        cursorBrush = SolidColor(contentColor),
         textStyle = LocalTypographies.current.bodyMediumRegular.textStyle.copy(
-            color = LocalColors.current.content.contentPrimary,
+            color = contentColor,
         ),
         singleLine = true,
         modifier = modifier.then(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -103,6 +104,7 @@ internal fun CoreSearchField(
         enabled = enabled,
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
+        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
         textStyle = LocalTypographies.current.bodyMediumRegular.textStyle.copy(
             color = LocalColors.current.content.contentPrimary,
         ),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -473,6 +474,7 @@ internal fun CoreTextField(
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
+        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
         textStyle = size.data.contentStyle.textStyle.copy(
             color = LocalColors.current.content.contentPrimary,
         ),
@@ -524,6 +526,7 @@ internal fun CoreTextField(
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
+        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
         textStyle = size.data.contentStyle.textStyle.copy(
             color = LocalColors.current.content.contentPrimary,
         ),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -466,6 +466,7 @@ internal fun CoreTextField(
     textBoxContent: @Composable BoxScope.(@Composable () -> Unit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val contentColor = LocalColors.current.content.contentPrimary
     BasicTextField(
         value = input,
         onValueChange = onInputChanged,
@@ -474,9 +475,9 @@ internal fun CoreTextField(
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
-        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
+        cursorBrush = SolidColor(contentColor),
         textStyle = size.data.contentStyle.textStyle.copy(
-            color = LocalColors.current.content.contentPrimary,
+            color = contentColor,
         ),
         singleLine = true,
         modifier = modifier,
@@ -518,6 +519,7 @@ internal fun CoreTextField(
     textBoxContent: @Composable BoxScope.(@Composable () -> Unit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val contentColor = LocalColors.current.content.contentPrimary
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
@@ -526,9 +528,9 @@ internal fun CoreTextField(
         keyboardActions = keyboardActions,
         keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
-        cursorBrush = SolidColor(LocalColors.current.content.contentPrimary),
+        cursorBrush = SolidColor(contentColor),
         textStyle = size.data.contentStyle.textStyle.copy(
-            color = LocalColors.current.content.contentPrimary,
+            color = contentColor,
         ),
         singleLine = true,
         modifier = modifier,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -32,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -88,6 +88,7 @@ private struct LemonadeSearchFieldView: View {
                 SwiftUI.TextField("", text: $input)
                     .font(LemonadeTypography.shared.bodyMediumRegular.font)
                     .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                    .tint(LemonadeTheme.colors.content.contentPrimary)
                     .focused($isFocused)
                     .disabled(!enabled)
                     .onChange(of: input) { newValue in

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -512,6 +512,7 @@ private struct LemonadeTextFieldView<LeadingContent: View, TrailingContent: View
                     SwiftUI.TextField("", text: $input)
                         .font(LemonadeTypography.shared.bodyMediumRegular.font)
                         .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                        .tint(LemonadeTheme.colors.content.contentPrimary)
                         .focused($isFocused)
                         .disabled(!enabled)
                         .onChange(of: input) { newValue in
@@ -595,6 +596,7 @@ private struct LemonadeTextFieldWithSelectorView<LeadingContent: View, TrailingC
                         SwiftUI.TextField("", text: $input)
                             .font(LemonadeTypography.shared.bodyMediumRegular.font)
                             .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                            .tint(LemonadeTheme.colors.content.contentPrimary)
                             .focused($isFocused)
                             .disabled(!enabled)
                             .onChange(of: input) { newValue in

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -31,6 +31,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.textColor = UIColor(textColor)
         textField.borderStyle = .none
         textField.backgroundColor = .clear
+        textField.tintColor = UIColor(textColor)
         textField.isEnabled = isEnabled
         textField.keyboardType = keyboardType
         textField.text = value.text
@@ -89,6 +90,7 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.isEnabled = isEnabled
         textField.font = textStyle.uiFont
         textField.textColor = UIColor(textColor)
+        textField.tintColor = UIColor(textColor)
 
         // Update keyboard type and reload if changed while focused
         if textField.keyboardType != keyboardType {


### PR DESCRIPTION
## Summary
- TextField and SearchField cursor was invisible/wrong color in dark mode on both KMP and iOS
- **KMP (Compose):** `BasicTextField` defaults to a black cursor (`SolidColor(Color.Black)`) — added `cursorBrush = SolidColor(contentPrimary)` to all 3 `BasicTextField` calls (TextField string variant, TextField value variant, SearchField)
- **iOS (SwiftUI):** Added `.tint(contentPrimary)` to all 3 `SwiftUI.TextField` instances and `tintColor` to `LemonadeUITextField` (both `makeUIView` and `updateUIView`)

## Test plan
- [x] Installed on Pixel 7 Pro emulator — builds and runs
- [ ] Verify cursor color adapts correctly in light mode
- [ ] Verify cursor color adapts correctly in dark mode
- [ ] Verify on iOS (SwiftUI TextField and UITextField variants)
- [ ] Verify SearchField cursor behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)