### PR TITLE
feat: add ContentListItem component for KMP and SwiftUI

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -37,11 +37,18 @@ internal fun ContentListItemDisplay() {
             contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Simple"),
         ) {
-            LemonadeUi.ContentListItem(
-                label = "Account holder",
-                value = "John Doe",
-                layout = LemonadeContentListItemLayout.Horizontal,
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400)) {
+                LemonadeUi.ContentListItem(
+                    label = "Account holder",
+                    value = "John Doe",
+                    layout = LemonadeContentListItemLayout.Horizontal,
+                )
+                LemonadeUi.ContentListItem(
+                    label = "Account number",
+                    value = "123-456-789",
+                    layout = LemonadeContentListItemLayout.Horizontal,
+                )
+            }
         }
 
         // Horizontal with leading SymbolContainer + trailing icon

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -1,0 +1,177 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.teya.lemonade.core.LemonadeAssetSize
+import com.teya.lemonade.core.LemonadeContentListItemLayout
+import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.SymbolContainerSize
+import com.teya.lemonade.core.SymbolContainerVoice
+import com.teya.lemonade.core.TagVoice
+
+@Suppress("LongMethod")
+@Composable
+internal fun ContentListItemDisplay() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing600),
+        modifier = Modifier
+            .background(LemonadeTheme.colors.background.bgSubtle)
+            .fillMaxSize()
+            .verticalScroll(state = rememberScrollState())
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(all = LemonadeTheme.spaces.spacing400),
+    ) {
+        // Horizontal simple
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal — Simple"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Account holder",
+                value = "John Doe",
+                layout = LemonadeContentListItemLayout.Horizontal,
+            )
+        }
+
+        // Horizontal with leading SymbolContainer + trailing icon
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal — Leading & Trailing"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Favourite",
+                value = "Enabled",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                leadingSlot = {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        voice = SymbolContainerVoice.Neutral,
+                        size = SymbolContainerSize.Medium,
+                        contentDescription = null,
+                    )
+                },
+                trailingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.PencilLine,
+                        tint = LemonadeTheme.colors.content.contentBrand,
+                        size = LemonadeAssetSize.Medium,
+                        contentDescription = "Edit",
+                    )
+                },
+            )
+        }
+
+        // Horizontal with content slot
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal — Content Slot"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Status",
+                value = "Active",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                contentSlot = {
+                    LemonadeUi.Tag(
+                        label = "Available",
+                        voice = TagVoice.Positive,
+                    )
+                },
+            )
+        }
+
+        // Vertical small (no content slot)
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Vertical Small — Simple"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Balance",
+                value = "$1,234.56",
+                layout = LemonadeContentListItemLayout.Vertical,
+            )
+        }
+
+        // Vertical small with leading + trailing
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Vertical Small — Leading & Trailing"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Savings",
+                value = "$5,678.90",
+                layout = LemonadeContentListItemLayout.Vertical,
+                leadingSlot = {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        voice = SymbolContainerVoice.Neutral,
+                        size = SymbolContainerSize.Medium,
+                        contentDescription = null,
+                    )
+                },
+                trailingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.PencilLine,
+                        tint = LemonadeTheme.colors.content.contentBrand,
+                        size = LemonadeAssetSize.Medium,
+                        contentDescription = "Edit",
+                    )
+                },
+            )
+        }
+
+        // Vertical large (with content slot)
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Vertical Large — Content Slot"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Total balance",
+                value = "$12,345.67",
+                layout = LemonadeContentListItemLayout.Vertical,
+                contentSlot = {
+                    LemonadeUi.Tag(
+                        label = "Available",
+                        voice = TagVoice.Positive,
+                    )
+                },
+            )
+        }
+
+        // Vertical large with leading + trailing + content slot
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Vertical Large — Full"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Investment portfolio",
+                value = "$98,765.43",
+                layout = LemonadeContentListItemLayout.Vertical,
+                leadingSlot = {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        voice = SymbolContainerVoice.Neutral,
+                        size = SymbolContainerSize.Medium,
+                        contentDescription = null,
+                    )
+                },
+                trailingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.PencilLine,
+                        tint = LemonadeTheme.colors.content.contentBrand,
+                        size = LemonadeAssetSize.Medium,
+                        contentDescription = "Edit",
+                    )
+                },
+                contentSlot = {
+                    LemonadeUi.Tag(
+                        label = "Available",
+                        voice = TagVoice.Positive,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
+import com.teya.lemonade.core.LemonadeCardPadding
 import com.teya.lemonade.core.LemonadeContentListItemLayout
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.SymbolContainerSize
@@ -33,6 +34,7 @@ internal fun ContentListItemDisplay() {
     ) {
         // Horizontal simple
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Simple"),
         ) {
             LemonadeUi.ContentListItem(
@@ -44,6 +46,7 @@ internal fun ContentListItemDisplay() {
 
         // Horizontal with leading SymbolContainer + trailing icon
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Leading & Trailing"),
         ) {
             LemonadeUi.ContentListItem(
@@ -71,6 +74,7 @@ internal fun ContentListItemDisplay() {
 
         // Horizontal with content slot
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Content Slot"),
         ) {
             LemonadeUi.ContentListItem(
@@ -88,6 +92,7 @@ internal fun ContentListItemDisplay() {
 
         // Vertical small (no content slot)
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Small — Simple"),
         ) {
             LemonadeUi.ContentListItem(
@@ -99,6 +104,7 @@ internal fun ContentListItemDisplay() {
 
         // Vertical small with leading + trailing
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Small — Leading & Trailing"),
         ) {
             LemonadeUi.ContentListItem(
@@ -126,6 +132,7 @@ internal fun ContentListItemDisplay() {
 
         // Vertical large (with content slot)
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Large — Content Slot"),
         ) {
             LemonadeUi.ContentListItem(
@@ -143,6 +150,7 @@ internal fun ContentListItemDisplay() {
 
         // Vertical large with leading + trailing + content slot
         LemonadeUi.Card(
+            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Large — Full"),
         ) {
             LemonadeUi.ContentListItem(

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
@@ -21,6 +21,7 @@ internal interface Displays {
             SelectionListItem,
             ActionListItem,
             ResourceListItem,
+            ContentListItem,
             Chip,
             SegmentedControl,
             SymbolContainer,
@@ -108,6 +109,11 @@ internal interface Displays {
     @Serializable
     data object ResourceListItem : Displays {
         override val label: String = "ResourceListItem"
+    }
+
+    @Serializable
+    data object ContentListItem : Displays {
+        override val label: String = "ContentListItem"
     }
 
     @Serializable

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -126,6 +126,7 @@ internal object DisplayRegistry {
                 Displays.Chip,
                 Displays.SelectionListItem,
                 Displays.ResourceListItem,
+                Displays.ContentListItem,
                 Displays.SegmentedControl,
                 Displays.ActionListItem,
             ),

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
@@ -22,6 +22,7 @@ import com.teya.lemonade.NoticeDisplay
 import com.teya.lemonade.OpacityDisplay
 import com.teya.lemonade.RadioButtonDisplay
 import com.teya.lemonade.RadiusDisplay
+import com.teya.lemonade.ContentListItemDisplay
 import com.teya.lemonade.ResourceListItemDisplay
 import com.teya.lemonade.SearchFieldDisplay
 import com.teya.lemonade.SegmentedControlDisplay
@@ -59,6 +60,7 @@ internal val screens: Map<Displays, @Composable (onNavigate: (Displays) -> Unit)
     Displays.SelectionListItem to { _ -> SelectionListItemDisplay() },
     Displays.ActionListItem to { _ -> ActionListItemDisplay() },
     Displays.ResourceListItem to { _ -> ResourceListItemDisplay() },
+    Displays.ContentListItem to { _ -> ContentListItemDisplay() },
     Displays.Chip to { _ -> ChipDisplay() },
     Displays.SegmentedControl to { _ -> SegmentedControlDisplay() },
     Displays.Text to { _ -> TextDisplay() },

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
@@ -10,6 +10,7 @@ import com.teya.lemonade.CardDisplay
 import com.teya.lemonade.CheckboxDisplay
 import com.teya.lemonade.ChipDisplay
 import com.teya.lemonade.ColorsDisplay
+import com.teya.lemonade.ContentListItemDisplay
 import com.teya.lemonade.CountryFlagDisplay
 import com.teya.lemonade.DatePickerDisplay
 import com.teya.lemonade.Displays
@@ -22,7 +23,6 @@ import com.teya.lemonade.NoticeDisplay
 import com.teya.lemonade.OpacityDisplay
 import com.teya.lemonade.RadioButtonDisplay
 import com.teya.lemonade.RadiusDisplay
-import com.teya.lemonade.ContentListItemDisplay
 import com.teya.lemonade.ResourceListItemDisplay
 import com.teya.lemonade.SearchFieldDisplay
 import com.teya.lemonade.SegmentedControlDisplay

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
@@ -1,0 +1,8 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.teya.lemonade.core
+
+public enum class LemonadeContentListItemLayout {
+    Horizontal,
+    Vertical,
+}

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
@@ -2,6 +2,12 @@
 
 package com.teya.lemonade.core
 
+/**
+ * Defines the layout arrangement for [ContentListItem].
+ *
+ * [Horizontal] places the label on the left and value on the right.
+ * [Vertical] stacks the label above the value.
+ */
 public enum class LemonadeContentListItemLayout {
     Horizontal,
     Vertical,

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/ContentListItem.kt
@@ -3,7 +3,7 @@
 package com.teya.lemonade.core
 
 /**
- * Defines the layout arrangement for [ContentListItem].
+ * Defines the layout arrangement for ContentListItem.
  *
  * [Horizontal] places the label on the left and value on the right.
  * [Vertical] stacks the label above the value.

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -46,7 +46,7 @@ import com.teya.lemonade.core.SymbolContainerVoice
  * @param leadingSlot - Optional slot for a leading element (e.g. SymbolContainer).
  * @param trailingSlot - Optional slot for a trailing element (e.g. icon action).
  * @param contentSlot - Optional slot for additional content. In vertical layout, this also
- *   switches the value typography to [bodyXLargeSemiBold].
+ *   switches the value typography to bodyXLargeSemiBold.
  */
 @Composable
 public fun LemonadeUi.ContentListItem(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -10,7 +10,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeContentListItemLayout
+import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.SymbolContainerSize
+import com.teya.lemonade.core.SymbolContainerVoice
 
 /**
  * A display-only list item for showing label-value pairs.
@@ -189,4 +195,82 @@ private fun VerticalContentListItem(
             }
         }
     }
+}
+
+private data class ContentListItemPreviewData(
+    val layout: LemonadeContentListItemLayout,
+    val hasLeading: Boolean,
+    val hasTrailing: Boolean,
+    val hasContentSlot: Boolean,
+)
+
+private class ContentListItemPreviewProvider :
+    PreviewParameterProvider<ContentListItemPreviewData> {
+    override val values: Sequence<ContentListItemPreviewData> =
+        buildList {
+            LemonadeContentListItemLayout.entries.forEach { layout ->
+                listOf(true, false).forEach { leading ->
+                    listOf(true, false).forEach { trailing ->
+                        listOf(true, false).forEach { contentSlot ->
+                            add(
+                                ContentListItemPreviewData(
+                                    layout = layout,
+                                    hasLeading = leading,
+                                    hasTrailing = trailing,
+                                    hasContentSlot = contentSlot,
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }.asSequence()
+}
+
+@LemonadePreview
+@Composable
+private fun ContentListItemPreview(
+    @PreviewParameter(ContentListItemPreviewProvider::class)
+    previewData: ContentListItemPreviewData,
+) {
+    LemonadeUi.ContentListItem(
+        label = "Label",
+        value = "Value",
+        layout = previewData.layout,
+        leadingSlot = if (previewData.hasLeading) {
+            {
+                LemonadeUi.SymbolContainer(
+                    icon = LemonadeIcons.Heart,
+                    voice = SymbolContainerVoice.Neutral,
+                    size = SymbolContainerSize.Medium,
+                    contentDescription = null,
+                )
+            }
+        } else {
+            null
+        },
+        trailingSlot = if (previewData.hasTrailing) {
+            {
+                LemonadeUi.Icon(
+                    icon = LemonadeIcons.PencilLine,
+                    tint = LocalColors.current.content.contentBrand,
+                    size = LemonadeAssetSize.Medium,
+                    contentDescription = "Edit",
+                )
+            }
+        } else {
+            null
+        },
+        contentSlot = if (previewData.hasContentSlot) {
+            {
+                LemonadeUi.Text(
+                    text = "Extra content",
+                    textStyle = LocalTypographies.current.bodySmallRegular,
+                    color = LocalColors.current.content.contentSecondary,
+                )
+            }
+        } else {
+            null
+        },
+    )
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -98,9 +98,7 @@ private fun HorizontalContentListItem(
             ),
     ) {
         if (leadingSlot != null) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                leadingSlot()
-            }
+            leadingSlot()
         }
 
         Column(
@@ -144,8 +142,6 @@ private fun VerticalContentListItem(
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
-    val isLarge = contentSlot != null
-
     Row(
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
@@ -156,9 +152,7 @@ private fun VerticalContentListItem(
             ),
     ) {
         if (leadingSlot != null) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                leadingSlot()
-            }
+            leadingSlot()
         }
 
         Column(
@@ -176,7 +170,7 @@ private fun VerticalContentListItem(
             ) {
                 LemonadeUi.Text(
                     text = value,
-                    textStyle = if (isLarge) {
+                    textStyle = if (contentSlot != null) {
                         LocalTypographies.current.bodyXLargeSemiBold
                     } else {
                         LocalTypographies.current.bodyMediumMedium

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -1,0 +1,192 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.teya.lemonade.core.LemonadeContentListItemLayout
+
+/**
+ * A display-only list item for showing label-value pairs.
+ *
+ * Supports horizontal (label left, value right) and vertical (label top, value bottom) layouts.
+ * In vertical layout, providing a [contentSlot] switches the value to a larger typography.
+ *
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.ContentListItem(
+ *     label = "Account holder",
+ *     value = "John Doe",
+ * )
+ *
+ * LemonadeUi.ContentListItem(
+ *     label = "Balance",
+ *     value = "$1,234.56",
+ *     layout = LemonadeContentListItemLayout.Vertical,
+ *     contentSlot = { LemonadeUi.Tag(label = "Available", voice = TagVoice.Positive) },
+ * )
+ * ```
+ *
+ * @param label - Label [String] describing the data field.
+ * @param value - Value [String] to display.
+ * @param layout - [LemonadeContentListItemLayout] horizontal or vertical arrangement.
+ * @param modifier - [Modifier] to be applied to the root container.
+ * @param leadingSlot - Optional slot for a leading element (e.g. SymbolContainer).
+ * @param trailingSlot - Optional slot for a trailing element (e.g. icon action).
+ * @param contentSlot - Optional slot for additional content. In vertical layout, this also
+ *   switches the value typography to [bodyXLargeSemiBold].
+ */
+@Composable
+public fun LemonadeUi.ContentListItem(
+    label: String,
+    value: String,
+    layout: LemonadeContentListItemLayout = LemonadeContentListItemLayout.Horizontal,
+    modifier: Modifier = Modifier,
+    leadingSlot: (@Composable RowScope.() -> Unit)? = null,
+    trailingSlot: (@Composable RowScope.() -> Unit)? = null,
+    contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
+) {
+    when (layout) {
+        LemonadeContentListItemLayout.Horizontal -> HorizontalContentListItem(
+            label = label,
+            value = value,
+            modifier = modifier,
+            leadingSlot = leadingSlot,
+            trailingSlot = trailingSlot,
+            contentSlot = contentSlot,
+        )
+
+        LemonadeContentListItemLayout.Vertical -> VerticalContentListItem(
+            label = label,
+            value = value,
+            modifier = modifier,
+            leadingSlot = leadingSlot,
+            trailingSlot = trailingSlot,
+            contentSlot = contentSlot,
+        )
+    }
+}
+
+@Composable
+private fun HorizontalContentListItem(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    leadingSlot: (@Composable RowScope.() -> Unit)? = null,
+    trailingSlot: (@Composable RowScope.() -> Unit)? = null,
+    contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
+        modifier = modifier
+            .padding(
+                horizontal = LocalSpaces.current.spacing400,
+                vertical = LocalSpaces.current.spacing200,
+            ),
+    ) {
+        if (leadingSlot != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                leadingSlot()
+            }
+        }
+
+        Column(
+            modifier = Modifier.weight(weight = 1f),
+        ) {
+            LemonadeUi.Text(
+                text = label,
+                textStyle = LocalTypographies.current.bodyMediumRegular,
+                color = LocalColors.current.content.contentSecondary,
+            )
+
+            if (contentSlot != null) {
+                contentSlot()
+            }
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
+        ) {
+            LemonadeUi.Text(
+                text = value,
+                textStyle = LocalTypographies.current.bodyMediumMedium,
+                color = LocalColors.current.content.contentPrimary,
+                textAlign = TextAlign.Right,
+            )
+
+            if (trailingSlot != null) {
+                trailingSlot()
+            }
+        }
+    }
+}
+
+@Composable
+private fun VerticalContentListItem(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    leadingSlot: (@Composable RowScope.() -> Unit)? = null,
+    trailingSlot: (@Composable RowScope.() -> Unit)? = null,
+    contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
+) {
+    val isLarge = contentSlot != null
+
+    Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
+        modifier = modifier
+            .padding(
+                horizontal = LocalSpaces.current.spacing400,
+                vertical = LocalSpaces.current.spacing200,
+            ),
+    ) {
+        if (leadingSlot != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                leadingSlot()
+            }
+        }
+
+        Column(
+            modifier = Modifier.weight(weight = 1f),
+        ) {
+            LemonadeUi.Text(
+                text = label,
+                textStyle = LocalTypographies.current.bodySmallRegular,
+                color = LocalColors.current.content.contentSecondary,
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
+            ) {
+                LemonadeUi.Text(
+                    text = value,
+                    textStyle = if (isLarge) {
+                        LocalTypographies.current.bodyXLargeSemiBold
+                    } else {
+                        LocalTypographies.current.bodyMediumMedium
+                    },
+                    color = LocalColors.current.content.contentPrimary,
+                    modifier = Modifier.weight(weight = 1f),
+                )
+
+                if (trailingSlot != null) {
+                    trailingSlot()
+                }
+            }
+
+            if (contentSlot != null) {
+                contentSlot()
+            }
+        }
+    }
+}

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -91,11 +90,7 @@ private fun HorizontalContentListItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-        modifier = modifier
-            .padding(
-                horizontal = LocalSpaces.current.spacing400,
-                vertical = LocalSpaces.current.spacing200,
-            ),
+        modifier = modifier,
     ) {
         if (leadingSlot != null) {
             leadingSlot()
@@ -145,11 +140,7 @@ private fun VerticalContentListItem(
     Row(
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-        modifier = modifier
-            .padding(
-                horizontal = LocalSpaces.current.spacing400,
-                vertical = LocalSpaces.current.spacing200,
-            ),
+        modifier = modifier,
     ) {
         if (leadingSlot != null) {
             leadingSlot()

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+import Lemonade
+
+struct ContentListItemDisplayView: View {
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(spacing: .space.spacing400) {
+                // MARK: - Horizontal Simple
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Horizontal Simple")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Account holder",
+                        value: "John Doe"
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Account number",
+                        value: "1234-5678"
+                    )
+                }
+
+                // MARK: - Horizontal with Leading + Trailing
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Horizontal with Leading + Trailing")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        leadingSlot: {
+                            LemonadeUi.SymbolContainer(
+                                icon: .heart,
+                                contentDescription: nil,
+                                size: .medium
+                            )
+                        },
+                        trailingSlot: {
+                            LemonadeUi.Icon(
+                                icon: .pencilLine,
+                                contentDescription: "Edit",
+                                size: .medium,
+                                tint: LemonadeTheme.colors.content.contentBrand
+                            )
+                        }
+                    )
+                }
+
+                // MARK: - Horizontal with Content Slot
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Horizontal with Content Slot")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Status",
+                        value: "Active",
+                        contentSlot: {
+                            LemonadeUi.Tag(label: "Available", voice: .positive)
+                        }
+                    )
+                }
+
+                // MARK: - Vertical Small
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Vertical Small")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Balance",
+                        value: "$1,234.56",
+                        layout: .vertical
+                    )
+                }
+
+                // MARK: - Vertical Small with Leading + Trailing
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Vertical Small with Leading + Trailing")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Balance",
+                        value: "$1,234.56",
+                        layout: .vertical,
+                        leadingSlot: {
+                            LemonadeUi.SymbolContainer(
+                                icon: .heart,
+                                contentDescription: nil,
+                                size: .medium
+                            )
+                        },
+                        trailingSlot: {
+                            LemonadeUi.Icon(
+                                icon: .pencilLine,
+                                contentDescription: "Edit",
+                                size: .medium,
+                                tint: LemonadeTheme.colors.content.contentBrand
+                            )
+                        }
+                    )
+                }
+
+                // MARK: - Vertical Large (with Content Slot)
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Vertical Large")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Total Balance",
+                        value: "$5,000.00",
+                        layout: .vertical,
+                        contentSlot: {
+                            LemonadeUi.Tag(label: "Available", voice: .positive)
+                        }
+                    )
+                }
+
+                // MARK: - Vertical Large with All Slots
+                LemonadeUi.Card(
+                    contentPadding: .none,
+                    header: CardHeaderConfig(title: "Vertical Large with All Slots")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Total Balance",
+                        value: "$5,000.00",
+                        layout: .vertical,
+                        leadingSlot: {
+                            LemonadeUi.SymbolContainer(
+                                icon: .heart,
+                                contentDescription: nil,
+                                size: .medium
+                            )
+                        },
+                        trailingSlot: {
+                            LemonadeUi.Icon(
+                                icon: .pencilLine,
+                                contentDescription: "Edit",
+                                size: .medium,
+                                tint: LemonadeTheme.colors.content.contentBrand
+                            )
+                        },
+                        contentSlot: {
+                            LemonadeUi.Tag(label: "Available", voice: .positive)
+                        }
+                    )
+                }
+            }
+            .padding(.space.spacing400)
+        }
+        .background(.bg.bgSubtle)
+        .navigationTitle("ContentListItem")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ContentListItemDisplayView()
+    }
+}

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -10,15 +10,17 @@ struct ContentListItemDisplayView: View {
                     contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal Simple")
                 ) {
-                    LemonadeUi.ContentListItem(
-                        label: "Account holder",
-                        value: "John Doe"
-                    )
-
-                    LemonadeUi.ContentListItem(
-                        label: "Account number",
-                        value: "1234-5678"
-                    )
+                    VStack(spacing: .space.spacing400) {
+                        LemonadeUi.ContentListItem(
+                            label: "Account holder",
+                            value: "John Doe"
+                        )
+                        
+                        LemonadeUi.ContentListItem(
+                            label: "Account number",
+                            value: "1234-5678"
+                        )
+                    }
                 }
 
                 // MARK: - Horizontal with Leading + Trailing

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -7,7 +7,7 @@ struct ContentListItemDisplayView: View {
             VStack(spacing: .space.spacing400) {
                 // MARK: - Horizontal Simple
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal Simple")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -23,7 +23,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Horizontal with Leading + Trailing
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal with Leading + Trailing")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -49,7 +49,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Horizontal with Content Slot
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal with Content Slot")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -63,7 +63,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Small
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Small")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -75,7 +75,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Small with Leading + Trailing
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Small with Leading + Trailing")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -102,7 +102,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Large (with Content Slot)
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Large")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -117,7 +117,7 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Large with All Slots
                 LemonadeUi.Card(
-                    contentPadding: .none,
+                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Large with All Slots")
                 ) {
                     LemonadeUi.ContentListItem(

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -80,6 +80,7 @@ struct HomeView: View {
                 items: [
                     DemoItem(title: "Chip", destination: AnyView(ChipDisplayView())),
                     DemoItem(title: "ListItem", destination: AnyView(ListItemDisplayView())),
+                    DemoItem(title: "ContentListItem", destination: AnyView(ContentListItemDisplayView())),
                     DemoItem(title: "SegmentedControl", destination: AnyView(SegmentedControlDisplayView()))
                 ]
             ),

--- a/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+// MARK: - LemonadeContentListItemLayout
+
+/// Defines the layout arrangement for ContentListItem.
+/// - `horizontal`: Label on the left, value on the right (same line)
+/// - `vertical`: Label on top, value below
+public enum LemonadeContentListItemLayout {
+    case horizontal
+    case vertical
+}
+
+// MARK: - Public API
+
+public extension LemonadeUi {
+    /// A display-only list item for showing label-value pairs.
+    ///
+    /// Supports horizontal (label left, value right) and vertical (label top, value bottom) layouts.
+    /// In vertical layout, providing a `contentSlot` switches the value to a larger typography.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.ContentListItem(
+    ///     label: "Account holder",
+    ///     value: "John Doe"
+    /// )
+    ///
+    /// LemonadeUi.ContentListItem(
+    ///     label: "Balance",
+    ///     value: "$1,234.56",
+    ///     layout: .vertical
+    /// ) {
+    ///     LemonadeUi.Tag(label: "Available", voice: .positive)
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - label: Label String describing the data field
+    ///   - value: Value String to display
+    ///   - layout: Horizontal or vertical arrangement
+    ///   - leadingSlot: Optional leading element (e.g. SymbolContainer)
+    ///   - trailingSlot: Optional trailing element (e.g. icon action)
+    ///   - contentSlot: Optional additional content. In vertical layout, switches value to larger typography
+    @ViewBuilder
+    static func ContentListItem<Leading: View, Trailing: View, Content: View>(
+        label: String,
+        value: String,
+        layout: LemonadeContentListItemLayout = .horizontal,
+        @ViewBuilder leadingSlot: @escaping () -> Leading = { EmptyView() },
+        @ViewBuilder trailingSlot: @escaping () -> Trailing = { EmptyView() },
+        @ViewBuilder contentSlot: @escaping () -> Content = { EmptyView() }
+    ) -> some View {
+        LemonadeContentListItemView(
+            label: label,
+            value: value,
+            layout: layout,
+            leadingSlot: leadingSlot,
+            trailingSlot: trailingSlot,
+            contentSlot: contentSlot
+        )
+    }
+}
+
+// MARK: - Internal View
+
+private struct LemonadeContentListItemView<Leading: View, Trailing: View, Content: View>: View {
+    let label: String
+    let value: String
+    let layout: LemonadeContentListItemLayout
+    @ViewBuilder let leadingSlot: () -> Leading
+    @ViewBuilder let trailingSlot: () -> Trailing
+    @ViewBuilder let contentSlot: () -> Content
+
+    private var hasContentSlot: Bool {
+        Content.self != EmptyView.self
+    }
+
+    private var hasTrailingSlot: Bool {
+        Trailing.self != EmptyView.self
+    }
+
+    private var hasLeadingSlot: Bool {
+        Leading.self != EmptyView.self
+    }
+
+    var body: some View {
+        switch layout {
+        case .horizontal:
+            horizontalLayout
+        case .vertical:
+            verticalLayout
+        }
+    }
+
+    private var horizontalLayout: some View {
+        HStack(alignment: .center, spacing: LemonadeTheme.spaces.spacing300) {
+            if hasLeadingSlot {
+                leadingSlot()
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodyMediumRegular,
+                    color: LemonadeTheme.colors.content.contentSecondary
+                )
+
+                if hasContentSlot {
+                    contentSlot()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: LemonadeTheme.spaces.spacing300) {
+                LemonadeUi.Text(
+                    value,
+                    textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                    color: LemonadeTheme.colors.content.contentPrimary
+                )
+                .multilineTextAlignment(.trailing)
+
+                if hasTrailingSlot {
+                    trailingSlot()
+                }
+            }
+        }
+        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+        .padding(.vertical, LemonadeTheme.spaces.spacing200)
+    }
+
+    private var verticalLayout: some View {
+        HStack(alignment: .top, spacing: LemonadeTheme.spaces.spacing300) {
+            if hasLeadingSlot {
+                leadingSlot()
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodySmallRegular,
+                    color: LemonadeTheme.colors.content.contentSecondary
+                )
+
+                HStack(spacing: LemonadeTheme.spaces.spacing100) {
+                    LemonadeUi.Text(
+                        value,
+                        textStyle: hasContentSlot
+                            ? LemonadeTypography.shared.bodyXLargeSemiBold
+                            : LemonadeTypography.shared.bodyMediumMedium,
+                        color: LemonadeTheme.colors.content.contentPrimary
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if hasTrailingSlot {
+                        trailingSlot()
+                    }
+                }
+
+                if hasContentSlot {
+                    contentSlot()
+                }
+            }
+        }
+        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+        .padding(.vertical, LemonadeTheme.spaces.spacing200)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+struct LemonadeContentListItem_Previews: PreviewProvider {
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: LemonadeTheme.spaces.spacing400) {
+                // Horizontal - simple
+                LemonadeUi.ContentListItem(
+                    label: "Account holder",
+                    value: "John Doe"
+                )
+
+                // Horizontal - with leading and trailing
+                LemonadeUi.ContentListItem(
+                    label: "Label",
+                    value: "Value",
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            icon: .heart,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    },
+                    trailingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .pencilLine,
+                            contentDescription: "Edit",
+                            size: .medium,
+                            tint: LemonadeTheme.colors.content.contentBrand
+                        )
+                    }
+                )
+
+                LemonadeUi.HorizontalDivider()
+
+                // Vertical small
+                LemonadeUi.ContentListItem(
+                    label: "Balance",
+                    value: "$1,234.56",
+                    layout: .vertical
+                )
+
+                // Vertical large (with content slot)
+                LemonadeUi.ContentListItem(
+                    label: "Balance",
+                    value: "$1,234.56",
+                    layout: .vertical,
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            icon: .heart,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    },
+                    trailingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .pencilLine,
+                            contentDescription: "Edit",
+                            size: .medium,
+                            tint: LemonadeTheme.colors.content.contentBrand
+                        )
+                    },
+                    contentSlot: {
+                        LemonadeUi.Tag(label: "Available", voice: .positive)
+                    }
+                )
+            }
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
@@ -124,8 +124,6 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
                 }
             }
         }
-        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-        .padding(.vertical, LemonadeTheme.spaces.spacing200)
     }
 
     private var verticalLayout: some View {
@@ -161,8 +159,6 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
                 }
             }
         }
