### PR TITLE
[LDS] redesign SegmentedControl with sizes, sliding indicator, and icon-only

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -22,13 +22,13 @@ internal fun HomeDisplay(onNavigate: (Displays) -> Unit) {
             LemonadeUi.SegmentedControl(
                 selectedTab = selectedIndex,
                 onTabSelected = { index -> styleHandler.currentStyle = styles[index] },
-                properties = styles.map { style -> TabButtonProperties(label = style.label) },
+                properties = styles.map { style -> TabButtonProperties.label(label = style.label) },
                 modifier = Modifier.padding(bottom = LemonadeTheme.spaces.spacing200),
             )
             LemonadeUi.SegmentedControl(
                 selectedTab = selectedVariantIndex,
                 onTabSelected = { index -> styleHandler.currentVariant = variants[index] },
-                properties = variants.map { variant -> TabButtonProperties(label = variant.label) },
+                properties = variants.map { variant -> TabButtonProperties.label(label = variant.label) },
                 modifier = Modifier.padding(bottom = LemonadeTheme.spaces.spacing400),
             )
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
@@ -34,9 +34,9 @@ internal fun SegmentedControlDisplay() {
                     },
                     selectedTab = selectedLarge,
                     properties = listOf(
-                        TabButtonProperties(label = "Tab 1"),
-                        TabButtonProperties(label = "Tab 2"),
-                        TabButtonProperties(label = "Tab 3"),
+                        TabButtonProperties.label(label = "Tab 1"),
+                        TabButtonProperties.label(label = "Tab 2"),
+                        TabButtonProperties.label(label = "Tab 3"),
                     ),
                 )
                 LemonadeUi.Text(
@@ -59,9 +59,9 @@ internal fun SegmentedControlDisplay() {
                     selectedTab = selectedMedium,
                     size = LemonadeSegmentedControlSize.Medium,
                     properties = listOf(
-                        TabButtonProperties(label = "Tab 1"),
-                        TabButtonProperties(label = "Tab 2"),
-                        TabButtonProperties(label = "Tab 3"),
+                        TabButtonProperties.label(label = "Tab 1"),
+                        TabButtonProperties.label(label = "Tab 2"),
+                        TabButtonProperties.label(label = "Tab 3"),
                     ),
                 )
                 LemonadeUi.Text(
@@ -84,9 +84,9 @@ internal fun SegmentedControlDisplay() {
                     selectedTab = selectedSmall,
                     size = LemonadeSegmentedControlSize.Small,
                     properties = listOf(
-                        TabButtonProperties(label = "Tab 1"),
-                        TabButtonProperties(label = "Tab 2"),
-                        TabButtonProperties(label = "Tab 3"),
+                        TabButtonProperties.label(label = "Tab 1"),
+                        TabButtonProperties.label(label = "Tab 2"),
+                        TabButtonProperties.label(label = "Tab 3"),
                     ),
                 )
                 LemonadeUi.Text(
@@ -108,9 +108,9 @@ internal fun SegmentedControlDisplay() {
                     },
                     selectedTab = selectedIcons,
                     properties = listOf(
-                        TabButtonProperties(label = "Home", icon = LemonadeIcons.Home),
-                        TabButtonProperties(label = "Profile", icon = LemonadeIcons.User),
-                        TabButtonProperties(label = "Settings", icon = LemonadeIcons.Gear),
+                        TabButtonProperties.labelAndIcon(label = "Home", icon = LemonadeIcons.Home),
+                        TabButtonProperties.labelAndIcon(label = "Profile", icon = LemonadeIcons.User),
+                        TabButtonProperties.labelAndIcon(label = "Settings", icon = LemonadeIcons.Gear),
                     ),
                 )
                 LemonadeUi.Text(
@@ -128,9 +128,9 @@ internal fun SegmentedControlDisplay() {
                 selectedTab = selectedIconOnly,
                 size = LemonadeSegmentedControlSize.Small,
                 properties = listOf(
-                    TabButtonProperties(icon = LemonadeIcons.Heart),
-                    TabButtonProperties(icon = LemonadeIcons.Star),
-                    TabButtonProperties(icon = LemonadeIcons.Gear),
+                    TabButtonProperties.icon(icon = LemonadeIcons.Heart),
+                    TabButtonProperties.icon(icon = LemonadeIcons.Star),
+                    TabButtonProperties.icon(icon = LemonadeIcons.Gear),
                 ),
             )
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
@@ -9,61 +9,104 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.LemonadeSegmentedControlSize
 import com.teya.lemonade.core.TabButtonProperties
 
 @Suppress("LongMethod")
 @Composable
 internal fun SegmentedControlDisplay() {
-    var selectedTab1 by remember { mutableIntStateOf(0) }
-    var selectedTab2 by remember { mutableIntStateOf(1) }
+    var selectedLarge by remember { mutableIntStateOf(0) }
+    var selectedMedium by remember { mutableIntStateOf(0) }
+    var selectedSmall by remember { mutableIntStateOf(0) }
+    var selectedIcons by remember { mutableIntStateOf(1) }
+    var selectedIconOnly by remember { mutableIntStateOf(0) }
 
     SampleScreenDisplayColumn("SegmentedControl") {
-        SegmentedControlSection("Basic") {
-            LemonadeUi.SegmentedControl(
-                onTabSelected = { },
-                selectedTab = 0,
-                properties = listOf(
-                    TabButtonProperties(label = "Tab 1"),
-                    TabButtonProperties(label = "Tab 2"),
+        SegmentedControlSection("Large (Default)") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    space = LemonadeTheme.spaces.spacing200,
                 ),
-            )
-        }
-
-        SegmentedControlSection("With Icons") {
-            LemonadeUi.SegmentedControl(
-                onTabSelected = { },
-                selectedTab = 1,
-                properties = listOf(
-                    TabButtonProperties(label = "Tab 1", icon = LemonadeIcons.Heart),
-                    TabButtonProperties(label = "Tab 2", icon = LemonadeIcons.Laptop),
-                    TabButtonProperties(label = "Tab 3", icon = LemonadeIcons.User),
-                ),
-            )
-        }
-
-        SegmentedControlSection("Interactive") {
-            Column(verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200)) {
+            ) {
                 LemonadeUi.SegmentedControl(
-                    onTabSelected = { selectedTab1 = it },
-                    selectedTab = selectedTab1,
+                    onTabSelected = { index ->
+                        selectedLarge = index
+                    },
+                    selectedTab = selectedLarge,
                     properties = listOf(
-                        TabButtonProperties(label = "First"),
-                        TabButtonProperties(label = "Second"),
-                        TabButtonProperties(label = "Third"),
+                        TabButtonProperties(label = "Tab 1"),
+                        TabButtonProperties(label = "Tab 2"),
+                        TabButtonProperties(label = "Tab 3"),
                     ),
                 )
                 LemonadeUi.Text(
-                    text = "Selected tab index: $selectedTab1",
+                    text = "Selected: Tab ${selectedLarge + 1}",
                     textStyle = LemonadeTheme.typography.bodySmallRegular,
                 )
             }
         }
 
-        SegmentedControlSection("With Icons Interactive") {
-            Column(verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200)) {
+        SegmentedControlSection("Medium") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    space = LemonadeTheme.spaces.spacing200,
+                ),
+            ) {
                 LemonadeUi.SegmentedControl(
-                    onTabSelected = { selectedTab2 = it },
-                    selectedTab = selectedTab2,
+                    onTabSelected = { index ->
+                        selectedMedium = index
+                    },
+                    selectedTab = selectedMedium,
+                    size = LemonadeSegmentedControlSize.Medium,
+                    properties = listOf(
+                        TabButtonProperties(label = "Tab 1"),
+                        TabButtonProperties(label = "Tab 2"),
+                        TabButtonProperties(label = "Tab 3"),
+                    ),
+                )
+                LemonadeUi.Text(
+                    text = "Selected: Tab ${selectedMedium + 1}",
+                    textStyle = LemonadeTheme.typography.bodySmallRegular,
+                )
+            }
+        }
+
+        SegmentedControlSection("Small") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    space = LemonadeTheme.spaces.spacing200,
+                ),
+            ) {
+                LemonadeUi.SegmentedControl(
+                    onTabSelected = { index ->
+                        selectedSmall = index
+                    },
+                    selectedTab = selectedSmall,
+                    size = LemonadeSegmentedControlSize.Small,
+                    properties = listOf(
+                        TabButtonProperties(label = "Tab 1"),
+                        TabButtonProperties(label = "Tab 2"),
+                        TabButtonProperties(label = "Tab 3"),
+                    ),
+                )
+                LemonadeUi.Text(
+                    text = "Selected: Tab ${selectedSmall + 1}",
+                    textStyle = LemonadeTheme.typography.bodySmallRegular,
+                )
+            }
+        }
+
+        SegmentedControlSection("With Icons") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(
+                    space = LemonadeTheme.spaces.spacing200,
+                ),
+            ) {
+                LemonadeUi.SegmentedControl(
+                    onTabSelected = { index ->
+                        selectedIcons = index
+                    },
+                    selectedTab = selectedIcons,
                     properties = listOf(
                         TabButtonProperties(label = "Home", icon = LemonadeIcons.Home),
                         TabButtonProperties(label = "Profile", icon = LemonadeIcons.User),
@@ -71,10 +114,25 @@ internal fun SegmentedControlDisplay() {
                     ),
                 )
                 LemonadeUi.Text(
-                    text = "Selected tab index: $selectedTab2",
+                    text = "Selected: ${listOf("Home", "Profile", "Settings")[selectedIcons]}",
                     textStyle = LemonadeTheme.typography.bodySmallRegular,
                 )
             }
+        }
+
+        SegmentedControlSection("Icon Only (Small)") {
+            LemonadeUi.SegmentedControl(
+                onTabSelected = { index ->
+                    selectedIconOnly = index
+                },
+                selectedTab = selectedIconOnly,
+                size = LemonadeSegmentedControlSize.Small,
+                properties = listOf(
+                    TabButtonProperties(icon = LemonadeIcons.Heart),
+                    TabButtonProperties(icon = LemonadeIcons.Star),
+                    TabButtonProperties(icon = LemonadeIcons.Gear),
+                ),
+            )
         }
     }
 }
