### PR TITLE
[LDS] update Tag corner radius to match Figma design

### DIFF
--- a/flutter/lib/src/components/tag.dart
+++ b/flutter/lib/src/components/tag.dart
@@ -107,7 +107,7 @@ class LemonadeTag extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           color: containerColor,
-          borderRadius: BorderRadius.circular(radius.radius100),
+          borderRadius: BorderRadius.circular(radius.radius150),
         ),
         padding: EdgeInsets.symmetric(
           horizontal: spaces.spacing100,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tag.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tag.kt
@@ -63,7 +63,7 @@ private fun CoreTag(
         modifier = modifier
             .background(
                 color = voice.containerColor,
-                shape = LocalShapes.current.radius100,
+                shape = LocalShapes.current.radius150,
             ).padding(
                 vertical = LocalSpaces.current.spacing50,
                 horizontal = LocalSpaces.current.spacing100,

--- a/swiftui/Sources/Lemonade/Components/LemonadeTag.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTag.swift
@@ -96,7 +96,7 @@ private struct LemonadeTagView: View {
         .padding(.vertical, LemonadeTheme.spaces.spacing50)
         .padding(.horizontal, LemonadeTheme.spaces.spacing100)
         .background(voice.containerColor)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius100))
+        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius150))
     }
 }
 


### PR DESCRIPTION
## Summary
- Update Tag component corner radius from `radius100` (4px) to `radius150` (6px) across all platforms (KMP, SwiftUI, Flutter) to match the updated Figma specs.

## Test plan
- [ ] Verify Tag renders with 6px corner radius on Android/iOS (Compose)
- [ ] Verify Tag renders with 6px corner radius on iOS (SwiftUI)
- [ ] Verify Tag renders with 6px corner radius on Flutter
- [ ] Visual comparison with Figma design

🤖 Generated with [Claude Code](https://claude.com/claude-code)