-        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-        .padding(.vertical, LemonadeTheme.spaces.spacing200)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add new **ContentListItem** display-only component for showing label-value pairs
- Supports **Horizontal** (label left, value right) and **Vertical** (label top, value below) layouts
- Vertical layout infers large typography when a `contentSlot` is provided
- Optional leading, trailing, and content slots
- Implemented for both **KMP (Compose Multiplatform)** and **SwiftUI**
- Includes demo displays in both composeApp and SwiftUI SampleApp

<img width="320" height="2622" alt="image" src="https://github.com/user-attachments/assets/d479e5cc-63a9-42ed-979f-f507da4f122c" />

<img width="320" height="2622" alt="image" src="https://github.com/user-attachments/assets/21353e59-5035-4328-9372-1af358e723a4" />

<img width="320" height="810" alt="image" src="https://github.com/user-attachments/assets/dd4b9ae5-be85-403d-a5b3-3825d28ff03f" />

<img width="320" height="802" alt="image" src="https://github.com/user-attachments/assets/1eb9b3e2-4e60-44bc-806a-d9d80edbb063" />


## Test plan
- [ ] Verify horizontal layout renders label on left, value on right
- [ ] Verify vertical layout renders label above value (small typography without contentSlot)
- [ ] Verify vertical layout renders large bold value when contentSlot is provided
- [ ] Verify leading slot (SymbolContainer) renders correctly
- [ ] Verify trailing slot (icon action) renders correctly
- [ ] Verify content slot renders below value in vertical large layout
- [ ] Run composeApp on Android emulator and check ContentListItem demo screen
- [ ] Build SwiftUI package successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)