@@ -87,7 +145,9 @@ private fun SegmentedControlSection(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+        verticalArrangement = Arrangement.spacedBy(
+            space = LemonadeTheme.spaces.spacing300,
+        ),
     ) {
         LemonadeUi.Text(
             text = title,

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
@@ -2,10 +2,40 @@
 
 package com.teya.lemonade.core
 
-public data class TabButtonProperties(
-    val label: String? = null,
-    val icon: LemonadeIcons? = null,
-)
+public class TabButtonProperties private constructor(
+    public val label: String?,
+    public val icon: LemonadeIcons?,
+) {
+    public companion object {
+        public fun label(
+            label: String,
+        ): TabButtonProperties {
+            return TabButtonProperties(
+                label = label,
+                icon = null,
+            )
+        }
+
+        public fun labelAndIcon(
+            label: String,
+            icon: LemonadeIcons,
+        ): TabButtonProperties {
+            return TabButtonProperties(
+                label = label,
+                icon = icon,
+            )
+        }
+
+        public fun icon(
+            icon: LemonadeIcons,
+        ): TabButtonProperties {
+            return TabButtonProperties(
+                label = null,
+                icon = icon,
+            )
+        }
+    }
+}
 
 public enum class LemonadeSegmentedControlSize {
     Small,

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
@@ -3,6 +3,12 @@
 package com.teya.lemonade.core
 
 public data class TabButtonProperties(
-    val label: String,
+    val label: String? = null,
     val icon: LemonadeIcons? = null,
 )
+
+public enum class LemonadeSegmentedControlSize {
+    Small,
+    Medium,
+    Large,
+}

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/SegmentedControl.kt
@@ -7,33 +7,26 @@ public class TabButtonProperties private constructor(
     public val icon: LemonadeIcons?,
 ) {
     public companion object {
-        public fun label(
-            label: String,
-        ): TabButtonProperties {
-            return TabButtonProperties(
+        public fun label(label: String): TabButtonProperties =
+            TabButtonProperties(
                 label = label,
                 icon = null,
             )
-        }
 
         public fun labelAndIcon(
             label: String,
             icon: LemonadeIcons,
-        ): TabButtonProperties {
-            return TabButtonProperties(
+        ): TabButtonProperties =
+            TabButtonProperties(
                 label = label,
                 icon = icon,
             )
-        }
 
-        public fun icon(
-            icon: LemonadeIcons,
-        ): TabButtonProperties {
-            return TabButtonProperties(
+        public fun icon(icon: LemonadeIcons): TabButtonProperties =
+            TabButtonProperties(
                 label = null,
                 icon = icon,
             )
-        }
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -37,8 +36,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
-import com.teya.lemonade.core.LemonadeShadow
 import com.teya.lemonade.core.LemonadeSegmentedControlSize
+import com.teya.lemonade.core.LemonadeShadow
 import com.teya.lemonade.core.LemonadeTextStyle
 import com.teya.lemonade.core.TabButtonProperties
 
@@ -116,7 +115,7 @@ public fun LemonadeUi.SegmentedControl(
     )
 }
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun CoreSegmentedControl(
     content: @Composable BoxScope.(Int) -> Unit,
@@ -144,9 +143,10 @@ internal fun CoreSegmentedControl(
         ?: 0
 
     // Find which non-selected tab is being pressed (for sticky expand)
-    val pressedNonSelectedIndex = pressedTabIndex.entries.firstOrNull { entry ->
-        entry.value && entry.key != selectedIndex
-    }?.key
+    val pressedNonSelectedIndex = pressedTabIndex.entries
+        .firstOrNull { entry ->
+            entry.value && entry.key != selectedIndex
+        }?.key
 
     val hasMeasurements = tabWidths.containsKey(selectedIndex) && tabOffsets.containsKey(selectedIndex)
 
@@ -196,8 +196,7 @@ internal fun CoreSegmentedControl(
             .background(
                 color = LocalColors.current.background.bgElevated,
                 shape = pillShape,
-            )
-            .clip(shape = pillShape)
+            ).clip(shape = pillShape)
             .padding(all = size.containerPadding()),
     ) {
         // Sliding indicator
@@ -209,14 +208,12 @@ internal fun CoreSegmentedControl(
                             x = with(density) { indicatorOffset.roundToPx() },
                             y = 0,
                         )
-                    }
-                    .width(width = indicatorWidth)
+                    }.width(width = indicatorWidth)
                     .fillMaxHeight()
                     .animateLemonadeShadow(
                         shape = pillShape,
                         shadow = LemonadeShadow.Xsmall,
-                    )
-                    .background(
+                    ).background(
                         color = LocalColors.current.background.bgDefault,
                         shape = pillShape,
                     ),
@@ -268,15 +265,13 @@ internal fun CoreSegmentedControl(
                                     tabOffsets[tabIndex] = newOffset
                                 }
                             }
-                        }
-                        .clip(shape = pillShape)
+                        }.clip(shape = pillShape)
                         .clickable(
                             onClick = { onTabSelected(tabIndex) },
                             role = Role.Tab,
                             interactionSource = tabInteractionSource,
                             indication = null,
-                        )
-                        .background(color = animatedBackgroundColor)
+                        ).background(color = animatedBackgroundColor)
                         .padding(
                             horizontal = size.buttonHorizontalPadding(),
                         ),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
@@ -233,7 +234,9 @@ internal fun CoreSegmentedControl(
                 val isPressed by tabInteractionSource.collectIsPressedAsState()
 
                 // Track pressed state for sticky expand effect
-                pressedTabIndex[tabIndex] = isPressed
+                SideEffect {
+                    pressedTabIndex[tabIndex] = isPressed
+                }
 
                 val animatedBackgroundColor by animateColorAsState(
                     targetValue = when {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -74,12 +75,10 @@ public fun LemonadeUi.SegmentedControl(
     modifier: Modifier = Modifier,
 ) {
     CoreSegmentedControl(
-        selectedTab = { tabIndex ->
-            tabIndex == selectedTab
-        },
+        selectedTab = selectedTab,
         onTabSelected = onTabSelected,
         modifier = modifier,
-        tabCount = { properties.size },
+        tabCount = properties.size,
         size = size,
         content = { index ->
             val property = properties[index]
@@ -116,18 +115,18 @@ public fun LemonadeUi.SegmentedControl(
     )
 }
 
-@Suppress("LongMethod", "CyclomaticComplexMethod")
+@Suppress("LongMethod")
 @Composable
 internal fun CoreSegmentedControl(
     content: @Composable BoxScope.(Int) -> Unit,
-    tabCount: () -> Int,
-    selectedTab: (Int) -> Boolean,
+    tabCount: Int,
+    selectedTab: Int,
     onTabSelected: (Int) -> Unit,
     size: LemonadeSegmentedControlSize = LemonadeSegmentedControlSize.Large,
     modifier: Modifier = Modifier,
 ) {
     require(
-        value = tabCount() > 0,
+        value = tabCount > 0,
         lazyMessage = { "Tab count should be greater than zero." },
     )
 
@@ -138,10 +137,10 @@ internal fun CoreSegmentedControl(
     val pressedTabIndex = remember { mutableStateMapOf<Int, Boolean>() }
     val stretchAmount = 8.dp
 
-    val selectedIndex = (0 until tabCount()).firstOrNull { index ->
-        selectedTab(index)
-    }
-        ?: 0
+    val selectedIndex = selectedTab.coerceIn(
+        minimumValue = 0,
+        maximumValue = tabCount - 1,
+    )
 
     // Find which non-selected tab is being pressed (for sticky expand)
     val pressedNonSelectedIndex = pressedTabIndex.entries
@@ -222,64 +221,90 @@ internal fun CoreSegmentedControl(
         }
 
         // Tab buttons
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(
-                space = LocalSpaces.current.spacing0,
-            ),
-        ) {
-            repeat(times = tabCount()) { tabIndex ->
-                val tabInteractionSource = remember { MutableInteractionSource() }
-                val isHovering by tabInteractionSource.collectIsHoveredAsState()
-                val isPressed by tabInteractionSource.collectIsPressedAsState()
+        SegmentedControlTabRow(
+            tabCount = tabCount,
+            selectedTab = selectedTab,
+            onTabSelected = onTabSelected,
+            size = size,
+            density = density,
+            pillShape = pillShape,
+            tabWidths = tabWidths,
+            tabOffsets = tabOffsets,
+            pressedTabIndex = pressedTabIndex,
+            content = content,
+        )
+    }
+}
 
-                // Track pressed state for sticky expand effect
-                SideEffect {
-                    pressedTabIndex[tabIndex] = isPressed
-                }
+@Composable
+private fun SegmentedControlTabRow(
+    tabCount: Int,
+    selectedTab: Int,
+    onTabSelected: (Int) -> Unit,
+    size: LemonadeSegmentedControlSize,
+    density: Density,
+    pillShape: RoundedCornerShape,
+    tabWidths: MutableMap<Int, Dp>,
+    tabOffsets: MutableMap<Int, Dp>,
+    pressedTabIndex: MutableMap<Int, Boolean>,
+    content: @Composable BoxScope.(Int) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(
+            space = LocalSpaces.current.spacing0,
+        ),
+    ) {
+        repeat(times = tabCount) { tabIndex ->
+            val tabInteractionSource = remember { MutableInteractionSource() }
+            val isHovering by tabInteractionSource.collectIsHoveredAsState()
+            val isPressed by tabInteractionSource.collectIsPressedAsState()
 
-                val animatedBackgroundColor by animateColorAsState(
-                    targetValue = when {
-                        selectedTab(tabIndex) -> LocalColors.current.background.bgDefault.copy(
-                            alpha = LocalOpacities.current.base.opacity0,
-                        )
-                        isPressed -> LocalColors.current.interaction.bgDefaultPressed
-                        isHovering -> LocalColors.current.interaction.bgDefaultInteractive
-                        else -> LocalColors.current.background.bgDefault.copy(
-                            alpha = LocalOpacities.current.base.opacity0,
-                        )
-                    },
-                )
-
-                Box(
-                    content = { content(tabIndex) },
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .weight(weight = 1f)
-                        .fillMaxHeight()
-                        .onGloballyPositioned { coordinates ->
-                            with(density) {
-                                val newWidth = coordinates.size.width.toDp()
-                                val newOffset = coordinates.positionInParent().x.toDp()
-                                if (tabWidths[tabIndex] != newWidth) {
-                                    tabWidths[tabIndex] = newWidth
-                                }
-                                if (tabOffsets[tabIndex] != newOffset) {
-                                    tabOffsets[tabIndex] = newOffset
-                                }
-                            }
-                        }.clip(shape = pillShape)
-                        .clickable(
-                            onClick = { onTabSelected(tabIndex) },
-                            role = Role.Tab,
-                            interactionSource = tabInteractionSource,
-                            indication = null,
-                        ).background(color = animatedBackgroundColor)
-                        .padding(
-                            horizontal = size.buttonHorizontalPadding(),
-                        ),
-                )
+            SideEffect {
+                pressedTabIndex[tabIndex] = isPressed
             }
+
+            val animatedBackgroundColor by animateColorAsState(
+                targetValue = when {
+                    tabIndex == selectedTab -> LocalColors.current.background.bgDefault.copy(
+                        alpha = LocalOpacities.current.base.opacity0,
+                    )
+                    isPressed -> LocalColors.current.interaction.bgDefaultPressed
+                    isHovering -> LocalColors.current.interaction.bgDefaultInteractive
+                    else -> LocalColors.current.background.bgDefault.copy(
+                        alpha = LocalOpacities.current.base.opacity0,
+                    )
+                },
+            )
+
+            Box(
+                content = { content(tabIndex) },
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .weight(weight = 1f)
+                    .fillMaxHeight()
+                    .onGloballyPositioned { coordinates ->
+                        with(density) {
+                            val newWidth = coordinates.size.width.toDp()
+                            val newOffset = coordinates.positionInParent().x.toDp()
+                            if (tabWidths[tabIndex] != newWidth) {
+                                tabWidths[tabIndex] = newWidth
+                            }
+                            if (tabOffsets[tabIndex] != newOffset) {
+                                tabOffsets[tabIndex] = newOffset
+                            }
+                        }
+                    }.clip(shape = pillShape)
+                    .clickable(
+                        onClick = { onTabSelected(tabIndex) },
+                        role = Role.Tab,
+                        interactionSource = tabInteractionSource,
+                        indication = null,
+                    ).background(color = animatedBackgroundColor)
+                    .padding(
+                        horizontal = size.buttonHorizontalPadding(),
+                    ),
+            )
         }
     }
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
@@ -143,12 +144,20 @@ internal fun CoreSegmentedControl(
     )
 
     // Find which non-selected tab is being pressed (for sticky expand)
-    val pressedNonSelectedIndex = pressedTabIndex.entries
-        .firstOrNull { entry ->
-            entry.value && entry.key != selectedIndex
-        }?.key
+    val pressedNonSelectedIndex by remember {
+        derivedStateOf {
+            pressedTabIndex.entries
+                .firstOrNull { entry ->
+                    entry.value && entry.key != selectedIndex
+                }?.key
+        }
+    }
 
-    val hasMeasurements = tabWidths.containsKey(selectedIndex) && tabOffsets.containsKey(selectedIndex)
+    val hasMeasurements by remember {
+        derivedStateOf {
+            tabWidths.containsKey(selectedIndex) && tabOffsets.containsKey(selectedIndex)
+        }
+    }
 
     // Indicator stretches toward the pressed tab
     val baseWidth = tabWidths[selectedIndex]

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -52,9 +52,9 @@ import com.teya.lemonade.core.TabButtonProperties
  *     onTabSelected = { tabIndex -> /* ... */ },
  *     selectedTab = selectedTabIndex,
  *     properties = listOf(
- *         TabButtonProperties(label = "Tab 1", icon = LemonadeIcons.Heart),
- *         TabButtonProperties(label = "Tab 2", icon = LemonadeIcons.Laptop),
- *         TabButtonProperties(label = "Tab 3"),
+ *         TabButtonProperties.labelAndIcon(label = "Tab 1", icon = LemonadeIcons.Heart),
+ *         TabButtonProperties.labelAndIcon(label = "Tab 2", icon = LemonadeIcons.Laptop),
+ *         TabButtonProperties.label(label = "Tab 3"),
  *     ),
  * )
  * ```
@@ -345,9 +345,9 @@ private fun SegmentedControlPreview() {
         onTabSelected = { /* preview only */ },
         selectedTab = 1,
         properties = listOf(
-            TabButtonProperties(label = "Tab 1", icon = LemonadeIcons.Heart),
-            TabButtonProperties(label = "Tab 2", icon = LemonadeIcons.Laptop),
-            TabButtonProperties(label = "Tab 3"),
+            TabButtonProperties.labelAndIcon(label = "Tab 1", icon = LemonadeIcons.Heart),
+            TabButtonProperties.labelAndIcon(label = "Tab 2", icon = LemonadeIcons.Laptop),
+            TabButtonProperties.label(label = "Tab 3"),
         ),
     )
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -1,7 +1,9 @@
 package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -133,22 +135,59 @@ internal fun CoreSegmentedControl(
     val pillShape = RoundedCornerShape(percent = 50)
     val tabWidths = remember { mutableStateMapOf<Int, Dp>() }
     val tabOffsets = remember { mutableStateMapOf<Int, Dp>() }
+    val pressedTabIndex = remember { mutableStateMapOf<Int, Boolean>() }
+    val stretchAmount = 8.dp
 
     val selectedIndex = (0 until tabCount()).firstOrNull { index ->
         selectedTab(index)
     }
         ?: 0
 
+    // Find which non-selected tab is being pressed (for sticky expand)
+    val pressedNonSelectedIndex = pressedTabIndex.entries.firstOrNull { entry ->
+        entry.value && entry.key != selectedIndex
+    }?.key
+
     val hasMeasurements = tabWidths.containsKey(selectedIndex) && tabOffsets.containsKey(selectedIndex)
+
+    // Indicator stretches toward the pressed tab
+    val baseWidth = tabWidths[selectedIndex]
+        ?: 0.dp
+    val baseOffset = tabOffsets[selectedIndex]
+        ?: 0.dp
+
+    val targetWidth: Dp
+    val targetOffset: Dp
+    if (pressedNonSelectedIndex != null) {
+        val pressedOffset = tabOffsets[pressedNonSelectedIndex]
+            ?: baseOffset
+        if (pressedOffset > baseOffset) {
+            // Pressed tab is to the right — stretch right edge
+            targetWidth = baseWidth + stretchAmount
+            targetOffset = baseOffset
+        } else {
+            // Pressed tab is to the left — stretch left edge
+            targetWidth = baseWidth + stretchAmount
+            targetOffset = baseOffset - stretchAmount
+        }
+    } else {
+        targetWidth = baseWidth
+        targetOffset = baseOffset
+    }
+
     val indicatorWidth by animateDpAsState(
-        targetValue = tabWidths[selectedIndex]
-            ?: 0.dp,
-        animationSpec = tween(durationMillis = 250),
+        targetValue = targetWidth,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
     )
     val indicatorOffset by animateDpAsState(
-        targetValue = tabOffsets[selectedIndex]
-            ?: 0.dp,
-        animationSpec = tween(durationMillis = 250),
+        targetValue = targetOffset,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
     )
 
     Box(
@@ -195,6 +234,10 @@ internal fun CoreSegmentedControl(
                 val tabInteractionSource = remember { MutableInteractionSource() }
                 val isHovering by tabInteractionSource.collectIsHoveredAsState()
                 val isPressed by tabInteractionSource.collectIsPressedAsState()
+
+                // Track pressed state for sticky expand effect
+                pressedTabIndex[tabIndex] = isPressed
+
                 val animatedBackgroundColor by animateColorAsState(
                     targetValue = when {
                         selectedTab(tabIndex) -> LocalColors.current.background.bgDefault.copy(
@@ -231,7 +274,7 @@ internal fun CoreSegmentedControl(
                             onClick = { onTabSelected(tabIndex) },
                             role = Role.Tab,
                             interactionSource = tabInteractionSource,
-                            indication = LocalEffects.current.interactionIndication,
+                            indication = null,
                         )
                         .background(color = animatedBackgroundColor)
                         .padding(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -1,6 +1,8 @@
 package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -10,74 +12,103 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeShadow
+import com.teya.lemonade.core.LemonadeSegmentedControlSize
+import com.teya.lemonade.core.LemonadeTextStyle
 import com.teya.lemonade.core.TabButtonProperties
 
 /**
  * A horizontal control used to select a single option from a set of two or more segments.
- *  Ideal for toggling between views or filtering content.
+ * Ideal for toggling between views or filtering content.
  *
- *  ## Usage
- *  ```kotlin
- *  LemonadeUi.SegmentedControl(
- *      onTabSelected = { tabIndex -> /* ... */ },
- *      selectedTab = selectedTabIndex,
- *      properties = listOf(
- *          TabButtonProperties(label = "Tab 1", icon = LemonadeIcons.Heart),
- *          TabButtonProperties(label = "Tab 2", icon = LemonadeIcons.Laptop),
- *          TabButtonProperties(label = "Tab 3"),
- *      ),
- *  )
- *  ```
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.SegmentedControl(
+ *     onTabSelected = { tabIndex -> /* ... */ },
+ *     selectedTab = selectedTabIndex,
+ *     properties = listOf(
+ *         TabButtonProperties(label = "Tab 1", icon = LemonadeIcons.Heart),
+ *         TabButtonProperties(label = "Tab 2", icon = LemonadeIcons.Laptop),
+ *         TabButtonProperties(label = "Tab 3"),
+ *     ),
+ * )
+ * ```
  *
- * @param properties - A list of [TabButtonProperties] that represent the tab buttons' information.
- * @param selectedTab - [Int] that indicates what is the index of the selected tab.
- * @param onTabSelected - A callback invoked when a tab is selected.
- * @param modifier - The [Modifier] to be applied to the root container of the component.
+ * @param properties A list of [TabButtonProperties] that represent the tab buttons' information.
+ * @param selectedTab [Int] that indicates what is the index of the selected tab.
+ * @param onTabSelected A callback invoked when a tab is selected.
+ * @param size The size of the segmented control. Defaults to [LemonadeSegmentedControlSize.Large].
+ * @param modifier The [Modifier] to be applied to the root container of the component.
  */
 @Composable
 public fun LemonadeUi.SegmentedControl(
     properties: List<TabButtonProperties>,
     selectedTab: Int,
     onTabSelected: (Int) -> Unit,
+    size: LemonadeSegmentedControlSize = LemonadeSegmentedControlSize.Large,
     modifier: Modifier = Modifier,
 ) {
     CoreSegmentedControl(
-        selectedTab = { tabIndex -> tabIndex == selectedTab },
+        selectedTab = { tabIndex ->
+            tabIndex == selectedTab
+        },
         onTabSelected = onTabSelected,
         modifier = modifier,
         tabCount = { properties.size },
+        size = size,
         content = { index ->
             val property = properties[index]
+            val contentColor = if (selectedTab == index) {
+                LocalColors.current.content.contentPrimary
+            } else {
+                LocalColors.current.content.contentSecondary
+            }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing200),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = size.buttonContentGap(),
+                ),
             ) {
                 property.icon?.let { icon ->
                     LemonadeUi.Icon(
                         icon = icon,
                         contentDescription = property.label,
                         size = LemonadeAssetSize.Small,
+                        tint = contentColor,
                     )
                 }
 
-                LemonadeUi.Text(
-                    text = property.label,
-                    textStyle = LocalTypographies.current.bodySmallMedium,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                property.label?.let { label ->
+                    LemonadeUi.Text(
+                        text = label,
+                        textStyle = size.textStyle(),
+                        overflow = TextOverflow.Ellipsis,
+                        color = contentColor,
+                    )
+                }
             }
         },
     )
@@ -90,6 +121,7 @@ internal fun CoreSegmentedControl(
     tabCount: () -> Int,
     selectedTab: (Int) -> Boolean,
     onTabSelected: (Int) -> Unit,
+    size: LemonadeSegmentedControlSize = LemonadeSegmentedControlSize.Large,
     modifier: Modifier = Modifier,
 ) {
     require(
@@ -97,58 +129,171 @@ internal fun CoreSegmentedControl(
         lazyMessage = { "Tab count should be greater than zero." },
     )
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing0),
+    val density = LocalDensity.current
+    val pillShape = RoundedCornerShape(percent = 50)
+    val tabWidths = remember { mutableStateMapOf<Int, Dp>() }
+    val tabOffsets = remember { mutableStateMapOf<Int, Dp>() }
+
+    val selectedIndex = (0 until tabCount()).firstOrNull { index ->
+        selectedTab(index)
+    }
+        ?: 0
+
+    val hasMeasurements = tabWidths.containsKey(selectedIndex) && tabOffsets.containsKey(selectedIndex)
+    val indicatorWidth by animateDpAsState(
+        targetValue = tabWidths[selectedIndex]
+            ?: 0.dp,
+        animationSpec = tween(durationMillis = 250),
+    )
+    val indicatorOffset by animateDpAsState(
+        targetValue = tabOffsets[selectedIndex]
+            ?: 0.dp,
+        animationSpec = tween(durationMillis = 250),
+    )
+
+    Box(
         modifier = modifier
+            .height(height = size.containerHeight())
             .background(
                 color = LocalColors.current.background.bgElevated,
-                shape = LocalShapes.current.radius200,
-            ).padding(all = LocalSpaces.current.spacing50),
-    ) {
-        repeat(times = tabCount()) { tabIndex ->
-            val tabInteractionSource = remember { MutableInteractionSource() }
-            val isHovering by tabInteractionSource.collectIsHoveredAsState()
-            val isPressed by tabInteractionSource.collectIsPressedAsState()
-            val animatedBackgroundColor by animateColorAsState(
-                targetValue = when {
-                    selectedTab(tabIndex) -> LocalColors.current.background.bgDefault
-                    isPressed -> LocalColors.current.interaction.bgDefaultPressed
-                    isHovering -> LocalColors.current.interaction.bgDefaultInteractive
-                    else -> LocalColors.current.background.bgDefault.copy(
-                        alpha = LocalOpacities.current.base.opacity0,
-                    )
-                },
+                shape = pillShape,
             )
-
+            .clip(shape = pillShape)
+            .padding(all = size.containerPadding()),
+    ) {
+        // Sliding indicator
+        if (hasMeasurements) {
             Box(
-                content = { content(tabIndex) },
-                contentAlignment = Alignment.Center,
                 modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            x = with(density) { indicatorOffset.roundToPx() },
+                            y = 0,
+                        )
+                    }
+                    .width(width = indicatorWidth)
+                    .fillMaxHeight()
                     .animateLemonadeShadow(
-                        shape = LocalShapes.current.radius200,
-                        shadow = if (selectedTab(tabIndex)) {
-                            LemonadeShadow.Xsmall
-                        } else {
-                            LemonadeShadow.None
-                        },
-                    ).weight(weight = 1f)
-                    .clip(shape = LocalShapes.current.radius200)
-                    .clickable(
-                        onClick = { onTabSelected(tabIndex) },
-                        role = Role.Tab,
-                        interactionSource = tabInteractionSource,
-                        indication = LocalEffects.current.interactionIndication,
-                    ).background(color = animatedBackgroundColor)
-                    .defaultMinSize(
-                        minHeight = LocalSizes.current.size800,
-                        minWidth = LocalSizes.current.size1600,
-                    ).padding(
-                        vertical = LocalSpaces.current.spacing100,
-                        horizontal = LocalSpaces.current.spacing200,
+                        shape = pillShape,
+                        shadow = LemonadeShadow.Xsmall,
+                    )
+                    .background(
+                        color = LocalColors.current.background.bgDefault,
+                        shape = pillShape,
                     ),
             )
         }
+
+        // Tab buttons
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(
+                space = LocalSpaces.current.spacing0,
+            ),
+        ) {
+            repeat(times = tabCount()) { tabIndex ->
+                val tabInteractionSource = remember { MutableInteractionSource() }
+                val isHovering by tabInteractionSource.collectIsHoveredAsState()
+                val isPressed by tabInteractionSource.collectIsPressedAsState()
+                val animatedBackgroundColor by animateColorAsState(
+                    targetValue = when {
+                        selectedTab(tabIndex) -> LocalColors.current.background.bgDefault.copy(
+                            alpha = LocalOpacities.current.base.opacity0,
+                        )
+                        isPressed -> LocalColors.current.interaction.bgDefaultPressed
+                        isHovering -> LocalColors.current.interaction.bgDefaultInteractive
+                        else -> LocalColors.current.background.bgDefault.copy(
+                            alpha = LocalOpacities.current.base.opacity0,
+                        )
+                    },
+                )
+
+                Box(
+                    content = { content(tabIndex) },
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .weight(weight = 1f)
+                        .fillMaxHeight()
+                        .onGloballyPositioned { coordinates ->
+                            with(density) {
+                                val newWidth = coordinates.size.width.toDp()
+                                val newOffset = coordinates.positionInParent().x.toDp()
+                                if (tabWidths[tabIndex] != newWidth) {
+                                    tabWidths[tabIndex] = newWidth
+                                }
+                                if (tabOffsets[tabIndex] != newOffset) {
+                                    tabOffsets[tabIndex] = newOffset
+                                }
+                            }
+                        }
+                        .clip(shape = pillShape)
+                        .clickable(
+                            onClick = { onTabSelected(tabIndex) },
+                            role = Role.Tab,
+                            interactionSource = tabInteractionSource,
+                            indication = LocalEffects.current.interactionIndication,
+                        )
+                        .background(color = animatedBackgroundColor)
+                        .padding(
+                            horizontal = size.buttonHorizontalPadding(),
+                        ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.containerHeight(): Dp {
+    val sizes = LocalSizes.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> sizes.size800
+        LemonadeSegmentedControlSize.Medium -> sizes.size1000
+        LemonadeSegmentedControlSize.Large -> sizes.size1200
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.containerPadding(): Dp {
+    val spaces = LocalSpaces.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> spaces.spacing50
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> spaces.spacing100
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.buttonContentGap(): Dp {
+    val spaces = LocalSpaces.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> spaces.spacing50
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> spaces.spacing100
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.buttonHorizontalPadding(): Dp {
+    val spaces = LocalSpaces.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> spaces.spacing200
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> spaces.spacing300
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.textStyle(): LemonadeTextStyle {
+    val typography = LocalTypographies.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> typography.bodyXSmallMedium
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> typography.bodySmallMedium
     }
 }
 

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -122,7 +122,7 @@ struct HomeView: View {
         List {
             Section {
                 LemonadeUi.SegmentedControl(
-                    properties: LemonadeStyle.allCases.map { LemonadeTabButtonProperties(label: $0.label) },
+                    properties: LemonadeStyle.allCases.map { .label($0.label) },
                     selectedTab: selectedStyleIndex,
                     onTabSelected: { index in
                         styleHandler.currentStyle = LemonadeStyle.allCases[index]

--- a/swiftui/SampleApp/SegmentedControlDisplayView.swift
+++ b/swiftui/SampleApp/SegmentedControlDisplayView.swift
@@ -5,12 +5,15 @@ struct SegmentedControlDisplayView: View {
     @State private var selectedTab1 = 0
     @State private var selectedTab2 = 1
     @State private var selectedTab3 = 0
+    @State private var selectedTabMedium = 0
+    @State private var selectedTabSmall = 0
+    @State private var selectedTabIconOnly = 0
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
-                // Basic tabs
-                sectionView(title: "Basic Tabs") {
+                // Large (default)
+                sectionView(title: "Large (Default)") {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
@@ -28,7 +31,47 @@ struct SegmentedControlDisplayView: View {
                     }
                 }
 
-                // Tabs with icons
+                // Medium
+                sectionView(title: "Medium") {
+                    VStack(spacing: 16) {
+                        LemonadeUi.SegmentedControl(
+                            properties: [
+                                LemonadeTabButtonProperties(label: "Tab 1"),
+                                LemonadeTabButtonProperties(label: "Tab 2"),
+                                LemonadeTabButtonProperties(label: "Tab 3"),
+                            ],
+                            selectedTab: selectedTabMedium,
+                            size: .medium,
+                            onTabSelected: { selectedTabMedium = $0 }
+                        )
+
+                        Text("Selected: Tab \(selectedTabMedium + 1)")
+                            .font(.caption)
+                            .foregroundStyle(.content.contentSecondary)
+                    }
+                }
+
+                // Small
+                sectionView(title: "Small") {
+                    VStack(spacing: 16) {
+                        LemonadeUi.SegmentedControl(
+                            properties: [
+                                LemonadeTabButtonProperties(label: "Tab 1"),
+                                LemonadeTabButtonProperties(label: "Tab 2"),
+                                LemonadeTabButtonProperties(label: "Tab 3"),
+                            ],
+                            selectedTab: selectedTabSmall,
+                            size: .small,
+                            onTabSelected: { selectedTabSmall = $0 }
+                        )
+
+                        Text("Selected: Tab \(selectedTabSmall + 1)")
+                            .font(.caption)
+                            .foregroundStyle(.content.contentSecondary)
+                    }
+                }
+
+                // With Icons
                 sectionView(title: "With Icons") {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
@@ -47,7 +90,23 @@ struct SegmentedControlDisplayView: View {
                     }
                 }
 
-                // Two tabs toggle
+                // Icon Only (Small)
+                sectionView(title: "Icon Only (Small)") {
+                    VStack(spacing: 16) {
+                        LemonadeUi.SegmentedControl(
+                            properties: [
+                                LemonadeTabButtonProperties(icon: .heart),
+                                LemonadeTabButtonProperties(icon: .star),
+                                LemonadeTabButtonProperties(icon: .gear),
+                            ],
+                            selectedTab: selectedTabIconOnly,
+                            size: .small,
+                            onTabSelected: { selectedTabIconOnly = $0 }
+                        )
+                    }
+                }
+
+                // Toggle
                 sectionView(title: "Toggle Style") {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
@@ -62,21 +121,6 @@ struct SegmentedControlDisplayView: View {
                         Text("Status: \(selectedTab3 == 0 ? "On" : "Off")")
                             .font(.caption)
                             .foregroundStyle(.content.contentSecondary)
-                    }
-                }
-
-                // Use case example
-                sectionView(title: "Filter Example") {
-                    VStack(spacing: 16) {
-                        LemonadeUi.SegmentedControl(
-                            properties: [
-                                LemonadeTabButtonProperties(label: "All"),
-                                LemonadeTabButtonProperties(label: "Active"),
-                                LemonadeTabButtonProperties(label: "Completed"),
-                            ],
-                            selectedTab: 0,
-                            onTabSelected: { _ in }
-                        )
                     }
                 }
             }

--- a/swiftui/SampleApp/SegmentedControlDisplayView.swift
+++ b/swiftui/SampleApp/SegmentedControlDisplayView.swift
@@ -17,9 +17,9 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(label: "Tab 1"),
-                                LemonadeTabButtonProperties(label: "Tab 2"),
-                                LemonadeTabButtonProperties(label: "Tab 3"),
+                                .label("Tab 1"),
+                                .label("Tab 2"),
+                                .label("Tab 3"),
                             ],
                             selectedTab: selectedTab1,
                             onTabSelected: { selectedTab1 = $0 }
@@ -36,9 +36,9 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(label: "Tab 1"),
-                                LemonadeTabButtonProperties(label: "Tab 2"),
-                                LemonadeTabButtonProperties(label: "Tab 3"),
+                                .label("Tab 1"),
+                                .label("Tab 2"),
+                                .label("Tab 3"),
                             ],
                             selectedTab: selectedTabMedium,
                             size: .medium,
@@ -56,9 +56,9 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(label: "Tab 1"),
-                                LemonadeTabButtonProperties(label: "Tab 2"),
-                                LemonadeTabButtonProperties(label: "Tab 3"),
+                                .label("Tab 1"),
+                                .label("Tab 2"),
+                                .label("Tab 3"),
                             ],
                             selectedTab: selectedTabSmall,
                             size: .small,
@@ -76,9 +76,9 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(label: "Favorites", icon: .heart),
-                                LemonadeTabButtonProperties(label: "Bookmarks", icon: .star),
-                                LemonadeTabButtonProperties(label: "Settings", icon: .gear),
+                                .labelAndIcon("Favorites", icon: .heart),
+                                .labelAndIcon("Bookmarks", icon: .star),
+                                .labelAndIcon("Settings", icon: .gear),
                             ],
                             selectedTab: selectedTab2,
                             onTabSelected: { selectedTab2 = $0 }
@@ -95,9 +95,9 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(icon: .heart),
-                                LemonadeTabButtonProperties(icon: .star),
-                                LemonadeTabButtonProperties(icon: .gear),
+                                .icon(.heart),
+                                .icon(.star),
+                                .icon(.gear),
                             ],
                             selectedTab: selectedTabIconOnly,
                             size: .small,
@@ -111,8 +111,8 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                LemonadeTabButtonProperties(label: "On"),
-                                LemonadeTabButtonProperties(label: "Off"),
+                                .label("On"),
+                                .label("Off"),
                             ],
                             selectedTab: selectedTab3,
                             onTabSelected: { selectedTab3 = $0 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -118,16 +118,21 @@ private struct LemonadeSegmentedControlView: View {
 
     var body: some View {
         #if canImport(UIKit)
-        ZStack {
-            LemonadeNativeSegmentedControl(
-                segmentLabels: properties.map { $0.label ?? $0.icon?.rawValue ?? "" },
-                selectedIndex: clampedSelectedTab,
-                onSelectionChanged: onTabSelected
-            )
-
-            labelsOverlay
+        if #available(iOS 26.0, *) {
+            ZStack {
+                LemonadeNativeSegmentedControl(
+                    segmentLabels: properties.map { $0.label ?? $0.icon?.rawValue ?? "" },
+                    selectedIndex: clampedSelectedTab,
+                    onSelectionChanged: onTabSelected
+                )
+                
+                labelsOverlay
+            }
+            .frame(height: size.containerHeight)
+//            .glassEffect(.regular.tint(.clear).interactive())
+        } else {
+            // Fallback on earlier versions
         }
-        .frame(height: size.containerHeight)
         #else
         labelsOverlay
             .frame(height: size.containerHeight)
@@ -146,31 +151,44 @@ private struct LemonadeSegmentedControlView: View {
                     ? LemonadeTheme.colors.content.contentPrimary
                     : LemonadeTheme.colors.content.contentSecondary
 
-                HStack(spacing: size.buttonContentGap) {
-                    if let icon = property.icon {
-                        LemonadeUi.Icon(
-                            icon: icon,
-                            contentDescription: property.label,
-                            size: .small,
-                            tint: tintColor
-                        )
-                    }
+                Button {
+                    onTabSelected(index)
+                } label: {
+                    HStack(spacing: size.buttonContentGap) {
+                        if let icon = property.icon {
+                            LemonadeUi.Icon(
+                                icon: icon,
+                                contentDescription: property.label,
+                                size: .small,
+                                tint: tintColor
+                            )
+                        }
 
-                    if let label = property.label {
-                        LemonadeUi.Text(
-                            label,
-                            textStyle: size.textStyle,
-                            textAlign: .center,
-                            color: tintColor,
-                            maxLines: 1
-                        )
+                        if let label = property.label {
+                            LemonadeUi.Text(
+                                label,
+                                textStyle: size.textStyle,
+                                textAlign: .center,
+                                color: tintColor,
+                                maxLines: 1
+                            )
+                        }
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .accessibilityHidden(true)
+                .buttonStyle(SegmentPressStyle())
+                .frame(maxWidth: .infinity)
             }
         }
-        .allowsHitTesting(false)
+        .animation(.easeInOut(duration: 0.2), value: clampedSelectedTab)
+    }
+}
+
+private struct SegmentPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.5 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -105,7 +105,7 @@ private struct LemonadeSegmentedControlView: View {
         #if canImport(UIKit)
         ZStack {
             LemonadeNativeSegmentedControl(
-                segmentLabels: properties.map { $0.label ?? "" },
+                segmentLabels: properties.map { $0.label ?? $0.icon?.rawValue ?? "" },
                 selectedIndex: clampedSelectedTab,
                 onSelectionChanged: onTabSelected
             )
@@ -196,6 +196,18 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
 
     func updateUIView(_ uiView: UISegmentedControl, context: Context) {
         context.coordinator.onSelectionChanged = onSelectionChanged
+
+        // Reconcile segment count if properties changed
+        if uiView.numberOfSegments != segmentLabels.count {
+            uiView.removeAllSegments()
+            for (index, label) in segmentLabels.enumerated() {
+                uiView.insertSegment(withTitle: label, at: index, animated: false)
+            }
+            let clearAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.clear]
+            uiView.setTitleTextAttributes(clearAttributes, for: .normal)
+            uiView.setTitleTextAttributes(clearAttributes, for: .selected)
+        }
+
         let clampedIndex = min(selectedIndex, segmentLabels.count - 1)
         if uiView.selectedSegmentIndex != clampedIndex {
             uiView.selectedSegmentIndex = clampedIndex

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -10,10 +10,25 @@ public struct LemonadeTabButtonProperties: Identifiable, Hashable {
     /// Optional icon to display before the label.
     public let icon: LemonadeIcon?
 
-    public init(id: String? = nil, label: String? = nil, icon: LemonadeIcon? = nil) {
+    private init(id: String? = nil, label: String?, icon: LemonadeIcon?) {
         self.id = id ?? UUID().uuidString
         self.label = label
         self.icon = icon
+    }
+
+    /// Creates a tab with a text label.
+    public static func label(_ label: String) -> Self {
+        Self(label: label, icon: nil)
+    }
+
+    /// Creates a tab with a text label and an icon.
+    public static func labelAndIcon(_ label: String, icon: LemonadeIcon) -> Self {
+        Self(label: label, icon: icon)
+    }
+
+    /// Creates a tab with only an icon.
+    public static func icon(_ icon: LemonadeIcon) -> Self {
+        Self(label: nil, icon: icon)
     }
 }
 
@@ -58,9 +73,9 @@ public extension LemonadeUi {
     /// ```swift
     /// LemonadeUi.SegmentedControl(
     ///     properties: [
-    ///         LemonadeTabButtonProperties(label: "Tab 1", icon: .heart),
-    ///         LemonadeTabButtonProperties(label: "Tab 2", icon: .laptop),
-    ///         LemonadeTabButtonProperties(label: "Tab 3"),
+    ///         .labelAndIcon("Tab 1", icon: .heart),
+    ///         .labelAndIcon("Tab 2", icon: .laptop),
+    ///         .label("Tab 3"),
     ///     ],
     ///     selectedTab: selectedTabIndex,
     ///     onTabSelected: { tabIndex in /* ... */ }
@@ -237,9 +252,9 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
             // Large (default)
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(label: "Tab 1"),
-                    LemonadeTabButtonProperties(label: "Tab 2"),
-                    LemonadeTabButtonProperties(label: "Tab 3"),
+                    .label("Tab 1"),
+                    .label("Tab 2"),
+                    .label("Tab 3"),
                 ],
                 selectedTab: 1,
                 onTabSelected: { _ in }
@@ -248,9 +263,9 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
             // Medium
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(label: "Tab 1"),
-                    LemonadeTabButtonProperties(label: "Tab 2"),
-                    LemonadeTabButtonProperties(label: "Tab 3"),
+                    .label("Tab 1"),
+                    .label("Tab 2"),
+                    .label("Tab 3"),
                 ],
                 selectedTab: 0,
                 size: .medium,
@@ -260,8 +275,8 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
             // Small
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(label: "Tab 1"),
-                    LemonadeTabButtonProperties(label: "Tab 2"),
+                    .label("Tab 1"),
+                    .label("Tab 2"),
                 ],
                 selectedTab: 0,
                 size: .small,
@@ -271,9 +286,9 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
             // Icon only (small)
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(icon: .heart),
-                    LemonadeTabButtonProperties(icon: .star),
-                    LemonadeTabButtonProperties(icon: .gear),
+                    .icon(.heart),
+                    .icon(.star),
+                    .icon(.gear),
                 ],
                 selectedTab: 0,
                 size: .small,

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -5,15 +5,46 @@ import SwiftUI
 /// Properties for a single tab button in a segmented control.
 public struct LemonadeTabButtonProperties: Identifiable, Hashable {
     public let id: String
-    /// The label text for the tab.
-    public let label: String
+    /// The label text for the tab. When nil, only the icon is shown.
+    public let label: String?
     /// Optional icon to display before the label.
     public let icon: LemonadeIcon?
 
-    public init(id: String? = nil, label: String, icon: LemonadeIcon? = nil) {
+    public init(id: String? = nil, label: String? = nil, icon: LemonadeIcon? = nil) {
         self.id = id ?? UUID().uuidString
         self.label = label
         self.icon = icon
+    }
+}
+
+/// Size variants for the segmented control.
+public enum LemonadeSegmentedControlSize {
+    case small
+    case medium
+    case large
+}
+
+private extension LemonadeSegmentedControlSize {
+    var containerHeight: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.sizes.size800   // 32
+        case .medium: return LemonadeTheme.sizes.size1000  // 40
+        case .large: return LemonadeTheme.sizes.size1200   // 48
+        }
+    }
+
+    var buttonContentGap: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.spaces.spacing50   // 2
+        case .medium, .large: return LemonadeTheme.spaces.spacing100  // 4
+        }
+    }
+
+    var textStyle: LemonadeTextStyle {
+        switch self {
+        case .small: return LemonadeTypography.shared.bodyXSmallMedium
+        case .medium, .large: return LemonadeTypography.shared.bodySmallMedium
+        }
     }
 }
 
@@ -39,17 +70,20 @@ public extension LemonadeUi {
     /// - Parameters:
     ///   - properties: A list of `LemonadeTabButtonProperties` that represent the tab buttons' information.
     ///   - selectedTab: Int that indicates what is the index of the selected tab.
+    ///   - size: The size of the segmented control. Defaults to `.large`.
     ///   - onTabSelected: A callback invoked when a tab is selected.
     /// - Returns: A styled SegmentedControl view
     @ViewBuilder
     static func SegmentedControl(
         properties: [LemonadeTabButtonProperties],
         selectedTab: Int,
+        size: LemonadeSegmentedControlSize = .large,
         onTabSelected: @escaping (Int) -> Void
     ) -> some View {
         LemonadeSegmentedControlView(
             properties: properties,
             selectedTab: selectedTab,
+            size: size,
             onTabSelected: onTabSelected
         )
     }
@@ -60,90 +94,104 @@ public extension LemonadeUi {
 private struct LemonadeSegmentedControlView: View {
     let properties: [LemonadeTabButtonProperties]
     let selectedTab: Int
+    let size: LemonadeSegmentedControlSize
     let onTabSelected: (Int) -> Void
 
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(Array(properties.enumerated()), id: \.element.id) { index, property in
-                LemonadeSegmentedTabButton(
-                    property: property,
-                    isSelected: index == selectedTab,
-                    onTap: { onTabSelected(index) }
-                )
-            }
-        }
-        .padding(LemonadeTheme.spaces.spacing50)
-        .background(
-            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200)
-                .fill(LemonadeTheme.colors.background.bgElevated)
-        )
-    }
-}
-
-// MARK: - Internal Tab Button
-
-private struct LemonadeSegmentedTabButton: View {
-    let property: LemonadeTabButtonProperties
-    let isSelected: Bool
-    let onTap: () -> Void
-
-    @State private var isPressed = false
-    @State private var isHovering = false
-
-    private var backgroundColor: Color {
-        if isSelected {
-            return LemonadeTheme.colors.background.bgDefault
-        } else if isPressed {
-            return LemonadeTheme.colors.interaction.bgDefaultPressed
-        } else if isHovering {
-            return LemonadeTheme.colors.interaction.bgDefaultInteractive
-        } else {
-            return LemonadeTheme.colors.background.bgDefault.opacity(LemonadeTheme.opacity.base.opacity0)
-        }
-    }
-
-    private var shadow: LemonadeShadow {
-        isSelected ? .xsmall : .none
-    }
-
-    var body: some View {
-        SwiftUI.Button(action: onTap) {
-            HStack(spacing: LemonadeTheme.spaces.spacing200) {
-                if let icon = property.icon {
-                    LemonadeUi.Icon(
-                        icon: icon,
-                        contentDescription: property.label,
-                        size: .small
-                    )
-                }
-
-                LemonadeUi.Text(
-                    property.label,
-                    textStyle: LemonadeTypography.shared.bodySmallMedium
-                )
-                .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(minHeight: LemonadeTheme.sizes.size800)
-            .frame(minWidth: LemonadeTheme.sizes.size1600)
-            .padding(.vertical, LemonadeTheme.spaces.spacing100)
-            .padding(.horizontal, LemonadeTheme.spaces.spacing200)
-            .background(
-                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200)
-                    .fill(backgroundColor)
-                    .animation(.easeInOut(duration: 0.1), value: backgroundColor)
+        ZStack {
+            LemonadeNativeSegmentedControl(
+                segmentLabels: properties.map { $0.label ?? "" },
+                selectedIndex: selectedTab,
+                onSelectionChanged: onTabSelected
             )
-            .lemonadeShadow(shadow)
-            .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200))
+
+            HStack(spacing: 0) {
+                ForEach(properties.indices, id: \.self) { index in
+                    let property = properties[index]
+                    let tintColor = index == selectedTab
+                        ? LemonadeTheme.colors.content.contentPrimary
+                        : LemonadeTheme.colors.content.contentSecondary
+
+                    HStack(spacing: size.buttonContentGap) {
+                        if let icon = property.icon {
+                            LemonadeUi.Icon(
+                                icon: icon,
+                                contentDescription: property.label,
+                                size: .small,
+                                tint: tintColor
+                            )
+                        }
+
+                        if let label = property.label {
+                            LemonadeUi.Text(
+                                label,
+                                textStyle: size.textStyle,
+                                textAlign: .center,
+                                color: tintColor,
+                                maxLines: 1
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityHidden(true)
+                }
+            }
+            .allowsHitTesting(false)
         }
-        .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
-        .onHover { hovering in
-            isHovering = hovering
-        }
-        .accessibilityAddTraits(.isButton)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .frame(height: size.containerHeight)
     }
 }
+
+// MARK: - Native UISegmentedControl (provides Liquid Glass on iOS 26)
+
+#if canImport(UIKit)
+import UIKit
+
+private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
+    let segmentLabels: [String]
+    let selectedIndex: Int
+    let onSelectionChanged: (Int) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onSelectionChanged: onSelectionChanged)
+    }
+
+    func makeUIView(context: Context) -> UISegmentedControl {
+        let control = UISegmentedControl(items: segmentLabels)
+        control.selectedSegmentIndex = selectedIndex
+        control.backgroundColor = .clear
+        control.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        control.setContentHuggingPriority(.defaultLow, for: .vertical)
+        control.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+        control.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.segmentChanged(_:)),
+            for: .valueChanged
+        )
+        return control
+    }
+
+    func updateUIView(_ uiView: UISegmentedControl, context: Context) {
+        context.coordinator.onSelectionChanged = onSelectionChanged
+        if uiView.selectedSegmentIndex != selectedIndex {
+            uiView.selectedSegmentIndex = selectedIndex
+        }
+    }
+
+    class Coordinator: NSObject {
+        var onSelectionChanged: (Int) -> Void
+
+        init(onSelectionChanged: @escaping (Int) -> Void) {
+            self.onSelectionChanged = onSelectionChanged
+        }
+
+        @MainActor @objc func segmentChanged(_ control: UISegmentedControl) {
+            onSelectionChanged(control.selectedSegmentIndex)
+        }
+    }
+}
+#endif
 
 // MARK: - Previews
 
@@ -151,7 +199,7 @@ private struct LemonadeSegmentedTabButton: View {
 struct LemonadeSegmentedControl_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 24) {
-            // Basic tabs
+            // Large (default)
             LemonadeUi.SegmentedControl(
                 properties: [
                     LemonadeTabButtonProperties(label: "Tab 1"),
@@ -162,24 +210,38 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
                 onTabSelected: { _ in }
             )
 
-            // Tabs with icons
+            // Medium
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(label: "Tab 1", icon: .heart),
-                    LemonadeTabButtonProperties(label: "Tab 2", icon: .star),
-                    LemonadeTabButtonProperties(label: "Tab 3", icon: .gear),
+                    LemonadeTabButtonProperties(label: "Tab 1"),
+                    LemonadeTabButtonProperties(label: "Tab 2"),
+                    LemonadeTabButtonProperties(label: "Tab 3"),
                 ],
                 selectedTab: 0,
+                size: .medium,
                 onTabSelected: { _ in }
             )
 
-            // Two tabs
+            // Small
             LemonadeUi.SegmentedControl(
                 properties: [
-                    LemonadeTabButtonProperties(label: "On"),
-                    LemonadeTabButtonProperties(label: "Off"),
+                    LemonadeTabButtonProperties(label: "Tab 1"),
+                    LemonadeTabButtonProperties(label: "Tab 2"),
                 ],
                 selectedTab: 0,
+                size: .small,
+                onTabSelected: { _ in }
+            )
+
+            // Icon only (small)
+            LemonadeUi.SegmentedControl(
+                properties: [
+                    LemonadeTabButtonProperties(icon: .heart),
+                    LemonadeTabButtonProperties(icon: .star),
+                    LemonadeTabButtonProperties(icon: .gear),
+                ],
+                selectedTab: 0,
+                size: .small,
                 onTabSelected: { _ in }
             )
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -97,48 +97,65 @@ private struct LemonadeSegmentedControlView: View {
     let size: LemonadeSegmentedControlSize
     let onTabSelected: (Int) -> Void
 
+    private var clampedSelectedTab: Int {
+        min(max(selectedTab, 0), properties.count - 1)
+    }
+
     var body: some View {
+        #if canImport(UIKit)
         ZStack {
             LemonadeNativeSegmentedControl(
                 segmentLabels: properties.map { $0.label ?? "" },
-                selectedIndex: selectedTab,
+                selectedIndex: clampedSelectedTab,
                 onSelectionChanged: onTabSelected
             )
 
-            HStack(spacing: 0) {
-                ForEach(properties.indices, id: \.self) { index in
-                    let property = properties[index]
-                    let tintColor = index == selectedTab
-                        ? LemonadeTheme.colors.content.contentPrimary
-                        : LemonadeTheme.colors.content.contentSecondary
-
-                    HStack(spacing: size.buttonContentGap) {
-                        if let icon = property.icon {
-                            LemonadeUi.Icon(
-                                icon: icon,
-                                contentDescription: property.label,
-                                size: .small,
-                                tint: tintColor
-                            )
-                        }
-
-                        if let label = property.label {
-                            LemonadeUi.Text(
-                                label,
-                                textStyle: size.textStyle,
-                                textAlign: .center,
-                                color: tintColor,
-                                maxLines: 1
-                            )
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .accessibilityHidden(true)
-                }
-            }
-            .allowsHitTesting(false)
+            labelsOverlay
         }
         .frame(height: size.containerHeight)
+        #else
+        labelsOverlay
+            .frame(height: size.containerHeight)
+            .background(
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
+                    .fill(LemonadeTheme.colors.background.bgElevated)
+            )
+        #endif
+    }
+
+    private var labelsOverlay: some View {
+        HStack(spacing: 0) {
+            ForEach(properties.indices, id: \.self) { index in
+                let property = properties[index]
+                let tintColor = index == clampedSelectedTab
+                    ? LemonadeTheme.colors.content.contentPrimary
+                    : LemonadeTheme.colors.content.contentSecondary
+
+                HStack(spacing: size.buttonContentGap) {
+                    if let icon = property.icon {
+                        LemonadeUi.Icon(
+                            icon: icon,
+                            contentDescription: property.label,
+                            size: .small,
+                            tint: tintColor
+                        )
+                    }
+
+                    if let label = property.label {
+                        LemonadeUi.Text(
+                            label,
+                            textStyle: size.textStyle,
+                            textAlign: .center,
+                            color: tintColor,
+                            maxLines: 1
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityHidden(true)
+            }
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -158,11 +175,16 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UISegmentedControl {
         let control = UISegmentedControl(items: segmentLabels)
-        control.selectedSegmentIndex = selectedIndex
+        control.selectedSegmentIndex = min(selectedIndex, segmentLabels.count - 1)
         control.backgroundColor = .clear
         control.setContentHuggingPriority(.defaultLow, for: .horizontal)
         control.setContentHuggingPriority(.defaultLow, for: .vertical)
         control.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+        // Hide native text — custom SwiftUI overlay handles visuals
+        let clearAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.clear]
+        control.setTitleTextAttributes(clearAttributes, for: .normal)
+        control.setTitleTextAttributes(clearAttributes, for: .selected)
 
         control.addTarget(
             context.coordinator,
@@ -174,8 +196,9 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
 
     func updateUIView(_ uiView: UISegmentedControl, context: Context) {
         context.coordinator.onSelectionChanged = onSelectionChanged
-        if uiView.selectedSegmentIndex != selectedIndex {
-            uiView.selectedSegmentIndex = selectedIndex
+        let clampedIndex = min(selectedIndex, segmentLabels.count - 1)
+        if uiView.selectedSegmentIndex != clampedIndex {
+            uiView.selectedSegmentIndex = clampedIndex
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 3 size variants (Small/Medium/Large, default Large) for both SwiftUI and KMP
- Use `radiusFull` pill shape for container and indicator
- Add sliding indicator animation (native `UISegmentedControl` on iOS for Liquid Glass support, `onGloballyPositioned` + `animateDpAsState` with spring physics on KMP)
- Support icon-only tabs when `label` is nil
- Use `contentSecondary` for unselected tab text/icons
- Add sticky expand effect on KMP — indicator stretches toward pressed tab before sliding
- Update SampleApp displays with all new variants


https://github.com/user-attachments/assets/7e33dbd9-8758-4674-a9e0-ae1ca3716986

[segment android 2.webm](https://github.com/user-attachments/assets/1246cc80-2ad8-41c2-87f3-1dfeddb46a50)


## Test plan
- [ ] SwiftUI: verify 3 sizes render correctly (Large/Medium/Small)
- [ ] SwiftUI: verify sliding indicator animates between tabs
- [ ] SwiftUI: verify icon-only tabs render correctly
- [ ] SwiftUI: verify Liquid Glass appears on iOS 26 devices
- [ ] KMP: verify 3 sizes render correctly
- [ ] KMP: verify sliding indicator with sticky expand animation
- [ ] KMP: verify icon-only tabs render correctly
- [ ] KMP: verify hover/press states work on desktop
- [ ] Verify backward compatibility — existing callers without `size` parameter still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)