### PR TITLE
refactor(calendar): extract shared building blocks from DatePicker

### DIFF
--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/BoolRef.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/BoolRef.kt
@@ -1,0 +1,8 @@
+package com.teya.lemonade
+
+/**
+ * A simple mutable boolean wrapper used as a `remember`-stable flag inside
+ * Composables where [androidx.compose.runtime.MutableState] would cause
+ * unwanted recomposition.
+ */
+internal class BoolRef(var value: Boolean)

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
@@ -1,0 +1,139 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+
+/**
+ * A single day cell that optionally displays a weekday label above the
+ * [ContentCell] and an optional trailing content slot below.
+ *
+ * Used by both the full-month grid (DatePicker) and the inline calendar strip.
+ *
+ * @param text Day-of-month text (e.g. "14").
+ * @param isCurrent Whether the date is today.
+ * @param isSelected Whether the date is currently selected.
+ * @param isEnabled Whether the cell is interactive.
+ * @param isOutsideVisibleRange Whether the date falls outside the displayed month.
+ * @param isInsideSelectedRange Whether the date is within a selected range.
+ * @param onClick Called when the cell is tapped.
+ * @param modifier Optional [Modifier] for the root container.
+ * @param contentDescription Optional accessibility description for the cell.
+ *   When provided, screen readers announce this instead of just the day number.
+ * @param showWeekdayLabel Whether to display the weekday label above the day number.
+ * @param weekdayLabel The short weekday text (e.g. "M", "Mon").
+ * @param expandSelectionToLabel When `true` (default), the selection background covers the
+ *   entire cell column including the weekday label and trailing content. When `false`, only
+ *   the day number circle carries the brand background (DatePicker style).
+ * @param selectionBackgroundColor When non-null, overrides the default brand background color
+ *   used for selected cells.
+ * @param selectionContentColor When non-null, overrides the default text color used on
+ *   selected cells. Also applied to the weekday label when [expandSelectionToLabel] is `true`.
+ * @param trailingContent Optional composable rendered below the day cell.
+ */
+@Composable
+internal fun CalendarDayCell(
+    text: String,
+    isCurrent: Boolean,
+    isSelected: Boolean,
+    isEnabled: Boolean,
+    isOutsideVisibleRange: Boolean,
+    isInsideSelectedRange: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    showWeekdayLabel: Boolean = true,
+    weekdayLabel: String = "",
+    expandSelectionToLabel: Boolean = true,
+    selectionBackgroundColor: Color? = null,
+    selectionContentColor: Color? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    val selectionShape = LocalShapes.current.radius300
+    val resolvedSelectionBgColor = selectionBackgroundColor
+        ?: LocalColors.current.interaction.bgBrandInteractive
+    val weekdayLabelColor = when {
+        isSelected && expandSelectionToLabel && selectionContentColor != null -> selectionContentColor
+        isSelected && expandSelectionToLabel -> LocalColors.current.content.contentOnBrandHigh
+        !isEnabled -> LocalColors.current.content.contentTertiary
+        else -> LocalColors.current.content.contentPrimary
+    }
+
+    Column(
+        modifier = modifier
+            .then(
+                if (isSelected && expandSelectionToLabel) {
+                    Modifier
+                        .clip(selectionShape)
+                        .background(
+                            color = resolvedSelectionBgColor,
+                            shape = selectionShape,
+                        ).padding(vertical = LocalSpaces.current.spacing100)
+                } else {
+                    Modifier
+                        .padding(vertical = LocalSpaces.current.spacing100)
+                },
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (showWeekdayLabel && weekdayLabel.isNotEmpty()) {
+            LemonadeUi.Text(
+                text = weekdayLabel,
+                textStyle = LocalTypographies.current.bodyXSmallOverline,
+                color = weekdayLabelColor,
+            )
+        }
+
+        // When expandSelectionToLabel is false, wrap the day number + trailing
+        // content in their own selection background so the weekday label stays
+        // outside the highlight.
+        val compactSelectionModifier = if (isSelected && !expandSelectionToLabel) {
+            Modifier
+                .clip(selectionShape)
+                .background(
+                    color = resolvedSelectionBgColor,
+                    shape = selectionShape,
+                ).padding(
+                    horizontal = LocalSpaces.current.spacing100,
+                    vertical = LocalSpaces.current.spacing100,
+                )
+        } else if (!expandSelectionToLabel) {
+            Modifier.padding(
+                horizontal = LocalSpaces.current.spacing100,
+                vertical = LocalSpaces.current.spacing100,
+            )
+        } else {
+            Modifier
+        }
+
+        Column(
+            modifier = compactSelectionModifier,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            ContentCell(
+                text = text,
+                isCurrent = isCurrent,
+                isSelected = isSelected,
+                isEnabled = isEnabled,
+                isOutsideVisibleRange = isOutsideVisibleRange,
+                isInsideSelectedRange = isInsideSelectedRange,
+                onClick = onClick,
+                modifier = Modifier.fillMaxWidth(),
+                contentDescription = contentDescription,
+                showSelectionBackground = false,
+                showTodayIndicator = false,
+                selectionContentColor = selectionContentColor,
+            )
+
+            if (trailingContent != null) {
+                trailingContent()
+            }
+        }
+    }
+}

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
@@ -58,27 +58,22 @@ internal fun CalendarDayCell(
     val selectionShape = LocalShapes.current.radius300
     val resolvedSelectionBgColor = selectionBackgroundColor
         ?: LocalColors.current.interaction.bgBrandInteractive
-    val weekdayLabelColor = when {
-        isSelected && expandSelectionToLabel && selectionContentColor != null -> selectionContentColor
-        isSelected && expandSelectionToLabel -> LocalColors.current.content.contentOnBrandHigh
-        !isEnabled -> LocalColors.current.content.contentTertiary
-        else -> LocalColors.current.content.contentPrimary
-    }
+    val weekdayLabelColor = resolveWeekdayLabelColor(
+        isSelected = isSelected,
+        isEnabled = isEnabled,
+        expandSelectionToLabel = expandSelectionToLabel,
+        selectionContentColor = selectionContentColor,
+    )
 
     Column(
         modifier = modifier
             .then(
-                if (isSelected && expandSelectionToLabel) {
-                    Modifier
-                        .clip(selectionShape)
-                        .background(
-                            color = resolvedSelectionBgColor,
-                            shape = selectionShape,
-                        ).padding(vertical = LocalSpaces.current.spacing100)
-                } else {
-                    Modifier
-                        .padding(vertical = LocalSpaces.current.spacing100)
-                },
+                expandedSelectionModifier(
+                    isSelected = isSelected,
+                    expandSelectionToLabel = expandSelectionToLabel,
+                    selectionShape = selectionShape,
+                    selectionBgColor = resolvedSelectionBgColor,
+                ),
             ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -90,30 +85,13 @@ internal fun CalendarDayCell(
             )
         }
 
-        // When expandSelectionToLabel is false, wrap the day number + trailing
-        // content in their own selection background so the weekday label stays
-        // outside the highlight.
-        val compactSelectionModifier = if (isSelected && !expandSelectionToLabel) {
-            Modifier
-                .clip(selectionShape)
-                .background(
-                    color = resolvedSelectionBgColor,
-                    shape = selectionShape,
-                ).padding(
-                    horizontal = LocalSpaces.current.spacing100,
-                    vertical = LocalSpaces.current.spacing100,
-                )
-        } else if (!expandSelectionToLabel) {
-            Modifier.padding(
-                horizontal = LocalSpaces.current.spacing100,
-                vertical = LocalSpaces.current.spacing100,
-            )
-        } else {
-            Modifier
-        }
-
         Column(
-            modifier = compactSelectionModifier,
+            modifier = compactSelectionModifier(
+                isSelected = isSelected,
+                expandSelectionToLabel = expandSelectionToLabel,
+                selectionShape = selectionShape,
+                selectionBgColor = resolvedSelectionBgColor,
+            ),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             ContentCell(
@@ -137,3 +115,65 @@ internal fun CalendarDayCell(
         }
     }
 }
+
+@Composable
+private fun resolveWeekdayLabelColor(
+    isSelected: Boolean,
+    isEnabled: Boolean,
+    expandSelectionToLabel: Boolean,
+    selectionContentColor: Color?,
+): Color {
+    val hasExpandedSelection = isSelected && expandSelectionToLabel
+    return when {
+        hasExpandedSelection && selectionContentColor != null -> selectionContentColor
+        hasExpandedSelection -> LocalColors.current.content.contentOnBrandHigh
+        !isEnabled -> LocalColors.current.content.contentTertiary
+        else -> LocalColors.current.content.contentPrimary
+    }
+}
+
+@Composable
+private fun expandedSelectionModifier(
+    isSelected: Boolean,
+    expandSelectionToLabel: Boolean,
+    selectionShape: androidx.compose.ui.graphics.Shape,
+    selectionBgColor: Color,
+): Modifier =
+    if (isSelected && expandSelectionToLabel) {
+        Modifier
+            .clip(selectionShape)
+            .background(
+                color = selectionBgColor,
+                shape = selectionShape,
+            ).padding(vertical = LocalSpaces.current.spacing100)
+    } else {
+        Modifier
+            .padding(vertical = LocalSpaces.current.spacing100)
+    }
+
+@Composable
+private fun compactSelectionModifier(
+    isSelected: Boolean,
+    expandSelectionToLabel: Boolean,
+    selectionShape: androidx.compose.ui.graphics.Shape,
+    selectionBgColor: Color,
+): Modifier =
+    when {
+        isSelected && !expandSelectionToLabel ->
+            Modifier
+                .clip(selectionShape)
+                .background(
+                    color = selectionBgColor,
+                    shape = selectionShape,
+                ).padding(
+                    horizontal = LocalSpaces.current.spacing100,
+                    vertical = LocalSpaces.current.spacing100,
+                )
+        !expandSelectionToLabel ->
+            Modifier.padding(
+                horizontal = LocalSpaces.current.spacing100,
+                vertical = LocalSpaces.current.spacing100,
+            )
+        else ->
+            Modifier
+    }

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarMonthHeader.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarMonthHeader.kt
@@ -1,0 +1,68 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.teya.lemonade.core.LemonadeIconButtonVariant
+import com.teya.lemonade.core.LemonadeIcons
+
+/**
+ * Shared month header composable used by both [LemonadeUi.DatePicker] and
+ * [LemonadeUi.InlineCalendar].
+ *
+ * Displays the current month/year label with left/right navigation arrows.
+ *
+ * @param headerLabel Formatted month-year string to display in the center.
+ * @param canGoPrev Whether the "previous month" arrow is enabled.
+ * @param canGoNext Whether the "next month" arrow is enabled.
+ * @param onPrev Called when the user taps the previous-month arrow.
+ * @param onNext Called when the user taps the next-month arrow.
+ * @param modifier Optional [Modifier] for layout adjustments.
+ * @param prevMonthContentDescription Accessibility label for the previous-month button.
+ *   Defaults to the English string "Previous month". Callers should supply a localized
+ *   string for proper i18n support.
+ * @param nextMonthContentDescription Accessibility label for the next-month button.
+ *   Defaults to the English string "Next month". Callers should supply a localized
+ *   string for proper i18n support.
+ */
+@Composable
+internal fun CalendarMonthHeader(
+    headerLabel: String,
+    canGoPrev: Boolean,
+    canGoNext: Boolean,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier,
+    prevMonthContentDescription: String = "Previous month",
+    nextMonthContentDescription: String = "Next month",
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LemonadeUi.IconButton(
+            icon = LemonadeIcons.ChevronLeft,
+            contentDescription = prevMonthContentDescription,
+            variant = LemonadeIconButtonVariant.Ghost,
+            enabled = canGoPrev,
+            onClick = onPrev,
+        )
+
+        LemonadeUi.Text(
+            text = headerLabel,
+            textStyle = LocalTypographies.current.bodySmallSemiBold,
+            color = LocalColors.current.content.contentPrimary,
+        )
+
+        LemonadeUi.IconButton(
+            icon = LemonadeIcons.ChevronRight,
+            contentDescription = nextMonthContentDescription,
+            variant = LemonadeIconButtonVariant.Ghost,
+            enabled = canGoNext,
+            onClick = onNext,
+        )
+    }
+}

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarUtils.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarUtils.kt
@@ -1,0 +1,115 @@
+package com.teya.lemonade
+
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.YearMonth
+import kotlinx.datetime.minusMonth
+import kotlinx.datetime.onDay
+import kotlinx.datetime.plusMonth
+
+/**
+ * Computes the number of leading cells from the previous month needed before
+ * [month]'s first day, given that the calendar grid starts on [firstDayOfWeek].
+ */
+private fun leadingOffset(
+    month: YearMonth,
+    firstDayOfWeek: DayOfWeek,
+): Int {
+    val firstDayOrdinal = month.onDay(1).dayOfWeek.ordinal
+    val startOrdinal = firstDayOfWeek.ordinal
+    return (firstDayOrdinal - startOrdinal + DayOfWeek.entries.size) % DayOfWeek.entries.size
+}
+
+/**
+ * Generates the full grid of [LocalDate] values for a calendar month page,
+ * including leading days from the previous month and trailing days from the
+ * next month so that the grid starts on [firstDayOfWeek] and fills 6 complete
+ * weeks (42 cells).
+ *
+ * @param month The target [YearMonth].
+ * @param firstDayOfWeek The day that should appear in the first column
+ *   (e.g. [DayOfWeek.MONDAY] for ISO locales).
+ * @return A list of exactly 42 [LocalDate] values.
+ */
+internal fun daysForMonth(
+    month: YearMonth,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+): List<LocalDate> {
+    val offset = leadingOffset(month = month, firstDayOfWeek = firstDayOfWeek)
+
+    return buildList {
+        // Previous month trailing days
+        val previousMonth = month.minusMonth()
+        val prevMonthLength = previousMonth.numberOfDays
+        for (day in prevMonthLength - offset + 1..prevMonthLength) {
+            add(previousMonth.onDay(day))
+        }
+
+        // Current month
+        for (day in 1..month.numberOfDays) {
+            add(month.onDay(day))
+        }
+
+        // Next month leading days
+        val nextMonth = month.plusMonth()
+        val remaining = CALENDAR_GRID_CELLS - size
+        for (day in 1..remaining) {
+            add(nextMonth.onDay(day))
+        }
+    }
+}
+
+/**
+ * Returns the days from the previous month that appear before [month]'s first
+ * day when the calendar starts on [firstDayOfWeek].
+ */
+internal fun peekDaysBefore(
+    month: YearMonth,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+): List<LocalDate> {
+    val offset = leadingOffset(month = month, firstDayOfWeek = firstDayOfWeek)
+
+    val previousMonth = month.minusMonth()
+    val prevMonthLength = previousMonth.numberOfDays
+
+    return buildList {
+        for (day in prevMonthLength - offset + 1..prevMonthLength) {
+            add(previousMonth.onDay(day))
+        }
+    }
+}
+
+/**
+ * Returns the days from the next month that appear after [month]'s last
+ * day to fill the remaining grid cells.
+ */
+internal fun peekDaysAfter(
+    month: YearMonth,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+): List<LocalDate> {
+    val totalBeforeAndCurrent =
+        leadingOffset(month = month, firstDayOfWeek = firstDayOfWeek) + month.numberOfDays
+    val remaining = CALENDAR_GRID_CELLS - totalBeforeAndCurrent
+
+    val nextMonth = month.plusMonth()
+    return buildList {
+        for (day in 1..remaining) {
+            add(nextMonth.onDay(day))
+        }
+    }
+}
+
+/**
+ * Produces an ordered list of [DayOfWeek] entries starting from [firstDayOfWeek].
+ *
+ * For example, if [firstDayOfWeek] is [DayOfWeek.MONDAY], the result is
+ * `[MONDAY, TUESDAY, ..., SUNDAY]`.
+ */
+internal fun weekdayOrder(firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY): List<DayOfWeek> {
+    val all = DayOfWeek.entries
+    val startIndex = all.indexOf(firstDayOfWeek)
+    return all.subList(startIndex, all.size) + all.subList(0, startIndex)
+}
+
+/** Number of cells in a 6-week calendar grid. */
+private const val CALENDAR_GRID_CELLS = 42

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/ContentCell.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/ContentCell.kt
@@ -1,0 +1,174 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * Reusable calendar date cell used by both the full-month [LemonadeUi.DatePicker]
+ * grid and the inline calendar strip.
+ *
+ * The cell renders a day number with the appropriate color/style based on its
+ * selection, "today", disabled, and outside-month states. A small dot indicator
+ * appears below the text when [isCurrent] is true.
+ *
+ * @param text The display text (typically the day-of-month number).
+ * @param isCurrent Whether this cell represents today's date.
+ * @param isSelected Whether this cell is the selected date.
+ * @param isEnabled Whether the cell is interactive.
+ * @param isOutsideVisibleRange Whether the date falls outside the displayed month.
+ * @param isInsideSelectedRange Whether the cell is within a selected date range.
+ * @param onClick Invoked when the cell is tapped.
+ * @param modifier Optional [Modifier] applied to the root container.
+ * @param contentDescription Optional accessibility label. When provided, screen readers
+ *   announce this description instead of just the [text] value.
+ * @param showSelectionBackground Whether to render the selection background color within
+ *   this cell. When `false`, the parent is expected to provide its own selection styling
+ *   (e.g. [CalendarDayCell] wraps the whole cell in a dark background). Defaults to `true`
+ *   so that the [LemonadeUi.DatePicker] grid continues to show the brand-colored background.
+ * @param selectionContentColor When non-null and the cell [isSelected], overrides the default
+ *   text color used on selected cells.
+ * @param interactionSource Interaction source for ripple/focus handling.
+ */
+@Composable
+internal fun ContentCell(
+    text: String,
+    isCurrent: Boolean,
+    isSelected: Boolean,
+    isEnabled: Boolean,
+    isOutsideVisibleRange: Boolean,
+    isInsideSelectedRange: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    showSelectionBackground: Boolean = true,
+    showTodayIndicator: Boolean = showSelectionBackground,
+    selectionContentColor: Color? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val textColor = contentCellTextColor(
+        isEnabled = isEnabled,
+        isSelected = isSelected,
+        isCurrent = isCurrent,
+        isInsideSelectedRange = isInsideSelectedRange,
+        isOutsideVisibleRange = isOutsideVisibleRange,
+        showSelectionBackground = showSelectionBackground,
+        selectionContentColor = selectionContentColor,
+    )
+
+    val textStyle = if (isCurrent) {
+        LocalTypographies.current.bodyMediumSemiBold
+    } else {
+        LocalTypographies.current.bodyMediumMedium
+    }
+
+    val backgroundColor = if (isSelected && showSelectionBackground) {
+        LocalColors.current.interaction.bgBrandInteractive
+    } else {
+        Color.Transparent
+    }
+
+    val cellShape = LocalShapes.current.radius200
+
+    Box(
+        modifier = modifier
+            .then(
+                other = if (isFocused) {
+                    Modifier
+                        .border(
+                            width = LocalBorderWidths.current.base.border50,
+                            color = LocalColors.current.border.borderSelected,
+                            shape = cellShape,
+                        )
+                } else {
+                    Modifier
+                },
+            ).clip(
+                shape = cellShape,
+            ).clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                role = Role.Button,
+                enabled = isEnabled,
+                indication = LocalEffects.current.interactionIndication,
+            ).semantics {
+                if (contentDescription != null) {
+                    this.contentDescription = contentDescription
+                }
+                selected = isSelected
+                if (!isEnabled) {
+                    disabled()
+                }
+            }.background(
+                color = backgroundColor,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        LemonadeUi.Text(
+            modifier = Modifier.padding(vertical = LocalSpaces.current.spacing200),
+            text = text,
+            textStyle = textStyle,
+            color = textColor,
+        )
+
+        if (isCurrent && showTodayIndicator) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = LocalSpaces.current.spacing100)
+                    .size(LocalSpaces.current.spacing100)
+                    .background(
+                        color = textColor,
+                        shape = LocalShapes.current.radiusFull,
+                    ),
+            )
+        }
+    }
+}
+
+/**
+ * Resolves the text color for a [ContentCell] based on its combined state flags.
+ * Extracted from the composable body to keep cyclomatic complexity of the cell
+ * itself inside detekt's threshold.
+ *
+ * When [selectionContentColor] is non-null and the cell [isSelected], that color
+ * takes precedence over the default brand on-color.
+ */
+@Composable
+private fun contentCellTextColor(
+    isEnabled: Boolean,
+    isSelected: Boolean,
+    isCurrent: Boolean,
+    isInsideSelectedRange: Boolean,
+    isOutsideVisibleRange: Boolean,
+    showSelectionBackground: Boolean,
+    selectionContentColor: Color?,
+): Color =
+    when {
+        !isEnabled -> LocalColors.current.content.contentTertiary
+        isSelected && selectionContentColor != null -> selectionContentColor
+        isSelected && !showSelectionBackground -> LocalColors.current.content.contentOnBrandHigh
+        isSelected || isInsideSelectedRange -> LocalColors.current.content.contentOnBrandHigh
+        isCurrent -> LocalColors.current.content.contentBrand
+        isOutsideVisibleRange -> LocalColors.current.content.contentSecondary
+        else -> LocalColors.current.content.contentPrimary
+    }

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
@@ -2,25 +2,19 @@
 
 package com.teya.lemonade
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,19 +23,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.disabled
-import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
-import com.teya.lemonade.core.LemonadeIconButtonVariant
-import com.teya.lemonade.core.LemonadeIcons
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -52,7 +38,6 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.minusMonth
 import kotlinx.datetime.monthsUntil
 import kotlinx.datetime.number
-import kotlinx.datetime.onDay
 import kotlinx.datetime.plus
 import kotlinx.datetime.plusMonth
 import kotlinx.datetime.todayIn
@@ -185,6 +170,10 @@ public fun rememberDateRangePickerState(
  * @param modifier Optional [Modifier] for layout adjustments.
  * @param state Configuration state created via [rememberDatePickerState].
  * Observe [DatePickerState.selectedDate] to react to user selections.
+ * @param firstDayOfWeek The first day of the week shown in the grid. Defaults to
+ * [DayOfWeek.SUNDAY]. Callers should supply the correct value for their locale
+ * (e.g. [DayOfWeek.MONDAY] for ISO / European locales).
+ * @param onMonthDisplayed Optional callback invoked when the displayed month changes.
  */
 @Composable
 public fun LemonadeUi.DatePicker(
@@ -192,6 +181,8 @@ public fun LemonadeUi.DatePicker(
     weekdayAbbreviations: List<String>,
     modifier: Modifier = Modifier,
     state: DatePickerState = rememberDatePickerState(),
+    firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+    onMonthDisplayed: ((YearMonth) -> Unit)? = null,
 ) {
     CoreDatePicker(
         monthFormatter = monthFormatter,
@@ -201,6 +192,8 @@ public fun LemonadeUi.DatePicker(
         onDateSelected = { date -> state.selectedDate = date },
         minDate = state.minDate,
         maxDate = state.maxDate,
+        firstDayOfWeek = firstDayOfWeek,
+        onMonthDisplayed = onMonthDisplayed,
     )
 }
 
@@ -230,6 +223,10 @@ public fun LemonadeUi.DatePicker(
  * @param state Configuration state created via [rememberDateRangePickerState].
  * Observe [DateRangePickerState.selectedStartDate] and [DateRangePickerState.selectedEndDate]
  * to react to user selections.
+ * @param firstDayOfWeek The first day of the week shown in the grid. Defaults to
+ * [DayOfWeek.SUNDAY]. Callers should supply the correct value for their locale
+ * (e.g. [DayOfWeek.MONDAY] for ISO / European locales).
+ * @param onMonthDisplayed Optional callback invoked when the displayed month changes.
  */
 @Composable
 public fun LemonadeUi.DateRangePicker(
@@ -237,6 +234,8 @@ public fun LemonadeUi.DateRangePicker(
     weekdayAbbreviations: List<String>,
     modifier: Modifier = Modifier,
     state: DateRangePickerState = rememberDateRangePickerState(),
+    firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+    onMonthDisplayed: ((YearMonth) -> Unit)? = null,
 ) {
     val isSelectingEndDate = state.selectedStartDate != null && state.selectedEndDate == null
 
@@ -295,6 +294,8 @@ public fun LemonadeUi.DateRangePicker(
         },
         minDate = effectiveMin,
         maxDate = effectiveMax,
+        firstDayOfWeek = firstDayOfWeek,
+        onMonthDisplayed = onMonthDisplayed,
     )
 }
 
@@ -307,6 +308,8 @@ private fun CoreDatePicker(
     onDateSelected: (LocalDate) -> Unit,
     minDate: LocalDate?,
     maxDate: LocalDate?,
+    firstDayOfWeek: DayOfWeek,
+    onMonthDisplayed: ((YearMonth) -> Unit)?,
 ) {
     val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
 
@@ -316,6 +319,18 @@ private fun CoreDatePicker(
     val coroutineScope = rememberCoroutineScope()
 
     val centerYearMonth = startMonth.plus(pagerState.currentPage.toLong() - CENTER_PAGE, DateTimeUnit.MONTH)
+
+    val hasEmittedInitialMonth = remember { BoolRef(false) }
+
+    if (onMonthDisplayed != null) {
+        LaunchedEffect(centerYearMonth) {
+            if (hasEmittedInitialMonth.value) {
+                onMonthDisplayed(centerYearMonth)
+            } else {
+                hasEmittedInitialMonth.value = true
+            }
+        }
+    }
 
     val headerLabel = "${monthFormatter(centerYearMonth.month.number)} ${centerYearMonth.year}"
 
@@ -335,20 +350,27 @@ private fun CoreDatePicker(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        MonthHeader(
+        CalendarMonthHeader(
             modifier = Modifier.fillMaxWidth().padding(horizontal = horizontalPadding),
-            yearMonth = centerYearMonth,
-            onYearMonthChange = { newYearMonth ->
+            headerLabel = headerLabel,
+            canGoPrev = canGoPrev,
+            canGoNext = canGoNext,
+            onPrev = {
+                val newYearMonth = centerYearMonth.minusMonth()
                 val diff = centerYearMonth.monthsUntil(newYearMonth)
                 val targetPage = (pagerState.currentPage + diff).coerceIn(0, PAGES_TOTAL - 1)
-
                 coroutineScope.launch {
                     pagerState.animateScrollToPage(targetPage)
                 }
             },
-            headerLabel = headerLabel,
-            canGoPrev = canGoPrev,
-            canGoNext = canGoNext,
+            onNext = {
+                val newYearMonth = centerYearMonth.plusMonth()
+                val diff = centerYearMonth.monthsUntil(newYearMonth)
+                val targetPage = (pagerState.currentPage + diff).coerceIn(0, PAGES_TOTAL - 1)
+                coroutineScope.launch {
+                    pagerState.animateScrollToPage(targetPage)
+                }
+            },
         )
 
         Spacer(modifier = Modifier.height(LocalSpaces.current.spacing200))
@@ -387,74 +409,9 @@ private fun CoreDatePicker(
                 selectedDates = selectedDates,
                 minDate = minDate,
                 maxDate = maxDate,
+                firstDayOfWeek = firstDayOfWeek,
                 onDateSelected = onDateSelected,
             )
-        }
-    }
-}
-
-@Composable
-private fun MonthHeader(
-    modifier: Modifier = Modifier,
-    yearMonth: YearMonth,
-    onYearMonthChange: (YearMonth) -> Unit,
-    headerLabel: String,
-    canGoPrev: Boolean,
-    canGoNext: Boolean,
-) {
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        LemonadeUi.IconButton(
-            icon = LemonadeIcons.ChevronLeft,
-            contentDescription = "Previous month",
-            variant = LemonadeIconButtonVariant.Ghost,
-            enabled = canGoPrev,
-            onClick = { onYearMonthChange(yearMonth.minusMonth()) },
-        )
-
-        LemonadeUi.Text(
-            text = headerLabel,
-            textStyle = LocalTypographies.current.bodySmallSemiBold,
-            color = LocalColors.current.content.contentPrimary,
-        )
-
-        LemonadeUi.IconButton(
-            icon = LemonadeIcons.ChevronRight,
-            contentDescription = "Next month",
-            variant = LemonadeIconButtonVariant.Ghost,
-            enabled = canGoNext,
-            onClick = { onYearMonthChange(yearMonth.plusMonth()) },
-        )
-    }
-}
-
-private fun generateMonthDays(month: YearMonth): List<LocalDate> {
-    val firstDayOfMonth = month.firstDay.dayOfWeek.ordinal
-
-    val startingWeekDay = DayOfWeek.SUNDAY.ordinal
-    val firstDayOffset =
-        (firstDayOfMonth - startingWeekDay + DayOfWeek.entries.size) % DayOfWeek.entries.size
-
-    return buildList {
-        // Previous month
-        val previousMonth = month.minusMonth()
-        val prevMonthLength = previousMonth.numberOfDays
-        for (day in prevMonthLength - firstDayOffset + 1..prevMonthLength) {
-            add(previousMonth.onDay(day))
-        }
-
-        // Current month
-        for (day in 1..month.numberOfDays) {
-            add(month.onDay(day))
-        }
-
-        // Next month
-        val nextMonth = month.plusMonth()
-        for (day in 1..42 - size) {
-            add(nextMonth.onDay(day))
         }
     }
 }
@@ -465,11 +422,12 @@ private fun MonthGrid(
     selectedDates: Set<LocalDate>,
     minDate: LocalDate?,
     maxDate: LocalDate?,
+    firstDayOfWeek: DayOfWeek,
     onDateSelected: (LocalDate) -> Unit,
 ) {
     val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
 
-    val days = remember(yearMonth) { generateMonthDays(yearMonth) }
+    val days = remember(yearMonth, firstDayOfWeek) { daysForMonth(yearMonth, firstDayOfWeek = firstDayOfWeek) }
 
     val isRangeComplete = selectedDates.size >= 2
     val rangeStartDate = if (isRangeComplete) selectedDates.min() else null
@@ -501,7 +459,9 @@ private fun MonthGrid(
                     val isAfterMax = maxDate != null && current > maxDate
 
                     ContentCell(
-                        modifier = Modifier.padding(horizontal = cellHorizontalPadding),
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = cellHorizontalPadding),
                         text = "${current.day}",
                         isCurrent = current == today,
                         isSelected = current in selectedDates,
@@ -509,7 +469,6 @@ private fun MonthGrid(
                         isOutsideVisibleRange = current.yearMonth != yearMonth,
                         isInsideSelectedRange = isInRange,
                         onClick = { onDateSelected(current) },
-                        interactionSource = remember { MutableInteractionSource() },
                     )
                 }
             }
@@ -544,96 +503,6 @@ private fun Modifier.drawRangeHighlight(
                 topLeft = Offset(left, 0f),
                 size = Size(right - left, size.height),
                 cornerRadius = CornerRadius(cellRadius.toPx()),
-            )
-        }
-    }
-}
-
-@Composable
-private fun RowScope.ContentCell(
-    modifier: Modifier = Modifier,
-    text: String,
-    isCurrent: Boolean,
-    isSelected: Boolean,
-    isEnabled: Boolean,
-    isOutsideVisibleRange: Boolean,
-    isInsideSelectedRange: Boolean,
-    onClick: () -> Unit,
-    interactionSource: MutableInteractionSource,
-) {
-    val isFocused by interactionSource.collectIsFocusedAsState()
-
-    val textColor = when {
-        !isEnabled -> LocalColors.current.content.contentTertiary
-        isSelected || isInsideSelectedRange -> LocalColors.current.content.contentOnBrandHigh
-        isCurrent -> LocalColors.current.content.contentBrand
-        isOutsideVisibleRange -> LocalColors.current.content.contentSecondary
-        else -> LocalColors.current.content.contentPrimary
-    }
-
-    val textStyle = if (isCurrent) {
-        LocalTypographies.current.bodyMediumSemiBold
-    } else {
-        LocalTypographies.current.bodyMediumMedium
-    }
-
-    val backgroundColor = if (isSelected) {
-        LocalColors.current.interaction.bgBrandInteractive
-    } else {
-        Color.Transparent
-    }
-
-    val cellShape = LocalShapes.current.radius200
-
-    Box(
-        modifier = modifier
-            .weight(1f)
-            .then(
-                other = if (isFocused) {
-                    Modifier
-                        .border(
-                            width = LocalBorderWidths.current.base.border50,
-                            color = LocalColors.current.border.borderSelected,
-                            shape = cellShape,
-                        )
-                } else {
-                    Modifier
-                },
-            ).clip(
-                shape = cellShape,
-            ).clickable(
-                onClick = onClick,
-                interactionSource = interactionSource,
-                role = Role.Button,
-                enabled = isEnabled,
-                indication = LocalEffects.current.interactionIndication,
-            ).semantics {
-                selected = isSelected
-                if (!isEnabled) {
-                    disabled()
-                }
-            }.background(
-                color = backgroundColor,
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        LemonadeUi.Text(
-            modifier = Modifier.padding(vertical = LocalSpaces.current.spacing200),
-            text = text,
-            textStyle = textStyle,
-            color = textColor,
-        )
-
-        if (isCurrent) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = LocalSpaces.current.spacing100)
-                    .size(LocalSpaces.current.spacing100)
-                    .background(
-                        color = textColor,
-                        shape = LocalShapes.current.radiusFull,
-                    ),
             )
         }
     }

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
@@ -1,0 +1,673 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.teya.lemonade
+
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import com.teya.lemonade.core.DayLabelFormat
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.YearMonth
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.onDay
+import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
+import kotlinx.datetime.yearMonth
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+private const val TOTAL_DAYS = 3651
+private const val CENTER_INDEX = TOTAL_DAYS / 2
+
+private const val DEFAULT_VISIBLE_CELLS = 7
+private const val LARGE_FONT_SCALE_VISIBLE_CELLS = 5
+private const val LARGE_FONT_SCALE_THRESHOLD = 1.3f
+
+/**
+ * Default English weekday labels ordered Monday through Sunday.
+ *
+ * These are provided as a fallback; callers should supply localized labels
+ * via the [weekdayLabels] parameter for proper i18n support.
+ */
+private val DEFAULT_WEEKDAY_LABELS_NARROW: List<String> =
+    listOf("M", "T", "W", "T", "F", "S", "S")
+
+/**
+ * Default English full weekday names ordered Monday through Sunday.
+ *
+ * Used as the accessibility fallback when [LemonadeUi.InlineCalendar] is called
+ * without [weekdayAccessibilityLabels]. Callers should supply a localized list for
+ * proper i18n support.
+ */
+private val DEFAULT_WEEKDAY_FULL_NAMES: List<String> = listOf(
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+)
+
+private val DEFAULT_WEEKDAY_LABELS_SHORT: List<String> =
+    listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+/**
+ * Default English month names indexed 0-11 (January through December).
+ *
+ * Provided as a fallback; callers should supply a localized [monthFormatter]
+ * for proper i18n support.
+ */
+private val DEFAULT_MONTH_NAMES: List<String> = listOf(
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+
+/**
+ * An inline calendar strip from the Lemonade Design System.
+ *
+ * Renders a horizontally scrollable row of day cells using index-based virtual
+ * scrolling over a fixed range of [TOTAL_DAYS] days (approximately +/-5 years
+ * from today). The list never regenerates - the displayed month is derived
+ * purely from the current scroll position, eliminating snap-back glitches.
+ *
+ * ## Localization
+ * By default the component uses English labels. For localized UIs, provide
+ * [weekdayLabels] and [monthFormatter] matching the user's locale, similar to
+ * the pattern used by [DatePicker].
+ *
+ * ## Usage
+ * ```kotlin
+ * val state = rememberInlineCalendarState(initialDate = today)
+ * LemonadeUi.InlineCalendar(
+ *     state = state,
+ *     weekdayLabels = listOf("L", "M", "M", "J", "V", "S", "D"), // French
+ *     monthFormatter = { month -> frenchMonthNames[month - 1] },
+ *     onDateSelected = { date -> /* handle selection */ },
+ * )
+ * // Observe: state.selectedDate
+ * ```
+ *
+ * @param state State holder created via [rememberInlineCalendarState].
+ * @param modifier Optional [Modifier] for layout adjustments.
+ * @param dayLabelFormat Controls whether weekday labels are [DayLabelFormat.Narrow] (single char)
+ *   or [DayLabelFormat.Short] (3 chars). Only used when [weekdayLabels] is not provided.
+ * @param weekdayLabels Optional list of exactly 7 localized weekday abbreviations ordered
+ *   Monday through Sunday. When provided, [dayLabelFormat] is ignored. Callers should
+ *   provide this for proper localization.
+ * @param monthFormatter Optional formatter returning a localized month name for a given
+ *   month number (1-12). Used in the header label. Defaults to English month names.
+ * @param onDateSelected Optional callback invoked when the user taps a date.
+ * @param onMonthDisplayed Optional callback invoked when the displayed month changes.
+ * @param enabledDates Optional predicate that controls which dates are interactive.
+ *   When provided, a date is enabled only when this predicate returns `true` **and**
+ *   the date falls within the [InlineCalendarState.minDate]..[InlineCalendarState.maxDate]
+ *   range (if set). This is useful, for example, to disable dates that have no associated
+ *   content.
+ * @param prevMonthContentDescription Accessibility label for the previous-month navigation
+ *   button. Defaults to the English string "Previous month". Callers should supply a
+ *   localized string for proper i18n support.
+ * @param nextMonthContentDescription Accessibility label for the next-month navigation
+ *   button. Defaults to the English string "Next month". Callers should supply a localized
+ *   string for proper i18n support.
+ * @param weekdayAccessibilityLabels Optional list of exactly 7 full weekday names ordered
+ *   Monday through Sunday, used only by screen readers (not as visual labels). When `null`,
+ *   defaults to English full names from [DEFAULT_WEEKDAY_FULL_NAMES]. Callers should
+ *   supply a localized list for proper i18n support.
+ * @param expandSelectionToLabel When `true` (default), the selection background covers the
+ *   weekday label, day number, and trailing content. When `false`, only the day number
+ *   circle carries the brand background (DatePicker style).
+ * @param selectionBackgroundColor When non-null, overrides the default brand background color
+ *   for selected cells.
+ * @param selectionContentColor When non-null, overrides the default text color on selected cells.
+ * @param trailingContent Optional composable rendered below each day cell (e.g. event dots).
+ *   Receives the [LocalDate] for the cell and a [Boolean] indicating whether that date is
+ *   currently selected.
+ */
+@ExperimentalLemonadeComponent
+@Composable
+public fun LemonadeUi.InlineCalendar(
+    state: InlineCalendarState,
+    modifier: Modifier = Modifier,
+    dayLabelFormat: DayLabelFormat = DayLabelFormat.Narrow,
+    weekdayLabels: List<String>? = null,
+    monthFormatter: ((month: Int) -> String)? = null,
+    onDateSelected: ((LocalDate) -> Unit)? = null,
+    onMonthDisplayed: ((YearMonth) -> Unit)? = null,
+    enabledDates: ((LocalDate) -> Boolean)? = null,
+    prevMonthContentDescription: String = "Previous month",
+    nextMonthContentDescription: String = "Next month",
+    weekdayAccessibilityLabels: List<String>? = null,
+    expandSelectionToLabel: Boolean = true,
+    selectionBackgroundColor: Color? = null,
+    selectionContentColor: Color? = null,
+    trailingContent: @Composable ((LocalDate, Boolean) -> Unit)? = null,
+) {
+    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
+    val anchorDate = remember { today }
+
+    val density = LocalDensity.current
+    val visibleCells = remember(density.fontScale) {
+        if (density.fontScale > LARGE_FONT_SCALE_THRESHOLD) {
+            LARGE_FONT_SCALE_VISIBLE_CELLS
+        } else {
+            DEFAULT_VISIBLE_CELLS
+        }
+    }
+
+    val resolvedWeekdayLabels = remember(weekdayLabels, dayLabelFormat) {
+        resolveWeekdayLabels(weekdayLabels, dayLabelFormat)
+    }
+
+    val resolvedMonthFormatter: (Int) -> String = remember(monthFormatter) {
+        monthFormatter ?: { month -> DEFAULT_MONTH_NAMES[month - 1] }
+    }
+
+    val resolvedAccessibilityLabels = remember(weekdayAccessibilityLabels) {
+        weekdayAccessibilityLabels ?: DEFAULT_WEEKDAY_FULL_NAMES
+    }
+
+    // Clamp the scrollable range to minDate/maxDate when set, with visibleCells
+    // of padding so the user can see a bit of context beyond the boundary.
+    // selectedDate is intentionally excluded from the key: changing it must not
+    // recalculate firstIndex, which would invalidate all index-to-date mappings
+    // and desync listState from the virtual index space.
+    val indexRange = remember(state.minDate, state.maxDate, anchorDate, visibleCells) {
+        calculateIndexRange(
+            minDate = state.minDate,
+            maxDate = state.maxDate,
+            anchorDate = anchorDate,
+            rangePadding = visibleCells,
+        )
+    }
+    val firstIndex = indexRange.firstIndex
+    val itemCount = indexRange.itemCount
+
+    // initialIndex positions the list so today (or center) is roughly visible
+    // before the LaunchedEffect(Unit) performs the exact centered scroll.
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = indexRange.initialIndex,
+    )
+
+    // Guards the selected-date and navigateToMonth effects from competing with
+    // the initial non-animated centering scroll in LaunchedEffect(Unit).
+    val initialScrollDone = remember { mutableStateOf(false) }
+
+    // Header month: derived from the item at the center of the visible viewport.
+    // Uses layoutInfo to find the actual center pixel, not an approximation.
+    val headerMonth by remember {
+        derivedStateOf {
+            deriveHeaderMonth(
+                listState = listState,
+                firstIndex = firstIndex,
+                visibleCells = visibleCells,
+                anchorDate = anchorDate,
+            )
+        }
+    }
+
+    val haptic = LocalHapticFeedback.current
+
+    // True when the current headerMonth change was triggered by a day tap rather
+    // than a scroll gesture. The onClick handler sets this flag before calling
+    // selectDate() so the LaunchedEffect below can skip its haptic and avoid
+    // firing a second feedback for cross-month taps.
+    val selectionTriggeredMonthChange = remember { BoolRef(false) }
+
+    // LaunchedEffect(headerMonth) fires once on initial composition with the
+    // starting month value. We need to swallow that first emission so mounting
+    // the component does not trigger a haptic (noticeable when several
+    // calendars appear on the same screen).
+    val hasEmittedInitialMonth = remember { BoolRef(false) }
+
+    // Sync displayedMonth on the state so external observers can read it.
+    // Haptic tick on month boundary crossing gives tactile scroll feedback,
+    // but only when the change was driven by a scroll - not a day tap (which
+    // already fired its own haptic in onClick) and not the initial composition.
+    LaunchedEffect(headerMonth) {
+        state.displayedMonth = headerMonth
+        onMonthDisplayed?.invoke(headerMonth)
+        when {
+            !hasEmittedInitialMonth.value -> {
+                hasEmittedInitialMonth.value = true
+            }
+            selectionTriggeredMonthChange.value -> {
+                selectionTriggeredMonthChange.value = false
+            }
+            else -> {
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+            }
+        }
+    }
+
+    // Scroll to a specific date, centering it in the viewport.
+    val coroutineScope = rememberCoroutineScope()
+
+    val scrollToDate: (LocalDate) -> Unit = { date ->
+        val targetIndex = (dateToGlobalIndex(date, anchorDate) - firstIndex)
+            .coerceIn(0, itemCount - 1)
+        coroutineScope.launch {
+            listState.scrollToCenteredIndex(targetIndex, visibleCells, animate = true)
+        }
+        Unit
+    }
+
+    // Center on initial position without animation. Sets initialScrollDone when
+    // complete so subsequent effects know the viewport is ready.
+    LaunchedEffect(Unit) {
+        snapshotFlow { listState.layoutInfo.viewportSize.width }
+            .filter { width -> width > 0 }
+            .first()
+        val targetDate = state.selectedDate ?: today
+        val targetIndex = (dateToGlobalIndex(targetDate, anchorDate) - firstIndex)
+            .coerceIn(0, itemCount - 1)
+        listState.scrollToCenteredIndex(targetIndex = targetIndex, visibleCells = visibleCells, animate = false)
+        initialScrollDone.value = true
+    }
+
+    // Scroll to newly selected date with animation. Guarded by initialScrollDone
+    // to prevent a competing animated scroll during initial composition.
+    LaunchedEffect(state.selectedDate) {
+        if (!initialScrollDone.value) return@LaunchedEffect
+        val targetDate = state.selectedDate ?: return@LaunchedEffect
+        val targetIndex = (dateToGlobalIndex(targetDate, anchorDate) - firstIndex)
+            .coerceIn(0, itemCount - 1)
+        snapshotFlow { listState.layoutInfo.viewportSize.width }
+            .filter { width -> width > 0 }
+            .first()
+        listState.scrollToCenteredIndex(targetIndex = targetIndex, visibleCells = visibleCells, animate = true)
+    }
+
+    // Responds to external navigateToMonth() calls by observing the dedicated
+    // navigationTarget on the state. Clears the target after scrolling so
+    // the same month can be navigated to again.
+    LaunchedEffect(state.navigationTarget) {
+        val target = state.navigationTarget
+            ?: return@LaunchedEffect
+        scrollToDate(target.onDay(1))
+        state.navigationTarget = null
+    }
+
+    Column(modifier = modifier) {
+        CalendarMonthHeader(
+            modifier = Modifier.fillMaxWidth(),
+            headerLabel = buildHeaderLabel(headerMonth, resolvedMonthFormatter),
+            canGoPrev = canNavigatePrev(headerMonth, state.minDate),
+            canGoNext = canNavigateNext(headerMonth, state.maxDate),
+            prevMonthContentDescription = prevMonthContentDescription,
+            nextMonthContentDescription = nextMonthContentDescription,
+            onPrev = {
+                val firstOfPrev = headerMonth.minus(1, DateTimeUnit.MONTH).onDay(1)
+                scrollToDate(firstOfPrev)
+            },
+            onNext = {
+                val firstOfNext = headerMonth.plus(1, DateTimeUnit.MONTH).onDay(1)
+                scrollToDate(firstOfNext)
+            },
+        )
+
+        Spacer(modifier = Modifier.height(LocalSpaces.current.spacing200))
+
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            val cellWidth: Dp = maxWidth / visibleCells
+
+            LazyRow(
+                state = listState,
+                flingBehavior = rememberSnapFlingBehavior(lazyListState = listState),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        collectionInfo = CollectionInfo(rowCount = 1, columnCount = itemCount)
+                    },
+            ) {
+                items(
+                    count = itemCount,
+                    key = { it + firstIndex },
+                ) { localIndex ->
+                    val globalIndex = localIndex + firstIndex
+                    val date = remember(globalIndex) {
+                        globalIndexToDate(globalIndex, anchorDate)
+                    }
+                    InlineCalendarDayItem(
+                        date = date,
+                        today = today,
+                        cellWidth = cellWidth,
+                        state = state,
+                        headerMonth = headerMonth,
+                        enabledDates = enabledDates,
+                        resolvedWeekdayLabels = resolvedWeekdayLabels,
+                        resolvedAccessibilityLabels = resolvedAccessibilityLabels,
+                        resolvedMonthFormatter = resolvedMonthFormatter,
+                        expandSelectionToLabel = expandSelectionToLabel,
+                        selectionBackgroundColor = selectionBackgroundColor,
+                        selectionContentColor = selectionContentColor,
+                        trailingContent = trailingContent,
+                        onDateTap = { tappedDate ->
+                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            if (tappedDate.yearMonth != headerMonth) {
+                                selectionTriggeredMonthChange.value = true
+                            }
+                            state.selectDate(tappedDate)
+                            onDateSelected?.invoke(tappedDate)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Resolves a weekday label from the caller-provided [weekdayLabels] list.
+ *
+ * The list is ordered Monday (index 0) through Sunday (index 6), matching
+ * [DayOfWeek] ordinal values.
+ */
+private fun resolveWeekdayLabel(
+    dayOfWeek: DayOfWeek,
+    weekdayLabels: List<String>,
+): String = weekdayLabels[dayOfWeek.ordinal]
+
+/**
+ * Builds a "Month Year" header string from a [YearMonth] using the provided
+ * [monthFormatter] for localized month names.
+ */
+private fun buildHeaderLabel(
+    yearMonth: YearMonth,
+    monthFormatter: (Int) -> String,
+): String {
+    val monthName = monthFormatter(yearMonth.month.number)
+    return "$monthName ${yearMonth.year}"
+}
+
+/**
+ * Builds an accessibility content description for a calendar day cell.
+ *
+ * Format: "Weekday, Month Day, Year" (e.g. "Monday, April 14, 2025").
+ * Uses the caller-provided labels so accessibility reads match the visual labels.
+ */
+private fun buildCellContentDescription(
+    date: LocalDate,
+    weekdayLabels: List<String>,
+    monthFormatter: (Int) -> String,
+): String {
+    val weekday = weekdayLabels[date.dayOfWeek.ordinal]
+    val month = monthFormatter(date.month.number)
+    return "$weekday, $month ${date.day}, ${date.year}"
+}
+
+/**
+ * Pure predicate that combines the state's `minDate`/`maxDate` bounds with the
+ * caller-provided [enabledDates] closure. Lives outside the main composable so
+ * its branching does not count toward the composable's cyclomatic complexity.
+ */
+private fun isDateEnabled(
+    date: LocalDate,
+    minDate: LocalDate?,
+    maxDate: LocalDate?,
+    enabledDates: ((LocalDate) -> Boolean)?,
+): Boolean {
+    val inRange = (minDate == null || date >= minDate) &&
+        (maxDate == null || date <= maxDate)
+    return inRange && enabledDates?.invoke(date) != false
+}
+
+/**
+ * Converts a global virtual index (0..[TOTAL_DAYS]) to a [LocalDate] using the
+ * caller-provided [anchorDate] pinned at [CENTER_INDEX].
+ */
+private fun globalIndexToDate(
+    globalIndex: Int,
+    anchorDate: LocalDate,
+): LocalDate {
+    val daysFromAnchor = (globalIndex - CENTER_INDEX).toLong()
+    return anchorDate.plus(daysFromAnchor, DateTimeUnit.DAY)
+}
+
+/**
+ * Inverse of [globalIndexToDate]: returns the global virtual index for [date].
+ */
+private fun dateToGlobalIndex(
+    date: LocalDate,
+    anchorDate: LocalDate,
+): Int = CENTER_INDEX + anchorDate.daysUntil(date)
+
+/**
+ * Resolves the effective weekday labels from the caller-provided list or a
+ * format-based English fallback.
+ */
+private fun resolveWeekdayLabels(
+    weekdayLabels: List<String>?,
+    dayLabelFormat: DayLabelFormat,
+): List<String> =
+    weekdayLabels ?: when (dayLabelFormat) {
+        DayLabelFormat.Narrow -> DEFAULT_WEEKDAY_LABELS_NARROW
+        DayLabelFormat.Short -> DEFAULT_WEEKDAY_LABELS_SHORT
+    }
+
+/**
+ * Bounded index range and initial scroll offset derived from the calendar
+ * state's `minDate`/`maxDate`/`selectedDate`.
+ */
+private data class CalendarIndexRange(
+    val firstIndex: Int,
+    val lastIndex: Int,
+    val itemCount: Int,
+    val initialIndex: Int,
+)
+
+/**
+ * Computes the clamped virtual index window. The initial scroll position is
+ * intentionally fixed to [CENTER_INDEX] so that [rememberLazyListState] always
+ * receives a stable value - the exact centering is handled by the
+ * `LaunchedEffect(Unit)` in the composable after the viewport is measured.
+ *
+ * [selectedDate] is NOT a parameter here by design: including it would cause
+ * [firstIndex] to shift whenever the user taps a date, which would desync
+ * all index-to-date mappings while [LazyListState] retains its old position.
+ */
+private fun calculateIndexRange(
+    minDate: LocalDate?,
+    maxDate: LocalDate?,
+    anchorDate: LocalDate,
+    rangePadding: Int,
+): CalendarIndexRange {
+    val firstIndex = minDate
+        ?.let { (dateToGlobalIndex(it, anchorDate) - rangePadding).coerceAtLeast(0) }
+        ?: 0
+    val lastIndex = maxDate
+        ?.let { (dateToGlobalIndex(it, anchorDate) + rangePadding).coerceAtMost(TOTAL_DAYS - 1) }
+        ?: TOTAL_DAYS - 1
+    val itemCount = lastIndex - firstIndex + 1
+    val initialIndex = (CENTER_INDEX - firstIndex).coerceIn(0, itemCount - 1)
+    return CalendarIndexRange(
+        firstIndex = firstIndex,
+        lastIndex = lastIndex,
+        itemCount = itemCount,
+        initialIndex = initialIndex,
+    )
+}
+
+/**
+ * Whether the chevron can navigate backward from [headerMonth] given [minDate].
+ */
+private fun canNavigatePrev(
+    headerMonth: YearMonth,
+    minDate: LocalDate?,
+): Boolean = minDate?.yearMonth?.let { headerMonth > it } ?: true
+
+/**
+ * Whether the chevron can navigate forward from [headerMonth] given [maxDate].
+ */
+private fun canNavigateNext(
+    headerMonth: YearMonth,
+    maxDate: LocalDate?,
+): Boolean = maxDate?.yearMonth?.let { headerMonth < it } ?: true
+
+/**
+ * Returns the [YearMonth] that should currently appear in the header label.
+ *
+ * The "current" month is the one owning the cell whose center is closest to
+ * the viewport center, matching the Compose reference. Falls back to
+ * `firstVisibleItemIndex + visibleCells / 2` when `layoutInfo` has not emitted
+ * visible items yet (e.g. during the initial frame).
+ */
+private fun deriveHeaderMonth(
+    listState: LazyListState,
+    firstIndex: Int,
+    visibleCells: Int,
+    anchorDate: LocalDate,
+): YearMonth {
+    val layoutInfo = listState.layoutInfo
+    val viewportCenter = layoutInfo.viewportStartOffset +
+        (layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset) / 2
+    val centerItem = layoutInfo.visibleItemsInfo.minByOrNull {
+        kotlin.math.abs(it.offset + it.size / 2 - viewportCenter)
+    }
+    val localIndex = centerItem?.index ?: listState.firstVisibleItemIndex + visibleCells / 2
+    val globalIndex = (localIndex + firstIndex).coerceIn(0, TOTAL_DAYS - 1)
+    val date = globalIndexToDate(globalIndex, anchorDate)
+    return YearMonth(date.year, date.month.number)
+}
+
+/**
+ * Scrolls a [LazyListState] so the cell at [targetIndex] sits in the horizontal
+ * center of the viewport. Shared between the initial-position effect, the
+ * selection-scroll effect, and the chevron handler so none of them has to
+ * recompute the viewport-relative offset inline.
+ */
+private suspend fun LazyListState.scrollToCenteredIndex(
+    targetIndex: Int,
+    visibleCells: Int,
+    animate: Boolean,
+) {
+    val viewportWidth = layoutInfo.viewportSize.width
+    if (viewportWidth <= 0) return
+    val cellWidthPx = viewportWidth / visibleCells
+    val scrollOffset = -(viewportWidth - cellWidthPx) / 2
+    if (animate) {
+        animateScrollToItem(targetIndex, scrollOffset)
+    } else {
+        scrollToItem(targetIndex, scrollOffset)
+    }
+}
+
+/**
+ * A single day cell inside the inline calendar strip.
+ *
+ * Extracted from the main composable body so its own branching (enabled
+ * predicate, selection state, cross-month detection) does not inflate the
+ * parent's cyclomatic complexity. Callers pass pre-resolved
+ * [resolvedWeekdayLabels], [resolvedAccessibilityLabels], and [resolvedMonthFormatter] so
+ * the item does not re-resolve them on every recomposition.
+ */
+@Composable
+@Suppress("LongParameterList")
+private fun InlineCalendarDayItem(
+    date: LocalDate,
+    today: LocalDate,
+    cellWidth: Dp,
+    state: InlineCalendarState,
+    headerMonth: YearMonth,
+    enabledDates: ((LocalDate) -> Boolean)?,
+    resolvedWeekdayLabels: List<String>,
+    resolvedAccessibilityLabels: List<String>,
+    resolvedMonthFormatter: (Int) -> String,
+    expandSelectionToLabel: Boolean,
+    selectionBackgroundColor: Color?,
+    selectionContentColor: Color?,
+    trailingContent: @Composable ((LocalDate, Boolean) -> Unit)?,
+    onDateTap: (LocalDate) -> Unit,
+) {
+    val isInHeaderMonth = date.yearMonth == headerMonth
+
+    val isEnabled = remember(date, state.minDate, state.maxDate, enabledDates) {
+        isDateEnabled(
+            date = date,
+            minDate = state.minDate,
+            maxDate = state.maxDate,
+            enabledDates = enabledDates,
+        )
+    }
+
+    val weekdayLabel = remember(date, resolvedWeekdayLabels) {
+        resolveWeekdayLabel(date.dayOfWeek, resolvedWeekdayLabels)
+    }
+
+    val accessibilityDescription = remember(
+        date,
+        resolvedAccessibilityLabels,
+        resolvedMonthFormatter,
+    ) {
+        buildCellContentDescription(
+            date = date,
+            weekdayLabels = resolvedAccessibilityLabels,
+            monthFormatter = resolvedMonthFormatter,
+        )
+    }
+
+    val isSelected = date == state.selectedDate
+    CalendarDayCell(
+        modifier = Modifier.width(cellWidth),
+        text = "${date.day}",
+        contentDescription = accessibilityDescription,
+        isCurrent = date == today,
+        isSelected = isSelected,
+        isEnabled = isEnabled,
+        isOutsideVisibleRange = !isInHeaderMonth,
+        isInsideSelectedRange = false,
+        showWeekdayLabel = true,
+        weekdayLabel = weekdayLabel,
+        expandSelectionToLabel = expandSelectionToLabel,
+        selectionBackgroundColor = selectionBackgroundColor,
+        selectionContentColor = selectionContentColor,
+        onClick = { onDateTap(date) },
+        trailingContent = trailingContent?.let { content ->
+            {
+                content(date, isSelected)
+            }
+        },
+    )
+}

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
@@ -66,6 +66,14 @@ public class InlineCalendarState internal constructor(
         internal set
 
     /**
+     * Programmatic navigation target. Written only by [navigateToMonth] and
+     * consumed (then cleared) by the composable. Keeping this separate from
+     * [displayedMonth] prevents the scroll-driven feedback loop where an
+     * internal header update triggers an unwanted scroll to the 1st.
+     */
+    internal var navigationTarget: YearMonth? by mutableStateOf(null)
+
+    /**
      * Select a date. The composable handles scrolling to make it visible.
      *
      * Does not update [displayedMonth] - the composable derives the
@@ -76,14 +84,6 @@ public class InlineCalendarState internal constructor(
         if (maxDate != null && date > maxDate) return
         selectedDate = date
     }
-
-    /**
-     * Programmatic navigation target. Written only by [navigateToMonth] and
-     * consumed (then cleared) by the composable. Keeping this separate from
-     * [displayedMonth] prevents the scroll-driven feedback loop where an
-     * internal header update triggers an unwanted scroll to the 1st.
-     */
-    internal var navigationTarget: YearMonth? by mutableStateOf(null)
 
     /**
      * Navigate to a specific month without changing the selection.

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
@@ -1,0 +1,171 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.teya.lemonade
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.YearMonth
+import kotlinx.datetime.number
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * State holder for [LemonadeUi.InlineCalendar].
+ *
+ * Manages the currently selected date and navigation bounds.
+ * The displayed month is derived from the scroll position by the composable
+ * and is not used as a data driver.
+ *
+ * Create via [rememberInlineCalendarState].
+ *
+ * @param initialDate The initially selected date.
+ * @param initialDisplayedMonth The month shown initially; defaults to the
+ *   month of [initialDate] or today.
+ * @param minDate Minimum selectable date (inclusive).
+ * @param maxDate Maximum selectable date (inclusive).
+ * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
+ *   used by the inline calendar rendering - the inline calendar is a continuous day strip
+ *   with no grid columns, so week-start ordering does not affect the displayed layout.
+ *   Stored and persisted so the API can be extended without a breaking change.
+ */
+@Stable
+public class InlineCalendarState internal constructor(
+    initialDate: LocalDate? = null,
+    initialDisplayedMonth: YearMonth? = null,
+    public val minDate: LocalDate? = null,
+    public val maxDate: LocalDate? = null,
+    public val firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+) {
+    /** The currently selected date. */
+    public var selectedDate: LocalDate? by mutableStateOf(initialDate)
+        internal set
+
+    /**
+     * The month currently shown in the header.
+     *
+     * This is a read-only observable updated by the composable based on
+     * scroll position. It is NOT used as a data driver for list generation.
+     */
+    public var displayedMonth: YearMonth by mutableStateOf(
+        initialDisplayedMonth
+            ?: initialDate?.let { YearMonth(it.year, it.month.number) }
+            ?: Clock.System.todayIn(TimeZone.currentSystemDefault()).let {
+                YearMonth(it.year, it.month.number)
+            },
+    )
+        internal set
+
+    /**
+     * Select a date. The composable handles scrolling to make it visible.
+     *
+     * Does not update [displayedMonth] - the composable derives the
+     * displayed month from the scroll position automatically.
+     */
+    public fun selectDate(date: LocalDate) {
+        if (minDate != null && date < minDate) return
+        if (maxDate != null && date > maxDate) return
+        selectedDate = date
+    }
+
+    /**
+     * Programmatic navigation target. Written only by [navigateToMonth] and
+     * consumed (then cleared) by the composable. Keeping this separate from
+     * [displayedMonth] prevents the scroll-driven feedback loop where an
+     * internal header update triggers an unwanted scroll to the 1st.
+     */
+    internal var navigationTarget: YearMonth? by mutableStateOf(null)
+
+    /**
+     * Navigate to a specific month without changing the selection.
+     *
+     * Sets [navigationTarget] which the composable observes to trigger
+     * a scroll to the first day of the given month.
+     */
+    public fun navigateToMonth(yearMonth: YearMonth) {
+        if (minDate != null && yearMonth.lastDay < minDate) return
+        if (maxDate != null && yearMonth.firstDay > maxDate) return
+        navigationTarget = yearMonth
+    }
+
+    internal companion object {
+        /**
+         * [Saver] implementation that persists the state across configuration
+         * changes using simple primitives.
+         */
+        fun saver(
+            minDate: LocalDate?,
+            maxDate: LocalDate?,
+            firstDayOfWeek: DayOfWeek,
+        ): Saver<InlineCalendarState, *> =
+            listSaver(
+                save = { state ->
+                    listOf(
+                        state.selectedDate?.toString().orEmpty(),
+                        state.displayedMonth.year,
+                        state.displayedMonth.month.number,
+                    )
+                },
+                restore = { list ->
+                    val selectedStr = list[0] as String
+                    val year = list[1] as Int
+                    val month = list[2] as Int
+                    InlineCalendarState(
+                        initialDate = selectedStr
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { LocalDate.parse(it) },
+                        initialDisplayedMonth = YearMonth(year, month),
+                        minDate = minDate,
+                        maxDate = maxDate,
+                        firstDayOfWeek = firstDayOfWeek,
+                    )
+                },
+            )
+    }
+}
+
+/**
+ * Creates and remembers an [InlineCalendarState] that survives configuration
+ * changes via [rememberSaveable].
+ *
+ * @param initialDate The initially selected date.
+ * @param initialDisplayedMonth The month to display initially.
+ * @param minDate Minimum selectable date (inclusive).
+ * @param maxDate Maximum selectable date (inclusive).
+ * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
+ *   used by the inline calendar rendering - the inline calendar is a continuous day strip
+ *   with no grid columns, so week-start ordering does not affect the displayed layout.
+ *   Stored and persisted so the API can be extended without a breaking change.
+ */
+@Composable
+public fun rememberInlineCalendarState(
+    initialDate: LocalDate? = null,
+    initialDisplayedMonth: YearMonth? = null,
+    minDate: LocalDate? = null,
+    maxDate: LocalDate? = null,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+): InlineCalendarState =
+    rememberSaveable(
+        saver = InlineCalendarState.saver(
+            minDate = minDate,
+            maxDate = maxDate,
+            firstDayOfWeek = firstDayOfWeek,
+        ),
+    ) {
+        InlineCalendarState(
+            initialDate = initialDate,
+            initialDisplayedMonth = initialDisplayedMonth,
+            minDate = minDate,
+            maxDate = maxDate,
+            firstDayOfWeek = firstDayOfWeek,
+        )
+    }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/Displays.kt
@@ -46,6 +46,7 @@ internal interface Displays {
             Divider,
             Tabs,
             DatePicker,
+            InlineCalendar,
             Notice,
             Toast,
         )
@@ -234,6 +235,11 @@ internal interface Displays {
     @Serializable
     data object DatePicker : Displays {
         override val label: String = "DatePicker"
+    }
+
+    @Serializable
+    data object InlineCalendar : Displays {
+        override val label: String = "InlineCalendar"
     }
 
     @Serializable

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -96,6 +96,7 @@ internal object DisplayRegistry {
                 Displays.RadioButton,
                 Displays.Switch,
                 Displays.DatePicker,
+                Displays.InlineCalendar,
             ),
         ),
         DisplayData(

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
@@ -28,7 +28,6 @@ import kotlinx.datetime.todayIn
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalLemonadeComponent::class)
 @Composable
 internal fun InlineCalendarDisplay() {
     val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
@@ -42,147 +41,158 @@ internal fun InlineCalendarDisplay() {
             .navigationBarsPadding()
             .padding(LemonadeTheme.spaces.spacing400),
     ) {
-        InlineCalendarSection(title = "Default (today selected)") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                onDateSelected = { /* observe state.selectedDate */ },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "With trailing content (dot on every 3rd day)") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                onDateSelected = { /* observe state.selectedDate */ },
-                enabledDates = { date -> date.day % 3 == 0 },
-                trailingContent = { date, isSelected ->
-                    if (date.day % 3 == 0) {
-                        Box(
-                            modifier = Modifier
-                                .size(size = 6.dp)
-                                .background(
-                                    color = if (isSelected) {
-                                        LemonadeTheme.colors.content.contentOnBrandHigh
-                                    } else {
-                                        LemonadeTheme.colors.content.contentBrand
-                                    },
-                                    shape = CircleShape,
-                                ),
-                        )
-                    }
-                },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "Short day labels (Mon, Tue, Wed...)") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                dayLabelFormat = DayLabelFormat.Short,
-                onDateSelected = { /* observe state.selectedDate */ },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "Constrained range (7 days before to 30 days after)") {
-            val minDate = remember { today.plus(-7, DateTimeUnit.DAY) }
-            val maxDate = remember { today.plus(30, DateTimeUnit.DAY) }
-            val state = rememberInlineCalendarState(
-                initialDate = today,
-                minDate = minDate,
-                maxDate = maxDate,
-            )
-            LemonadeUi.InlineCalendar(
-                state = state,
-                onDateSelected = { /* observe state.selectedDate */ },
-            )
-            LemonadeUi.Text(
-                text = "Range: ${formatInlineDate(minDate)} - ${formatInlineDate(maxDate)}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "Compact selection (day number only)") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                expandSelectionToLabel = false,
-                onDateSelected = { /* observe state.selectedDate */ },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "Compact selection with trailing dots") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                expandSelectionToLabel = false,
-                onDateSelected = { /* observe state.selectedDate */ },
-                enabledDates = { date -> date.day % 3 == 0 },
-                trailingContent = { date, isSelected ->
-                    if (date.day % 3 == 0) {
-                        Box(
-                            modifier = Modifier
-                                .size(size = 6.dp)
-                                .background(
-                                    color = if (isSelected) {
-                                        LemonadeTheme.colors.content.contentOnBrandHigh
-                                    } else {
-                                        LemonadeTheme.colors.content.contentBrand
-                                    },
-                                    shape = CircleShape,
-                                ),
-                        )
-                    }
-                },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
-
-        InlineCalendarSection(title = "Custom selection colors") {
-            val state = rememberInlineCalendarState(initialDate = today)
-            LemonadeUi.InlineCalendar(
-                state = state,
-                selectionBackgroundColor = LemonadeTheme.colors.interaction.bgInfoInteractive,
-                selectionContentColor = LemonadeTheme.colors.content.contentAlwaysLight,
-                onDateSelected = { /* observe state.selectedDate */ },
-            )
-            LemonadeUi.Text(
-                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
-                textStyle = LemonadeTheme.typography.bodySmallRegular,
-                color = LemonadeTheme.colors.content.contentSecondary,
-            )
-        }
+        DefaultSection(today = today)
+        TrailingDotsSection(today = today)
+        ShortLabelsSection(today = today)
+        ConstrainedRangeSection(today = today)
+        CompactSelectionSection(today = today)
+        CompactDotsSection(today = today)
+        CustomColorsSection(today = today)
     }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun DefaultSection(today: LocalDate) {
+    InlineCalendarSection(title = "Default (today selected)") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            onDateSelected = { /* observe state.selectedDate */ },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun TrailingDotsSection(today: LocalDate) {
+    InlineCalendarSection(title = "With trailing content (dot on every 3rd day)") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            onDateSelected = { /* observe state.selectedDate */ },
+            enabledDates = { date -> date.day % 3 == 0 },
+            trailingContent = { date, isSelected ->
+                if (date.day % 3 == 0) {
+                    EventDot(isSelected = isSelected)
+                }
+            },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun ShortLabelsSection(today: LocalDate) {
+    InlineCalendarSection(title = "Short day labels (Mon, Tue, Wed...)") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            dayLabelFormat = DayLabelFormat.Short,
+            onDateSelected = { /* observe state.selectedDate */ },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun ConstrainedRangeSection(today: LocalDate) {
+    InlineCalendarSection(title = "Constrained range (7 days before to 30 days after)") {
+        val minDate = remember { today.plus(-7, DateTimeUnit.DAY) }
+        val maxDate = remember { today.plus(30, DateTimeUnit.DAY) }
+        val state = rememberInlineCalendarState(
+            initialDate = today,
+            minDate = minDate,
+            maxDate = maxDate,
+        )
+        LemonadeUi.InlineCalendar(
+            state = state,
+            onDateSelected = { /* observe state.selectedDate */ },
+        )
+        LemonadeUi.Text(
+            text = "Range: ${formatInlineDate(minDate)} - ${formatInlineDate(maxDate)}",
+            textStyle = LemonadeTheme.typography.bodySmallRegular,
+            color = LemonadeTheme.colors.content.contentSecondary,
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun CompactSelectionSection(today: LocalDate) {
+    InlineCalendarSection(title = "Compact selection (day number only)") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            expandSelectionToLabel = false,
+            onDateSelected = { /* observe state.selectedDate */ },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun CompactDotsSection(today: LocalDate) {
+    InlineCalendarSection(title = "Compact selection with trailing dots") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            expandSelectionToLabel = false,
+            onDateSelected = { /* observe state.selectedDate */ },
+            enabledDates = { date -> date.day % 3 == 0 },
+            trailingContent = { date, isSelected ->
+                if (date.day % 3 == 0) {
+                    EventDot(isSelected = isSelected)
+                }
+            },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+private fun CustomColorsSection(today: LocalDate) {
+    InlineCalendarSection(title = "Custom selection colors") {
+        val state = rememberInlineCalendarState(initialDate = today)
+        LemonadeUi.InlineCalendar(
+            state = state,
+            selectionBackgroundColor = LemonadeTheme.colors.interaction.bgInfoInteractive,
+            selectionContentColor = LemonadeTheme.colors.content.contentAlwaysLight,
+            onDateSelected = { /* observe state.selectedDate */ },
+        )
+        SelectedDateLabel(state = state)
+    }
+}
+
+@Composable
+private fun EventDot(isSelected: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(size = 6.dp)
+            .background(
+                color = if (isSelected) {
+                    LemonadeTheme.colors.content.contentOnBrandHigh
+                } else {
+                    LemonadeTheme.colors.content.contentBrand
+                },
+                shape = CircleShape,
+            ),
+    )
+}
+
+@Composable
+private fun SelectedDateLabel(state: InlineCalendarState) {
+    LemonadeUi.Text(
+        text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+        textStyle = LemonadeTheme.typography.bodySmallRegular,
+        color = LemonadeTheme.colors.content.contentSecondary,
+    )
 }
 
 @Composable

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
@@ -1,0 +1,205 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.teya.lemonade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.teya.lemonade.core.DayLabelFormat
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalLemonadeComponent::class)
+@Composable
+internal fun InlineCalendarDisplay() {
+    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing600),
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(state = rememberScrollState())
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(LemonadeTheme.spaces.spacing400),
+    ) {
+        InlineCalendarSection(title = "Default (today selected)") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                onDateSelected = { /* observe state.selectedDate */ },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "With trailing content (dot on every 3rd day)") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                onDateSelected = { /* observe state.selectedDate */ },
+                enabledDates = { date -> date.day % 3 == 0 },
+                trailingContent = { date, isSelected ->
+                    if (date.day % 3 == 0) {
+                        Box(
+                            modifier = Modifier
+                                .size(size = 6.dp)
+                                .background(
+                                    color = if (isSelected) {
+                                        LemonadeTheme.colors.content.contentOnBrandHigh
+                                    } else {
+                                        LemonadeTheme.colors.content.contentBrand
+                                    },
+                                    shape = CircleShape,
+                                ),
+                        )
+                    }
+                },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "Short day labels (Mon, Tue, Wed...)") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                dayLabelFormat = DayLabelFormat.Short,
+                onDateSelected = { /* observe state.selectedDate */ },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "Constrained range (7 days before to 30 days after)") {
+            val minDate = remember { today.plus(-7, DateTimeUnit.DAY) }
+            val maxDate = remember { today.plus(30, DateTimeUnit.DAY) }
+            val state = rememberInlineCalendarState(
+                initialDate = today,
+                minDate = minDate,
+                maxDate = maxDate,
+            )
+            LemonadeUi.InlineCalendar(
+                state = state,
+                onDateSelected = { /* observe state.selectedDate */ },
+            )
+            LemonadeUi.Text(
+                text = "Range: ${formatInlineDate(minDate)} - ${formatInlineDate(maxDate)}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "Compact selection (day number only)") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                expandSelectionToLabel = false,
+                onDateSelected = { /* observe state.selectedDate */ },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "Compact selection with trailing dots") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                expandSelectionToLabel = false,
+                onDateSelected = { /* observe state.selectedDate */ },
+                enabledDates = { date -> date.day % 3 == 0 },
+                trailingContent = { date, isSelected ->
+                    if (date.day % 3 == 0) {
+                        Box(
+                            modifier = Modifier
+                                .size(size = 6.dp)
+                                .background(
+                                    color = if (isSelected) {
+                                        LemonadeTheme.colors.content.contentOnBrandHigh
+                                    } else {
+                                        LemonadeTheme.colors.content.contentBrand
+                                    },
+                                    shape = CircleShape,
+                                ),
+                        )
+                    }
+                },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+
+        InlineCalendarSection(title = "Custom selection colors") {
+            val state = rememberInlineCalendarState(initialDate = today)
+            LemonadeUi.InlineCalendar(
+                state = state,
+                selectionBackgroundColor = LemonadeTheme.colors.interaction.bgInfoInteractive,
+                selectionContentColor = LemonadeTheme.colors.content.contentAlwaysLight,
+                onDateSelected = { /* observe state.selectedDate */ },
+            )
+            LemonadeUi.Text(
+                text = "Selected: ${state.selectedDate?.let { formatInlineDate(it) } ?: "none"}",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InlineCalendarSection(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+    ) {
+        LemonadeUi.Text(
+            text = title,
+            textStyle = LemonadeTheme.typography.headingXSmall,
+            color = LemonadeTheme.colors.content.contentSecondary,
+        )
+        content()
+    }
+}
+
+private fun formatInlineDate(date: LocalDate): String = "${date.day}/${date.month.number}/${date.year}"

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/app/App.kt
@@ -18,6 +18,7 @@ import com.teya.lemonade.DividerDisplay
 import com.teya.lemonade.HomeDisplay
 import com.teya.lemonade.IconButtonDisplay
 import com.teya.lemonade.IconsDisplay
+import com.teya.lemonade.InlineCalendarDisplay
 import com.teya.lemonade.LinkDisplay
 import com.teya.lemonade.NoticeDisplay
 import com.teya.lemonade.OpacityDisplay
@@ -85,6 +86,7 @@ internal val screens: Map<Displays, @Composable (onNavigate: (Displays) -> Unit)
     Displays.Divider to { _ -> DividerDisplay() },
     Displays.Tabs to { _ -> TabsDisplay() },
     Displays.DatePicker to { _ -> DatePickerDisplay() },
+    Displays.InlineCalendar to { _ -> InlineCalendarDisplay() },
     Displays.Notice to { _ -> NoticeDisplay() },
     Displays.Toast to { _ -> ToastDisplay() },
 )

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/DayLabelFormat.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/DayLabelFormat.kt
@@ -1,0 +1,12 @@
+package com.teya.lemonade.core
+
+/**
+ * Format for weekday labels shown above calendar day cells.
+ */
+public enum class DayLabelFormat {
+    /** Single character, e.g. "M", "T", "W". */
+    Narrow,
+
+    /** Three characters, e.g. "Mon", "Tue", "Wed". */
+    Short,
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarDayCell.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarDayCell.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+// MARK: - Accessibility Formatter
+
+/// Shared date formatter for generating VoiceOver-friendly date labels.
+///
+/// Produces full date strings such as "Thursday, April 2, 2026". Defined at
+/// file scope so it is allocated exactly once for the process - `DateFormatter`
+/// initialization is expensive due to ObjC bridging and locale loading. Cannot
+/// live as a static stored property on `CalendarDayCell` because that struct
+/// is generic over `TrailingContent`, and Swift forbids static stored properties
+/// on generic types.
+private let calendarDayCellAccessibilityFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .full
+    return formatter
+}()
+
+// MARK: - Calendar Day Cell
+
+/// A generic day cell that wraps ``ContentCellView`` with an optional weekday label
+/// on top and an optional trailing content slot below.
+///
+/// Used by both ``LemonadeUi/DatePicker`` and ``LemonadeUi/InlineCalendar``
+/// to render individual day cells with consistent styling.
+///
+/// - Parameters:
+///   - TrailingContent: The type of view displayed below the day number.
+struct CalendarDayCell<TrailingContent: View>: View {
+
+    // MARK: - Properties
+
+    let date: Date?
+    let text: String
+    let isCurrent: Bool
+    let isSelected: Bool
+    let isEnabled: Bool
+    let isOutsideVisibleRange: Bool
+    let isInsideSelectedRange: Bool
+    let showWeekdayLabel: Bool
+    let weekdayLabel: String?
+    /// Controls the extent of the selection background when `showWeekdayLabel` is `true`.
+    ///
+    /// When `true` (default), the brand background covers the entire cell - weekday
+    /// label, day number, and trailing content. When `false`, only the day number
+    /// circle draws the brand background (DatePicker style), and the weekday label
+    /// retains its default color.
+    let expandSelectionToLabel: Bool
+    let selectionBackgroundColor: Color?
+    let selectionContentColor: Color?
+    let onClick: () -> Void
+    let trailingContent: () -> TrailingContent
+
+    init(
+        date: Date? = nil,
+        text: String,
+        isCurrent: Bool,
+        isSelected: Bool,
+        isEnabled: Bool,
+        isOutsideVisibleRange: Bool,
+        isInsideSelectedRange: Bool = false,
+        showWeekdayLabel: Bool = true,
+        weekdayLabel: String? = nil,
+        expandSelectionToLabel: Bool = true,
+        selectionBackgroundColor: Color? = nil,
+        selectionContentColor: Color? = nil,
+        onClick: @escaping () -> Void,
+        @ViewBuilder trailingContent: @escaping () -> TrailingContent = { EmptyView() }
+    ) {
+        self.date = date
+        self.text = text
+        self.isCurrent = isCurrent
+        self.isSelected = isSelected
+        self.isEnabled = isEnabled
+        self.isOutsideVisibleRange = isOutsideVisibleRange
+        self.isInsideSelectedRange = isInsideSelectedRange
+        self.showWeekdayLabel = showWeekdayLabel
+        self.weekdayLabel = weekdayLabel
+        self.expandSelectionToLabel = expandSelectionToLabel
+        self.selectionBackgroundColor = selectionBackgroundColor
+        self.selectionContentColor = selectionContentColor
+        self.onClick = onClick
+        self.trailingContent = trailingContent
+    }
+
+    /// Returns a VoiceOver-friendly label for the cell.
+    ///
+    /// If a `date` is provided, returns the full date string (e.g. "Thursday, April 2, 2026").
+    /// Otherwise falls back to the display text (day number).
+    private var cellAccessibilityLabel: String {
+        if let date = date {
+            return calendarDayCellAccessibilityFormatter.string(from: date)
+        }
+        return text
+    }
+
+    /// The text color for the weekday label, adapting to selection state.
+    ///
+    /// When the cell is selected and `expandSelectionToLabel` is `true`, the label
+    /// switches to an inverse color so it remains legible against the dark selection
+    /// background. When `expandSelectionToLabel` is `false`, the brand background
+    /// only covers the day number, so the weekday label keeps its default color.
+    private var weekdayLabelColor: Color {
+        if isSelected && expandSelectionToLabel {
+            return selectionContentColor ?? LemonadeTheme.colors.content.contentOnBrandHigh
+        }
+        return LemonadeTheme.colors.content.contentPrimary
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if showWeekdayLabel, let label = weekdayLabel {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodyXSmallOverline,
+                    color: weekdayLabelColor
+                )
+                .frame(maxWidth: .infinity)
+            }
+
+            // When expandSelectionToLabel is false, wrap the day number +
+            // trailing content in their own selection background so the weekday
+            // label stays outside the highlight.
+            VStack(spacing: 0) {
+                ContentCellView(
+                    text: text,
+                    accessibilityLabel: cellAccessibilityLabel,
+                    isCurrent: isCurrent,
+                    isSelected: isSelected,
+                    isEnabled: isEnabled,
+                    isOutsideVisibleRange: isOutsideVisibleRange,
+                    isInsideSelectedRange: isInsideSelectedRange,
+                    showSelectionBackground: false,
+                    showTodayIndicator: false,
+                    selectionContentColor: selectionContentColor,
+                    onClick: onClick
+                )
+
+                trailingContent()
+            }
+            .padding(.vertical, !expandSelectionToLabel ? LemonadeTheme.spaces.spacing100 : 0)
+            .background(
+                Group {
+                    if !expandSelectionToLabel && isSelected {
+                        // Negative horizontal padding extends the background into the
+                        // outer VStack's padding area so the compact selection matches
+                        // the expanded selection width.
+                        RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius400)
+                            .fill(selectionBackgroundColor ?? LemonadeTheme.colors.interaction.bgBrandInteractive)
+                            .padding(.horizontal, -LemonadeTheme.spaces.spacing100)
+                            .padding(.vertical, -LemonadeTheme.spaces.spacing100)
+                    }
+                }
+            )
+        }
+        .padding(.horizontal, LemonadeTheme.spaces.spacing100)
+        .padding(.vertical, LemonadeTheme.spaces.spacing100)
+        .background(
+            Group {
+                if showWeekdayLabel && expandSelectionToLabel && isSelected {
+                    RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius400)
+                        .fill(selectionBackgroundColor ?? LemonadeTheme.colors.interaction.bgBrandInteractive)
+                }
+            }
+        )
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarMonthHeader.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarMonthHeader.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+// MARK: - Calendar Month Header
+
+/// A reusable month header with navigation arrows used by calendar components.
+///
+/// Displays a centered month/year label flanked by previous and next navigation buttons.
+/// Used internally by ``LemonadeUi/DatePicker`` and ``LemonadeUi/InlineCalendar``.
+struct CalendarMonthHeader: View {
+    let headerLabel: String
+    let canGoPrev: Bool
+    let canGoNext: Bool
+    let onPrev: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        HStack {
+            LemonadeUi.IconButton(
+                icon: .chevronLeft,
+                contentDescription: NSLocalizedString("calendar.navigation.previous_month", value: "Previous month", comment: "VoiceOver label for previous month navigation button"),
+                onClick: onPrev,
+                enabled: canGoPrev,
+                variant: .ghost
+            )
+
+            Spacer()
+
+            headerText
+
+            Spacer()
+
+            LemonadeUi.IconButton(
+                icon: .chevronRight,
+                contentDescription: NSLocalizedString("calendar.navigation.next_month", value: "Next month", comment: "VoiceOver label for next month navigation button"),
+                onClick: onNext,
+                enabled: canGoNext,
+                variant: .ghost
+            )
+        }
+    }
+
+    /// Header label with a 150ms cross-fade transition driven by `headerLabel`
+    /// changes. Mirrors the Compose reference, which wraps the header text in
+    /// `AnimatedContent` with `fadeIn(tween(150)) togetherWith fadeOut(tween(150))`.
+    /// On iOS 16+ `.contentTransition(.opacity)` makes the cross-fade explicit;
+    /// on iOS 15 the value-driven `.animation(...)` still produces a SwiftUI
+    /// implicit text animation, which degrades gracefully without breaking.
+    @ViewBuilder
+    private var headerText: some View {
+        let label = LemonadeUi.Text(
+            headerLabel,
+            textStyle: LemonadeTypography.shared.bodySmallSemiBold,
+            color: LemonadeTheme.colors.content.contentPrimary
+        )
+
+        if #available(iOS 16.0, macOS 13.0, *) {
+            label
+                .contentTransition(.opacity)
+                .animation(.easeInOut(duration: 0.15), value: headerLabel)
+        } else {
+            label
+                .animation(.easeInOut(duration: 0.15), value: headerLabel)
+        }
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+// MARK: - Calendar Utilities
+
+/// Shared date utilities used by calendar components.
+///
+/// Contains helpers for date normalization, month grid generation,
+/// and label formatting used by both ``LemonadeUi/DatePicker`` and
+/// ``LemonadeUi/InlineCalendar``.
+enum CalendarUtils {
+
+    // MARK: - Date Normalization
+
+    /// Returns the start of day for the given date, stripping time components.
+    static func startOfDay(_ date: Date, calendar: Calendar = .current) -> Date {
+        calendar.startOfDay(for: date)
+    }
+
+    // MARK: - Month Boundaries
+
+    /// Returns the last day of the given month as a `Date`, or `nil` if the date cannot be constructed.
+    static func lastDayOfMonth(year: Int, month: Int, calendar: Calendar) -> Date? {
+        var components = DateComponents(year: year, month: month)
+        guard let monthDate = calendar.date(from: components),
+              let range = calendar.range(of: .day, in: .month, for: monthDate) else { return nil }
+        components.day = range.upperBound - 1
+        return calendar.date(from: components)
+    }
+
+    // MARK: - Month Grid Generation
+
+    /// Generate 42 dates (6 weeks) for a given month, with leading/trailing days.
+    ///
+    /// The grid always starts on the calendar's `firstWeekday` and fills
+    /// exactly 6 rows of 7 columns, padding with days from adjacent months.
+    static func generateMonthDays(year: Int, month: Int, calendar: Calendar) -> [Date] {
+        guard let firstOfMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1)) else {
+            return []
+        }
+        let weekday = calendar.component(.weekday, from: firstOfMonth) // 1=Sun, 7=Sat
+        let firstDayOffset = (weekday - calendar.firstWeekday + 7) % 7
+
+        var days: [Date] = []
+
+        // Previous month trailing days
+        for i in (0..<firstDayOffset).reversed() {
+            guard let date = calendar.date(byAdding: .day, value: -(i + 1), to: firstOfMonth) else { return [] }
+            days.append(date)
+        }
+
+        // Current month days
+        guard let range = calendar.range(of: .day, in: .month, for: firstOfMonth) else { return [] }
+        for day in range {
+            guard let date = calendar.date(from: DateComponents(year: year, month: month, day: day)) else { return [] }
+            days.append(date)
+        }
+
+        // Next month leading days
+        var nextDay = 1
+        guard let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: firstOfMonth) else { return [] }
+        while days.count < 42 {
+            guard let date = calendar.date(byAdding: .day, value: nextDay - 1, to: nextMonthStart) else { return [] }
+            days.append(date)
+            nextDay += 1
+        }
+
+        return days
+    }
+
+    // MARK: - Inline Calendar Helpers
+
+    /// Returns only the days that belong to the given month (no padding from adjacent months).
+    ///
+    /// - Parameters:
+    ///   - year: The year of the month.
+    ///   - month: The month number (1-12).
+    ///   - calendar: The calendar to use for date calculations.
+    /// - Returns: An array of `Date` values for each day in the month.
+    static func daysForMonth(year: Int, month: Int, calendar: Calendar) -> [Date] {
+        guard let firstOfMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
+              let range = calendar.range(of: .day, in: .month, for: firstOfMonth) else { return [] }
+        return range.compactMap { day in
+            calendar.date(from: DateComponents(year: year, month: month, day: day))
+        }
+    }
+
+    /// Returns up to `count` days from the end of the previous month.
+    ///
+    /// Used to show "peek" days before the current month in an inline calendar.
+    ///
+    /// - Parameters:
+    ///   - year: The year of the current month.
+    ///   - month: The current month number (1-12).
+    ///   - count: Maximum number of days to return.
+    ///   - calendar: The calendar to use for date calculations.
+    /// - Returns: An array of `Date` values from the previous month, ordered chronologically.
+    static func peekDaysBefore(year: Int, month: Int, count: Int, calendar: Calendar) -> [Date] {
+        guard let firstOfMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
+              let prevMonthEnd = calendar.date(byAdding: .day, value: -1, to: firstOfMonth) else {
+            return []
+        }
+        let prevYM = calendar.dateComponents([.year, .month], from: prevMonthEnd)
+        guard let prevYear = prevYM.year, let prevMonth = prevYM.month else { return [] }
+        let prevRange = calendar.range(of: .day, in: .month, for: prevMonthEnd)
+        let prevDayCount = prevRange?.count ?? 0
+        let startDay = max(1, prevDayCount - count + 1)
+        var result: [Date] = []
+        for day in startDay...prevDayCount {
+            if let date = calendar.date(from: DateComponents(year: prevYear, month: prevMonth, day: day)) {
+                result.append(date)
+            }
+        }
+        return result
+    }
+
+    /// Returns up to `count` days from the beginning of the next month.
+    ///
+    /// Used to show "peek" days after the current month in an inline calendar.
+    ///
+    /// - Parameters:
+    ///   - year: The year of the current month.
+    ///   - month: The current month number (1-12).
+    ///   - count: Maximum number of days to return.
+    ///   - calendar: The calendar to use for date calculations.
+    /// - Returns: An array of `Date` values from the next month, ordered chronologically.
+    static func peekDaysAfter(year: Int, month: Int, count: Int, calendar: Calendar) -> [Date] {
+        guard let firstOfMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
+              let nextMonth = calendar.date(byAdding: .month, value: 1, to: firstOfMonth) else { return [] }
+        let nextYM = calendar.dateComponents([.year, .month], from: nextMonth)
+        guard let nextYear = nextYM.year, let nextMonth = nextYM.month else { return [] }
+        let nextDays = daysForMonth(year: nextYear, month: nextMonth, calendar: calendar)
+        return Array(nextDays.prefix(count))
+    }
+
+    /// Returns a formatted "Month Year" label for the given date components.
+    ///
+    /// - Parameters:
+    ///   - yearMonth: Date components containing at least `.year` and `.month`.
+    ///   - monthFormatter: A closure that converts a month number (1-12) to a display string.
+    /// - Returns: A string in the format "Month Year" (e.g. "April 2026").
+    static func monthYearLabel(
+        for yearMonth: DateComponents,
+        monthFormatter: (Int) -> String
+    ) -> String {
+        guard let month = yearMonth.month, let year = yearMonth.year else { return "" }
+        return "\(monthFormatter(month)) \(year)"
+    }
+
+    /// Returns an array of 7 weekday labels starting from the calendar's first weekday.
+    ///
+    /// - Parameters:
+    ///   - format: The label format (`.narrow` for single-letter, `.short` for abbreviated).
+    ///   - calendar: The calendar to use for determining first weekday and symbols.
+    /// - Returns: An array of 7 weekday label strings.
+    static func weekdayLabels(format: DayLabelFormat, calendar: Calendar = .current) -> [String] {
+        let symbols: [String]
+        switch format {
+        case .narrow:
+            symbols = calendar.veryShortWeekdaySymbols
+        case .short:
+            symbols = calendar.shortWeekdaySymbols
+        }
+        let first = calendar.firstWeekday - 1 // 0-indexed
+        return (0..<7).map { symbols[(first + $0) % 7] }
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/ContentCellView.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/ContentCellView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+// MARK: - Content Cell Button Style
+
+/// A button style that scales the cell slightly on press, mimicking the
+/// tap-feedback ripple from the Compose reference.
+///
+/// Uses a short spring so the scale-down on touch-down and rebound on
+/// release absorbs rapid taps without a linear-looking jitter.
+private struct CalendarCellPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .animation(
+                .spring(response: 0.25, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
+    }
+}
+
+// MARK: - Content Cell View
+
+/// A reusable cell view used internally by calendar components.
+///
+/// Renders a single day number with the appropriate styling based on its state
+/// (current day, selected, disabled, outside visible month, or inside a selected range).
+struct ContentCellView: View {
+    let text: String
+    let accessibilityLabel: String
+    let isCurrent: Bool
+    let isSelected: Bool
+    let isEnabled: Bool
+    let isOutsideVisibleRange: Bool
+    let isInsideSelectedRange: Bool
+    let showSelectionBackground: Bool
+    let showTodayIndicator: Bool
+    let selectionContentColor: Color?
+    let onClick: () -> Void
+
+    init(
+        text: String,
+        accessibilityLabel: String,
+        isCurrent: Bool,
+        isSelected: Bool,
+        isEnabled: Bool,
+        isOutsideVisibleRange: Bool,
+        isInsideSelectedRange: Bool,
+        showSelectionBackground: Bool = true,
+        showTodayIndicator: Bool? = nil,
+        selectionContentColor: Color? = nil,
+        onClick: @escaping () -> Void
+    ) {
+        self.text = text
+        self.accessibilityLabel = accessibilityLabel
+        self.isCurrent = isCurrent
+        self.isSelected = isSelected
+        self.isEnabled = isEnabled
+        self.isOutsideVisibleRange = isOutsideVisibleRange
+        self.isInsideSelectedRange = isInsideSelectedRange
+        self.showSelectionBackground = showSelectionBackground
+        self.showTodayIndicator = showTodayIndicator ?? showSelectionBackground
+        self.selectionContentColor = selectionContentColor
+        self.onClick = onClick
+    }
+
+    private var textColor: Color {
+        if !isEnabled {
+            return LemonadeTheme.colors.content.contentTertiary
+        } else if isSelected {
+            return selectionContentColor ?? LemonadeTheme.colors.content.contentOnBrandHigh
+        } else if isInsideSelectedRange {
+            return LemonadeTheme.colors.content.contentOnBrandHigh
+        } else if isCurrent {
+            return LemonadeTheme.colors.content.contentBrand
+        } else if isOutsideVisibleRange {
+            return LemonadeTheme.colors.content.contentSecondary
+        } else {
+            return LemonadeTheme.colors.content.contentPrimary
+        }
+    }
+
+    private var textStyle: LemonadeTextStyle {
+        isCurrent
+            ? LemonadeTypography.shared.bodyMediumSemiBold
+            : LemonadeTypography.shared.bodyMediumMedium
+    }
+
+    private var backgroundColor: Color {
+        isSelected && showSelectionBackground
+            ? LemonadeTheme.colors.interaction.bgBrandInteractive
+            : Color.clear
+    }
+
+    var body: some View {
+        SwiftUI.Button(action: onClick) {
+            ZStack(alignment: .bottom) {
+                LemonadeUi.Text(
+                    text,
+                    textStyle: textStyle,
+                    color: textColor
+                )
+                .padding(.vertical, LemonadeTheme.spaces.spacing200)
+
+                if isCurrent && showTodayIndicator {
+                    Circle()
+                        .fill(textColor)
+                        .frame(
+                            width: LemonadeTheme.spaces.spacing100,
+                            height: LemonadeTheme.spaces.spacing100
+                        )
+                        .padding(.bottom, LemonadeTheme.spaces.spacing100)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200)
+                    .fill(backgroundColor)
+            )
+        }
+        .buttonStyle(CalendarCellPressStyle())
+        .disabled(!isEnabled)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(isEnabled ? NSLocalizedString("calendar.cell.hint.select", value: "Double tap to select", comment: "VoiceOver hint for selectable calendar day cell") : "")
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/DayLabelFormat.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/DayLabelFormat.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// MARK: - Day Label Format
+
+/// Controls how weekday labels are displayed in calendar components.
+///
+/// Used by ``LemonadeUi/InlineCalendar`` to determine whether weekday headers
+/// show single-letter abbreviations or short abbreviations.
+public enum DayLabelFormat {
+    /// Single-letter weekday labels (e.g. "S", "M", "T").
+    ///
+    /// Maps to `Calendar.veryShortWeekdaySymbols`.
+    case narrow
+
+    /// Short weekday labels (e.g. "Sun", "Mon", "Tue").
+    ///
+    /// Maps to `Calendar.shortWeekdaySymbols`.
+    case short
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/LemonadeInlineCalendar.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/LemonadeInlineCalendar.swift
@@ -1,0 +1,769 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Public API
+
+public extension LemonadeUi {
+    /// An inline (horizontal-scrolling) calendar component from the Lemonade Design System.
+    ///
+    /// Displays a continuous horizontal scroll strip spanning approximately 10 years
+    /// (5 years before and after today) using index-based virtual scrolling. The header
+    /// label updates to reflect which month occupies the center of the viewport.
+    /// Arrow buttons navigate month-by-month.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// @StateObject var state = LemonadeInlineCalendarState()
+    ///
+    /// LemonadeUi.InlineCalendar(state: state)
+    ///
+    /// // With trailing content dots:
+    /// LemonadeUi.InlineCalendar(state: state) { date in
+    ///     Circle()
+    ///         .fill(hasEvent(date) ? Color.red : Color.clear)
+    ///         .frame(width: 6, height: 6)
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - state: The calendar state managing selection, displayed month, and bounds.
+    ///     Observe ``LemonadeInlineCalendarState/selectedDate`` via `onChange(of:)`.
+    ///   - dayLabelFormat: Format for weekday labels above each cell.
+    ///     Defaults to `.narrow` (single letter).
+    ///   - expandSelectionToLabel: When `true` (default), the brand background covers
+    ///     the full cell - weekday label, day number, and trailing content. When `false`,
+    ///     only the day number circle is highlighted (DatePicker style).
+    ///   - onMonthDisplayed: Optional callback invoked when the displayed month changes.
+    ///     Receives a `DateComponents` with `.year` and `.month` set.
+    ///   - enabledDates: Optional closure that determines which dates are tappable.
+    ///     When provided, a date is enabled only when this closure returns `true`.
+    ///     When `nil`, falls back to the default `minDate`/`maxDate` logic.
+    ///   - selectionBackgroundColor: Optional color override for the selection background.
+    ///     When `nil`, defaults to the brand interactive background color.
+    ///   - selectionContentColor: Optional color override for text on selected cells.
+    ///     When `nil`, defaults to `contentOnBrandHigh`.
+    ///   - trailingContent: Optional view builder providing content below each day cell.
+    ///     Receives the `Date` and a `Bool` indicating whether the date is selected.
+    ///     Max height is 16pt (clipped).
+    @ViewBuilder
+    static func InlineCalendar<TrailingContent: View>(
+        state: LemonadeInlineCalendarState,
+        dayLabelFormat: DayLabelFormat = .narrow,
+        expandSelectionToLabel: Bool = true,
+        onMonthDisplayed: ((DateComponents) -> Void)? = nil,
+        enabledDates: ((Date) -> Bool)? = nil,
+        selectionBackgroundColor: Color? = nil,
+        selectionContentColor: Color? = nil,
+        @ViewBuilder trailingContent: @escaping (Date, Bool) -> TrailingContent
+    ) -> some View {
+        LemonadeInlineCalendarView(
+            state: state,
+            dayLabelFormat: dayLabelFormat,
+            expandSelectionToLabel: expandSelectionToLabel,
+            enabledDates: enabledDates,
+            onMonthDisplayed: onMonthDisplayed,
+            selectionBackgroundColor: selectionBackgroundColor,
+            selectionContentColor: selectionContentColor,
+            trailingContent: trailingContent
+        )
+    }
+
+    /// An inline (horizontal-scrolling) calendar component from the Lemonade Design System.
+    ///
+    /// Convenience overload without trailing content.
+    ///
+    /// - Parameters:
+    ///   - state: The calendar state managing selection, displayed month, and bounds.
+    ///   - dayLabelFormat: Format for weekday labels above each cell.
+    ///   - expandSelectionToLabel: When `true` (default), the brand background covers
+    ///     the full cell - weekday label, day number, and trailing content. When `false`,
+    ///     only the day number circle is highlighted (DatePicker style).
+    ///   - onMonthDisplayed: Optional callback invoked when the displayed month changes.
+    ///   - enabledDates: Optional closure that determines which dates are tappable.
+    ///   - selectionBackgroundColor: Optional color override for the selection background.
+    ///     When `nil`, defaults to the brand interactive background color.
+    ///   - selectionContentColor: Optional color override for text on selected cells.
+    ///     When `nil`, defaults to `contentOnBrandHigh`.
+    @ViewBuilder
+    static func InlineCalendar(
+        state: LemonadeInlineCalendarState,
+        dayLabelFormat: DayLabelFormat = .narrow,
+        expandSelectionToLabel: Bool = true,
+        onMonthDisplayed: ((DateComponents) -> Void)? = nil,
+        enabledDates: ((Date) -> Bool)? = nil,
+        selectionBackgroundColor: Color? = nil,
+        selectionContentColor: Color? = nil
+    ) -> some View {
+        LemonadeInlineCalendarView(
+            state: state,
+            dayLabelFormat: dayLabelFormat,
+            expandSelectionToLabel: expandSelectionToLabel,
+            enabledDates: enabledDates,
+            onMonthDisplayed: onMonthDisplayed,
+            selectionBackgroundColor: selectionBackgroundColor,
+            selectionContentColor: selectionContentColor,
+            trailingContent: { _, _ in EmptyView() }
+        )
+    }
+}
+
+// MARK: - Constants
+
+/// Virtual scroll range (~+/- 5 years). Odd so `centerIndex` has equal days on each side.
+private let totalDays = 3651
+private let centerIndex = totalDays / 2
+
+/// Time before a programmatic scroll intent is abandoned. Must exceed the
+/// `.spring(response: 0.35)` animation settle time (~350ms) plus gesture
+/// recognition margin.
+private let scrollIntentAbandonNanos: UInt64 = 600_000_000
+
+/// Estimated height of the weekday label text (bodyXSmallOverline metrics).
+private let calendarWeekdayLabelHeight: CGFloat = 16
+
+/// Estimated height of the day number cell (bodyMediumMedium metrics + vertical padding).
+private let calendarDayCellHeight: CGFloat = 36
+
+// MARK: - Scroll Tracking Types
+
+private struct ScrollContentOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+/// Programmatic scroll target. `id` is bumped per request so `onChange` fires
+/// even when consecutive targets are equal.
+private struct ProgrammaticScrollRequest: Equatable {
+    let id: Int
+    let index: Int
+}
+
+/// Maps a measured content offset to the virtual day index it corresponds to.
+private struct OffsetCalibration {
+    let offset: CGFloat
+    let index: Int
+}
+
+private let scrollCoordinateSpaceName = "lemonadeInlineCalendarScroll"
+
+// MARK: - Internal View
+
+private struct LemonadeInlineCalendarView<TrailingContent: View>: View {
+    @ObservedObject var state: LemonadeInlineCalendarState
+    let dayLabelFormat: DayLabelFormat
+    let expandSelectionToLabel: Bool
+    let enabledDates: ((Date) -> Bool)?
+    let onMonthDisplayed: ((DateComponents) -> Void)?
+    let selectionBackgroundColor: Color?
+    let selectionContentColor: Color?
+    let trailingContent: (Date, Bool) -> TrailingContent
+
+    @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.calendar) private var calendar
+
+    @State private var visibleCenterIndex: Int = centerIndex
+    @State private var observedScrollPositionIndex: Int?
+    @State private var didInitialScroll = false
+    @State private var offsetCalibration: OffsetCalibration?
+    @State private var programmaticScrollTarget: ProgrammaticScrollRequest?
+    @State private var lastObservedHeaderMonth: DateComponents?
+
+    /// Set on a cross-month tap so the next header transition into that month
+    /// suppresses its scroll-driven haptic (the tap already fired one).
+    @State private var pendingSelectionMonthChange: DateComponents?
+
+    /// Pinned at view init so the index space stays stable across midnight,
+    /// matching the Compose reference's `remember { today }`.
+    /// Re-derived from the environment calendar in the initial scroll `.task`.
+    @State private var anchorDate: Date = Date()
+
+    /// `Calendar.monthSymbols` allocates a fresh array on every access; cache
+    /// it and refresh via `onChange(of: calendar)` in `body`.
+    @State private var cachedMonthSymbols: [String] = []
+
+    /// Shared so the Taptic Engine stays warm; allocating per-haptic would
+    /// re-pay the warmup cost on every cell tap and month crossing.
+#if canImport(UIKit)
+    @State private var selectionFeedbackGenerator = UISelectionFeedbackGenerator()
+#endif
+
+    private var visibleCellCount: CGFloat {
+        sizeCategory.isAccessibilityCategory ? 5 : 7
+    }
+
+    private var weekdayLabels: [String] {
+        CalendarUtils.weekdayLabels(format: dayLabelFormat, calendar: calendar)
+    }
+
+    // MARK: - Index-Date Mapping
+
+    /// Clipped to the `minDate`/`maxDate` window with one viewport of disabled
+    /// padding (matches Compose `rangePadding = visibleCells`).
+    private var indexRange: Range<Int> {
+        let padding = Int(visibleCellCount)
+        var lower = 0
+        var upper = totalDays
+        if let minDate = state.minDate {
+            lower = max(0, dateToIndex(minDate) - padding)
+        }
+        if let maxDate = state.maxDate {
+            upper = min(totalDays, dateToIndex(maxDate) + padding + 1)
+        }
+        guard lower < upper else { return 0..<totalDays }
+        return lower..<upper
+    }
+
+    private func clampedIndex(_ index: Int) -> Int {
+        let range = indexRange
+        return min(max(index, range.lowerBound), range.upperBound - 1)
+    }
+
+    private func indexToDate(_ index: Int) -> Date {
+        calendar.date(byAdding: .day, value: index - centerIndex, to: anchorDate) ?? anchorDate
+    }
+
+    private func dateToIndex(_ date: Date) -> Int {
+        let days = calendar.dateComponents(
+            [.day],
+            from: anchorDate,
+            to: CalendarUtils.startOfDay(date, calendar: calendar)
+        ).day ?? 0
+        return centerIndex + days
+    }
+
+    // MARK: - Header Month
+
+    private var headerMonth: DateComponents {
+        let date = indexToDate(clampedIndex(visibleCenterIndex))
+        return DateComponents(
+            year: calendar.component(.year, from: date),
+            month: calendar.component(.month, from: date)
+        )
+    }
+
+    private var monthYearLabel: String {
+        CalendarUtils.monthYearLabel(for: headerMonth) { monthNum in
+            let symbols = cachedMonthSymbols.isEmpty ? calendar.monthSymbols : cachedMonthSymbols
+            return symbols[monthNum - 1]
+        }
+    }
+
+    // MARK: - Navigation Helpers
+
+    /// Centers the viewport on the 1st of `headerMonth + delta`. When called
+    /// while a previous request is still in flight, chains off that target so
+    /// rapid clicks accumulate instead of restarting from the visible month.
+    private func navigateMonth(delta: Int) {
+        let baseMonth: DateComponents
+        if let pendingTarget = programmaticScrollTarget {
+            let pendingDate = indexToDate(pendingTarget.index)
+            baseMonth = calendar.dateComponents([.year, .month], from: pendingDate)
+        } else {
+            baseMonth = headerMonth
+        }
+
+        guard let year = baseMonth.year,
+              let month = baseMonth.month,
+              let firstOfCurrentMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
+              let firstOfTargetMonth = calendar.date(byAdding: .month, value: delta, to: firstOfCurrentMonth) else {
+            return
+        }
+
+        let targetIndex = clampedIndex(dateToIndex(firstOfTargetMonth))
+        let nextId = (programmaticScrollTarget?.id ?? 0) + 1
+        programmaticScrollTarget = ProgrammaticScrollRequest(id: nextId, index: targetIndex)
+    }
+
+    // MARK: - Helpers
+
+    private func isSameMonth(_ lhs: DateComponents, _ rhs: DateComponents) -> Bool {
+        lhs.year == rhs.year && lhs.month == rhs.month
+    }
+
+    private func performCalendarHaptic() {
+#if canImport(UIKit)
+        selectionFeedbackGenerator.selectionChanged()
+        selectionFeedbackGenerator.prepare()
+#endif
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            CalendarMonthHeader(
+                headerLabel: monthYearLabel,
+                canGoPrev: state.canGoPrev(calendar: calendar),
+                canGoNext: state.canGoNext(calendar: calendar),
+                onPrev: { navigateMonth(delta: -1) },
+                onNext: { navigateMonth(delta: 1) }
+            )
+            .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+
+            Spacer().frame(height: LemonadeTheme.spaces.spacing200)
+
+            GeometryReader { geo in
+                let viewportWidth = geo.size.width
+                let cellWidth = viewportWidth / visibleCellCount
+
+                if #available(iOS 17.0, macOS 14.0, *) {
+                    ios17ScrollView(cellWidth: cellWidth, viewportWidth: viewportWidth)
+                } else {
+                    legacyScrollView(cellWidth: cellWidth, viewportWidth: viewportWidth)
+                }
+            }
+            .frame(height: estimatedRowHeight)
+        }
+        .accessibilityElement(children: .contain)
+        .onAppear {
+            if lastObservedHeaderMonth == nil {
+                lastObservedHeaderMonth = headerMonth
+            }
+            cachedMonthSymbols = calendar.monthSymbols
+#if canImport(UIKit)
+            selectionFeedbackGenerator.prepare()
+#endif
+        }
+        .onChange(of: calendar) { newCalendar in
+            cachedMonthSymbols = newCalendar.monthSymbols
+        }
+        .onChange(of: headerMonth) { newMonth in
+            state.navigate(toMonth: newMonth, calendar: calendar)
+
+            guard let previousMonth = lastObservedHeaderMonth else {
+                lastObservedHeaderMonth = newMonth
+                return
+            }
+
+            guard !isSameMonth(previousMonth, newMonth) else {
+                lastObservedHeaderMonth = newMonth
+                return
+            }
+
+            guard didInitialScroll else {
+                pendingSelectionMonthChange = nil
+                lastObservedHeaderMonth = newMonth
+                return
+            }
+
+            // Only fire callback after initial scroll is done
+            onMonthDisplayed?(newMonth)
+
+            let shouldSuppressMonthHaptic = pendingSelectionMonthChange
+                .map { isSameMonth($0, newMonth) } ?? false
+            pendingSelectionMonthChange = nil
+
+            if !shouldSuppressMonthHaptic {
+                performCalendarHaptic()
+            }
+
+            if let target = programmaticScrollTarget {
+                let targetMonth = calendar.dateComponents([.year, .month], from: indexToDate(target.index))
+                if isSameMonth(targetMonth, newMonth) {
+                    programmaticScrollTarget = nil
+                }
+            }
+
+            lastObservedHeaderMonth = newMonth
+        }
+        // Abandon stale programmatic scroll intent if the user drags away
+        // before the animation reaches the target.
+        .task(id: programmaticScrollTarget?.id) {
+            guard programmaticScrollTarget != nil else { return }
+            do {
+                try await Task.sleep(nanoseconds: scrollIntentAbandonNanos)
+            } catch {
+                return
+            }
+            programmaticScrollTarget = nil
+        }
+    }
+
+    // MARK: - iOS 17+ Scroll View
+
+    @available(iOS 17.0, macOS 14.0, *)
+    @ViewBuilder
+    private func ios17ScrollView(cellWidth: CGFloat, viewportWidth: CGFloat) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 0) {
+                    ForEach(indexRange, id: \.self) { index in
+                        dayCellView(for: index, cellWidth: cellWidth)
+                            .id(index)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.viewAligned)
+            .scrollPosition(id: $observedScrollPositionIndex, anchor: .center)
+            .task {
+                guard !didInitialScroll else { return }
+                anchorDate = CalendarUtils.startOfDay(Date(), calendar: calendar)
+                let initialIdx = clampedIndex(state.selectedDate.map { dateToIndex($0) } ?? centerIndex)
+                visibleCenterIndex = initialIdx
+                observedScrollPositionIndex = initialIdx
+                offsetCalibration = nil
+                proxy.scrollTo(initialIdx, anchor: .center)
+                // Let layout settle so the initial jump doesn't fire a spurious haptic.
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                didInitialScroll = true
+            }
+            .onChange(of: observedScrollPositionIndex) { newIndex in
+                guard let newIndex else { return }
+                let clamped = clampedIndex(newIndex)
+
+                // Only update visibleCenterIndex on month boundaries during free drag;
+                // per-day updates cause unnecessary churn and hurt scroll FPS.
+                let currentMonth = calendar.dateComponents([.year, .month], from: indexToDate(visibleCenterIndex))
+                let candidateMonth = calendar.dateComponents([.year, .month], from: indexToDate(clamped))
+                let isProgrammatic = programmaticScrollTarget != nil
+
+                if isProgrammatic || !isSameMonth(currentMonth, candidateMonth) {
+                    visibleCenterIndex = clamped
+                }
+            }
+            .onChange(of: state.selectedDate) { newDate in
+                guard let date = newDate else { return }
+                let idx = clampedIndex(dateToIndex(date))
+                offsetCalibration = nil
+                visibleCenterIndex = idx
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+                    proxy.scrollTo(idx, anchor: .center)
+                }
+            }
+            .onChange(of: programmaticScrollTarget) { request in
+                guard let request = request else { return }
+                let idx = clampedIndex(request.index)
+                offsetCalibration = nil
+                visibleCenterIndex = idx
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+                    proxy.scrollTo(idx, anchor: .center)
+                }
+            }
+        }
+    }
+
+    /// Maps a measured content offset back to a virtual index and updates
+    /// `visibleCenterIndex`. Used by the legacy iOS 15-16 path.
+    private func updateVisibleCenterFromOffset(contentOffset: CGFloat, cellWidth: CGFloat) {
+        guard cellWidth > 0 else { return }
+
+        guard let calibration = offsetCalibration else {
+            let anchorIndex = clampedIndex(programmaticScrollTarget?.index ?? visibleCenterIndex)
+            if anchorIndex != visibleCenterIndex {
+                visibleCenterIndex = anchorIndex
+            }
+            offsetCalibration = OffsetCalibration(offset: contentOffset, index: anchorIndex)
+            return
+        }
+
+        let deltaInCells = (contentOffset - calibration.offset) / cellWidth
+        let rawIndex = calibration.index + Int(deltaInCells.rounded())
+        let clamped = clampedIndex(rawIndex)
+
+        // ScrollView may rebase its content offset under lazy virtualization;
+        // re-anchor when we detect a large discontinuity.
+        if abs(clamped - visibleCenterIndex) > 180 {
+            let fallbackIndex = programmaticScrollTarget?.index ?? clamped
+            let anchoredIndex = clampedIndex(fallbackIndex)
+            visibleCenterIndex = anchoredIndex
+            offsetCalibration = OffsetCalibration(offset: contentOffset, index: anchoredIndex)
+            return
+        }
+
+        if clamped != visibleCenterIndex {
+            visibleCenterIndex = clamped
+            offsetCalibration = OffsetCalibration(offset: contentOffset, index: clamped)
+        }
+    }
+
+    // MARK: - iOS 15-16 Scroll View
+
+    @ViewBuilder
+    private func legacyScrollView(cellWidth: CGFloat, viewportWidth: CGFloat) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 0) {
+                    ForEach(indexRange, id: \.self) { index in
+                        dayCellView(for: index, cellWidth: cellWidth)
+                            .id(index)
+                    }
+                }
+                .background(
+                    GeometryReader { stackGeo in
+                        Color.clear.preference(
+                            key: ScrollContentOffsetKey.self,
+                            value: -stackGeo.frame(in: .named(scrollCoordinateSpaceName)).minX
+                        )
+                    }
+                )
+            }
+            .coordinateSpace(name: scrollCoordinateSpaceName)
+            .onPreferenceChange(ScrollContentOffsetKey.self) { contentOffset in
+                updateVisibleCenterFromOffset(
+                    contentOffset: contentOffset,
+                    cellWidth: cellWidth
+                )
+            }
+            .task {
+                guard !didInitialScroll else { return }
+                anchorDate = CalendarUtils.startOfDay(Date(), calendar: calendar)
+                let initialIdx = clampedIndex(state.selectedDate.map { dateToIndex($0) } ?? centerIndex)
+                visibleCenterIndex = initialIdx
+                offsetCalibration = nil
+                proxy.scrollTo(initialIdx, anchor: .center)
+                // Let layout settle so the initial jump doesn't fire a spurious haptic.
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                didInitialScroll = true
+            }
+            .onChange(of: state.selectedDate) { newDate in
+                guard let date = newDate else { return }
+                let idx = clampedIndex(dateToIndex(date))
+                offsetCalibration = nil
+                visibleCenterIndex = idx
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+                    proxy.scrollTo(idx, anchor: .center)
+                }
+            }
+            .onChange(of: programmaticScrollTarget) { request in
+                guard let request = request else { return }
+                let idx = clampedIndex(request.index)
+                offsetCalibration = nil
+                visibleCenterIndex = idx
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
+                    proxy.scrollTo(idx, anchor: .center)
+                }
+            }
+        }
+    }
+
+    // MARK: - Day Cell
+
+    /// `date`, `state.minDate/maxDate`, and `state.selectedDate` are all
+    /// pre-normalized to start-of-day, so per-frame `startOfDay` calls are
+    /// not needed.
+    @ViewBuilder
+    private func dayCellView(for index: Int, cellWidth: CGFloat) -> some View {
+        let date = indexToDate(index)
+        let yearMonth = calendar.dateComponents([.year, .month], from: date)
+        let dayNumber = calendar.component(.day, from: date)
+        let weekdayIndex = calendar.component(.weekday, from: date)
+        let labelIndex = (weekdayIndex - calendar.firstWeekday + 7) % 7
+        let weekdayText = weekdayLabels[labelIndex]
+
+        let outsideMonth = !isSameMonth(yearMonth, headerMonth)
+
+        let beforeMin = state.minDate.map { date < $0 } ?? false
+        let afterMax = state.maxDate.map { date > $0 } ?? false
+        let enabledByPredicate = enabledDates?(date) ?? true
+        let isEnabled = !beforeMin && !afterMax && enabledByPredicate
+
+        let isSelectedCell = state.selectedDate.map { $0 == date } ?? false
+        let isToday = calendar.isDateInToday(date)
+
+        CalendarDayCell(
+            date: date,
+            text: "\(dayNumber)",
+            isCurrent: isToday,
+            isSelected: isSelectedCell,
+            isEnabled: isEnabled,
+            isOutsideVisibleRange: outsideMonth,
+            showWeekdayLabel: true,
+            weekdayLabel: weekdayText,
+            expandSelectionToLabel: expandSelectionToLabel,
+            selectionBackgroundColor: selectionBackgroundColor,
+            selectionContentColor: selectionContentColor,
+            onClick: {
+                performCalendarHaptic()
+                pendingSelectionMonthChange = isSameMonth(yearMonth, headerMonth)
+                    ? nil
+                    : yearMonth
+                state.select(date: date, calendar: calendar)
+            }
+        ) {
+            trailingContent(date, isSelectedCell)
+        }
+        .frame(width: cellWidth)
+    }
+
+    // MARK: - Layout Metrics
+
+    private var estimatedRowHeight: CGFloat {
+        let weekdayHeight = calendarWeekdayLabelHeight
+        let dayHeight = calendarDayCellHeight
+        let trailing: CGFloat = LemonadeTheme.spaces.spacing400
+        let spacing: CGFloat = LemonadeTheme.spaces.spacing100
+        let selectionPadding: CGFloat = LemonadeTheme.spaces.spacing100 * 2
+        return weekdayHeight + spacing + dayHeight + trailing + selectionPadding
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+private struct InlineCalendarDefaultPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(state: state)
+    }
+}
+
+private struct InlineCalendarWithDotsPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    private let eventDays: Set<Int> = [3, 7, 12, 18, 25]
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(state: state) { date, isSelected in
+            let day = Calendar.current.component(.day, from: date)
+            if eventDays.contains(day) {
+                Circle()
+                    .fill(isSelected
+                        ? LemonadeTheme.colors.content.contentOnBrandHigh
+                        : LemonadeTheme.colors.content.contentBrand)
+                    .frame(width: 6, height: 6)
+            }
+        }
+    }
+}
+
+private struct InlineCalendarShortLabelsPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(
+            state: state,
+            dayLabelFormat: .short
+        )
+    }
+}
+
+private struct InlineCalendarConstrainedPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState(
+        minDate: Calendar.current.date(byAdding: .month, value: -2, to: Date()),
+        maxDate: Calendar.current.date(byAdding: .month, value: 3, to: Date())
+    )
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(state: state)
+    }
+}
+
+private struct InlineCalendarCompactSelectionPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(
+            state: state,
+            expandSelectionToLabel: false
+        )
+    }
+}
+
+private struct InlineCalendarCompactWithDotsPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    private let eventDays: Set<Int> = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30]
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(
+            state: state,
+            expandSelectionToLabel: false
+        ) { date, isSelected in
+            let day = Calendar.current.component(.day, from: date)
+            if eventDays.contains(day) {
+                Circle()
+                    .fill(isSelected
+                        ? LemonadeTheme.colors.content.contentOnBrandHigh
+                        : LemonadeTheme.colors.content.contentBrand)
+                    .frame(width: 6, height: 6)
+            }
+        }
+    }
+}
+
+private struct InlineCalendarCustomColorsPreview: View {
+    @StateObject private var state = LemonadeInlineCalendarState()
+
+    var body: some View {
+        LemonadeUi.InlineCalendar(
+            state: state,
+            selectionBackgroundColor: LemonadeTheme.colors.background.bgPositive,
+            selectionContentColor: LemonadeTheme.colors.content.contentAlwaysLight
+        )
+    }
+}
+
+struct LemonadeInlineCalendar_Previews: PreviewProvider {
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Default",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarDefaultPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "With trailing dots",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarWithDotsPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Short labels",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarShortLabelsPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Constrained date range",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarConstrainedPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Compact selection",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarCompactSelectionPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Compact with dots",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarCompactWithDotsPreview()
+                }
+
+                VStack(alignment: .leading) {
+                    LemonadeUi.Text(
+                        "Custom colors",
+                        textStyle: LemonadeTypography.shared.bodySmallSemiBold
+                    )
+                    InlineCalendarCustomColorsPreview()
+                }
+            }
+            .padding()
+        }
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/swiftui/Sources/Lemonade/Components/Calendar/LemonadeInlineCalendarState.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/LemonadeInlineCalendarState.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+// MARK: - Inline Calendar State
+
+/// State holder for ``LemonadeUi/InlineCalendar(state:dayLabelFormat:onMonthDisplayed:trailingContent:)``.
+///
+/// Manages the currently selected date, displayed month, and navigation bounds.
+/// Observe ``selectedDate`` via SwiftUI's `onChange(of:)` to react to user selections.
+///
+/// ## Usage
+/// ```swift
+/// @StateObject var state = LemonadeInlineCalendarState()
+/// // React to selections:
+/// .onChange(of: state.selectedDate) { newDate in
+///     print("Selected: \(String(describing: newDate))")
+/// }
+/// ```
+@MainActor
+public final class LemonadeInlineCalendarState: ObservableObject {
+
+    // MARK: - Published Properties
+
+    /// The currently selected date, or `nil` if no date is selected.
+    @Published public internal(set) var selectedDate: Date?
+
+    /// The year and month currently displayed in the calendar header.
+    ///
+    /// Contains `.year` and `.month` components. Updated by the view based on
+    /// scroll position - do not set this directly to navigate; use ``navigate(toMonth:)``
+    /// or the arrow buttons instead.
+    @Published public internal(set) var displayedMonth: DateComponents
+
+    // MARK: - Bounds
+
+    /// The earliest selectable date, or `nil` for no lower bound.
+    public let minDate: Date?
+
+    /// The latest selectable date, or `nil` for no upper bound.
+    public let maxDate: Date?
+
+    // MARK: - Initialization
+
+    /// Creates a new inline calendar state.
+    ///
+    /// All date parameters are normalized to start-of-day to ensure consistent
+    /// comparisons throughout the calendar lifecycle.
+    ///
+    /// - Parameters:
+    ///   - initialDate: The initially selected date. Defaults to `nil`.
+    ///   - initialMonth: The month to display initially. Defaults to the current month.
+    ///   - minDate: The earliest selectable date. Defaults to `nil` (no lower bound).
+    ///   - maxDate: The latest selectable date. Defaults to `nil` (no upper bound).
+    public init(
+        initialDate: Date? = nil,
+        initialMonth: DateComponents? = nil,
+        minDate: Date? = nil,
+        maxDate: Date? = nil
+    ) {
+        let cal = Calendar.current
+        self.selectedDate = initialDate.map { CalendarUtils.startOfDay($0, calendar: cal) }
+        self.minDate = minDate.map { CalendarUtils.startOfDay($0, calendar: cal) }
+        self.maxDate = maxDate.map { CalendarUtils.startOfDay($0, calendar: cal) }
+
+        if let month = initialMonth {
+            self.displayedMonth = month
+        } else {
+            let referenceDate = initialDate ?? Date()
+            self.displayedMonth = cal.dateComponents([.year, .month], from: referenceDate)
+        }
+    }
+
+    // MARK: - Selection
+
+    /// Selects the given date.
+    ///
+    /// The date is normalized to start-of-day before storing.
+    /// If the date falls outside `minDate`/`maxDate` bounds, the selection is ignored.
+    /// The view is responsible for updating `displayedMonth` based on scroll position.
+    ///
+    /// - Parameters:
+    ///   - date: The date to select.
+    ///   - calendar: The calendar to use for normalization. Defaults to `.current`.
+    public func select(date: Date, calendar: Calendar = .current) {
+        let normalized = CalendarUtils.startOfDay(date, calendar: calendar)
+
+        if let min = minDate, normalized < min {
+            return
+        }
+        if let max = maxDate, normalized > max {
+            return
+        }
+
+        selectedDate = normalized
+    }
+
+    // MARK: - Navigation
+
+    /// Navigates to the specified month, clamped to `minDate`/`maxDate`. The
+    /// equality guard prevents `objectWillChange` storms from the view's
+    /// scroll-driven feedback loop.
+    ///
+    /// - Parameters:
+    ///   - month: Date components with `.year` and `.month` set.
+    ///   - calendar: The calendar to use for date arithmetic. Defaults to `.current`.
+    public func navigate(toMonth month: DateComponents, calendar: Calendar = .current) {
+        guard let targetDate = calendar.date(from: month) else { return }
+        let targetYM = calendar.dateComponents([.year, .month], from: targetDate)
+
+        var resolvedYM = targetYM
+
+        if let min = minDate,
+           let targetMonthDate = calendar.date(from: targetYM) {
+            let minYM = calendar.dateComponents([.year, .month], from: min)
+            if let minMonthDate = calendar.date(from: minYM),
+               targetMonthDate < minMonthDate {
+                resolvedYM = minYM
+            }
+        }
+
+        if let max = maxDate,
+           let resolvedDate = calendar.date(from: resolvedYM) {
+            let maxYM = calendar.dateComponents([.year, .month], from: max)
+            if let maxMonthDate = calendar.date(from: maxYM),
+               resolvedDate > maxMonthDate {
+                resolvedYM = maxYM
+            }
+        }
+
+        guard resolvedYM.year != displayedMonth.year
+                || resolvedYM.month != displayedMonth.month else {
+            return
+        }
+        displayedMonth = resolvedYM
+    }
+
+    /// Navigates to the previous month.
+    ///
+    /// Does nothing if `canGoPrev(calendar:)` returns `false`.
+    ///
+    /// - Parameter calendar: The calendar to use for date arithmetic. Defaults to `.current`.
+    public func navigatePreviousMonth(calendar: Calendar = .current) {
+        guard canGoPrev(calendar: calendar) else { return }
+        guard let current = calendar.date(from: displayedMonth),
+              let prev = calendar.date(byAdding: .month, value: -1, to: current) else { return }
+        displayedMonth = calendar.dateComponents([.year, .month], from: prev)
+    }
+
+    /// Navigates to the next month.
+    ///
+    /// Does nothing if `canGoNext(calendar:)` returns `false`.
+    ///
+    /// - Parameter calendar: The calendar to use for date arithmetic. Defaults to `.current`.
+    public func navigateNextMonth(calendar: Calendar = .current) {
+        guard canGoNext(calendar: calendar) else { return }
+        guard let current = calendar.date(from: displayedMonth),
+              let next = calendar.date(byAdding: .month, value: 1, to: current) else { return }
+        displayedMonth = calendar.dateComponents([.year, .month], from: next)
+    }
+
+    // MARK: - Navigation Availability
+
+    /// Whether the calendar can navigate to the previous month.
+    ///
+    /// Returns `false` if `minDate` is set and the previous month would be
+    /// entirely before it.
+    ///
+    /// - Parameter calendar: The calendar to use for date arithmetic. Defaults to `.current`.
+    public func canGoPrev(calendar: Calendar = .current) -> Bool {
+        guard let min = minDate else { return true }
+        guard let current = calendar.date(from: displayedMonth),
+              let prev = calendar.date(byAdding: .month, value: -1, to: current) else { return false }
+        let prevYM = calendar.dateComponents([.year, .month], from: prev)
+        guard let prevYear = prevYM.year, let prevMonth = prevYM.month else { return false }
+        guard let lastDay = CalendarUtils.lastDayOfMonth(year: prevYear, month: prevMonth, calendar: calendar) else {
+            return false
+        }
+        return min <= lastDay
+    }
+
+    /// Whether the calendar can navigate to the next month.
+    ///
+    /// Returns `false` if `maxDate` is set and the next month would be
+    /// entirely after it.
+    ///
+    /// - Parameter calendar: The calendar to use for date arithmetic. Defaults to `.current`.
+    public func canGoNext(calendar: Calendar = .current) -> Bool {
+        guard let max = maxDate else { return true }
+        guard let current = calendar.date(from: displayedMonth),
+              let next = calendar.date(byAdding: .month, value: 1, to: current) else { return false }
+        let nextYM = calendar.dateComponents([.year, .month], from: next)
+        guard let nextYear = nextYM.year, let nextMonth = nextYM.month,
+              let firstDay = calendar.date(from: DateComponents(year: nextYear, month: nextMonth, day: 1)) else {
+            return false
+        }
+        return max >= firstDay
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -70,16 +70,20 @@ public extension LemonadeUi {
     ///     Observe ``LemonadeDatePickerState/selectedDate`` to react to user selections.
     ///   - monthFormatter: Formatter that returns the month name for a given month number (1-12).
     ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday.
+    ///   - onMonthDisplayed: Optional callback invoked when the displayed month changes.
+    ///     Receives a `DateComponents` with `.year` and `.month` set.
     @ViewBuilder
     static func DatePicker(
         state: LemonadeDatePickerState,
         monthFormatter: @escaping (Int) -> String,
-        weekdayAbbreviations: [String]
+        weekdayAbbreviations: [String],
+        onMonthDisplayed: ((DateComponents) -> Void)? = nil
     ) -> some View {
         LemonadeDatePickerView(
             state: state,
             monthFormatter: monthFormatter,
-            weekdayAbbreviations: weekdayAbbreviations
+            weekdayAbbreviations: weekdayAbbreviations,
+            onMonthDisplayed: onMonthDisplayed
         )
     }
 
@@ -106,16 +110,20 @@ public extension LemonadeUi {
     ///     ``LemonadeDateRangePickerState/selectedEndDate`` to react to user selections.
     ///   - monthFormatter: Formatter that returns the month name for a given month number (1-12).
     ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday.
+    ///   - onMonthDisplayed: Optional callback invoked when the displayed month changes.
+    ///     Receives a `DateComponents` with `.year` and `.month` set.
     @ViewBuilder
     static func DateRangePicker(
         state: LemonadeDateRangePickerState,
         monthFormatter: @escaping (Int) -> String,
-        weekdayAbbreviations: [String]
+        weekdayAbbreviations: [String],
+        onMonthDisplayed: ((DateComponents) -> Void)? = nil
     ) -> some View {
         LemonadeDateRangePickerView(
             state: state,
             monthFormatter: monthFormatter,
-            weekdayAbbreviations: weekdayAbbreviations
+            weekdayAbbreviations: weekdayAbbreviations,
+            onMonthDisplayed: onMonthDisplayed
         )
     }
 }
@@ -126,6 +134,7 @@ private struct LemonadeDatePickerView: View {
     @ObservedObject var state: LemonadeDatePickerState
     let monthFormatter: (Int) -> String
     let weekdayAbbreviations: [String]
+    let onMonthDisplayed: ((DateComponents) -> Void)?
 
     var body: some View {
         CoreDatePickerView(
@@ -136,7 +145,8 @@ private struct LemonadeDatePickerView: View {
                 state.selectedDate = date
             },
             minDate: state.minDate,
-            maxDate: state.maxDate
+            maxDate: state.maxDate,
+            onMonthDisplayed: onMonthDisplayed
         )
     }
 }
@@ -147,6 +157,7 @@ private struct LemonadeDateRangePickerView: View {
     @ObservedObject var state: LemonadeDateRangePickerState
     let monthFormatter: (Int) -> String
     let weekdayAbbreviations: [String]
+    let onMonthDisplayed: ((DateComponents) -> Void)?
 
     private var isSelectingEndDate: Bool {
         state.selectedStartDate != nil && state.selectedEndDate == nil
@@ -154,8 +165,8 @@ private struct LemonadeDateRangePickerView: View {
 
     private var effectiveMin: Date? {
         var min = state.minDate
-        if isSelectingEndDate, let maxDays = state.maxRangeDays, let start = state.selectedStartDate {
-            let rangeMin = Calendar.current.date(byAdding: .day, value: -maxDays, to: start)!
+        if isSelectingEndDate, let maxDays = state.maxRangeDays, let start = state.selectedStartDate,
+           let rangeMin = Calendar.current.date(byAdding: .day, value: -maxDays, to: start) {
             if min == nil || rangeMin > min! {
                 min = rangeMin
             }
@@ -165,8 +176,8 @@ private struct LemonadeDateRangePickerView: View {
 
     private var effectiveMax: Date? {
         var max = state.maxDate
-        if isSelectingEndDate, let maxDays = state.maxRangeDays, let start = state.selectedStartDate {
-            let rangeMax = Calendar.current.date(byAdding: .day, value: maxDays, to: start)!
+        if isSelectingEndDate, let maxDays = state.maxRangeDays, let start = state.selectedStartDate,
+           let rangeMax = Calendar.current.date(byAdding: .day, value: maxDays, to: start) {
             if max == nil || rangeMax < max! {
                 max = rangeMax
             }
@@ -192,7 +203,8 @@ private struct LemonadeDateRangePickerView: View {
                 state.selectedEndDate = newEnd
             },
             minDate: effectiveMin,
-            maxDate: effectiveMax
+            maxDate: effectiveMax,
+            onMonthDisplayed: onMonthDisplayed
         )
     }
 }
@@ -206,6 +218,7 @@ private struct CoreDatePickerView: View {
     let onDateSelected: (Date) -> Void
     let minDate: Date?
     let maxDate: Date?
+    let onMonthDisplayed: ((DateComponents) -> Void)?
 
     private let totalPages = 240
     private var centerPage: Int { totalPages / 2 }
@@ -213,39 +226,50 @@ private struct CoreDatePickerView: View {
     @State private var displayedMonthOffset: Int = 0
 
     private let calendar = Calendar.current
-    private let today = DatePickerUtils.startOfDay(Date())
+    private let today = CalendarUtils.startOfDay(Date())
 
     private var currentYearMonth: DateComponents {
-        let target = calendar.date(byAdding: .month, value: displayedMonthOffset, to: today)!
+        guard let target = calendar.date(byAdding: .month, value: displayedMonthOffset, to: today) else {
+            return calendar.dateComponents([.year, .month], from: today)
+        }
         return calendar.dateComponents([.year, .month], from: target)
     }
 
     private var headerLabel: String {
-        let ym = currentYearMonth
-        return "\(monthFormatter(ym.month!)) \(ym.year!)"
+        CalendarUtils.monthYearLabel(for: currentYearMonth, monthFormatter: monthFormatter)
     }
 
     private var canGoPrev: Bool {
         guard displayedMonthOffset > -centerPage else { return false }
         guard let min = minDate else { return true }
-        let prevMonth = calendar.date(byAdding: .month, value: displayedMonthOffset - 1, to: today)!
+        guard let prevMonth = calendar.date(byAdding: .month, value: displayedMonthOffset - 1, to: today) else {
+            return false
+        }
         let prevYM = calendar.dateComponents([.year, .month], from: prevMonth)
-        let lastDayOfPrev = DatePickerUtils.lastDayOfMonth(year: prevYM.year!, month: prevYM.month!, calendar: calendar)
+        guard let prevYear = prevYM.year, let prevMonth = prevYM.month,
+              let lastDayOfPrev = CalendarUtils.lastDayOfMonth(year: prevYear, month: prevMonth, calendar: calendar) else {
+            return false
+        }
         return min <= lastDayOfPrev
     }
 
     private var canGoNext: Bool {
         guard displayedMonthOffset < centerPage - 1 else { return false }
         guard let max = maxDate else { return true }
-        let nextMonth = calendar.date(byAdding: .month, value: displayedMonthOffset + 1, to: today)!
+        guard let nextMonth = calendar.date(byAdding: .month, value: displayedMonthOffset + 1, to: today) else {
+            return false
+        }
         let nextYM = calendar.dateComponents([.year, .month], from: nextMonth)
-        let firstDayOfNext = calendar.date(from: DateComponents(year: nextYM.year!, month: nextYM.month!, day: 1))!
+        guard let nextYear = nextYM.year, let nextMonth = nextYM.month,
+              let firstDayOfNext = calendar.date(from: DateComponents(year: nextYear, month: nextMonth, day: 1)) else {
+            return false
+        }
         return max >= firstDayOfNext
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            MonthHeaderView(
+            CalendarMonthHeader(
                 headerLabel: headerLabel,
                 canGoPrev: canGoPrev,
                 canGoNext: canGoNext,
@@ -287,45 +311,8 @@ private struct CoreDatePickerView: View {
             .tabViewStyle(.page(indexDisplayMode: .never))
             .frame(height: 300)
         }
-    }
-}
-
-// MARK: - Month Header View
-
-private struct MonthHeaderView: View {
-    let headerLabel: String
-    let canGoPrev: Bool
-    let canGoNext: Bool
-    let onPrev: () -> Void
-    let onNext: () -> Void
-
-    var body: some View {
-        HStack {
-            LemonadeUi.IconButton(
-                icon: .chevronLeft,
-                contentDescription: "Previous month",
-                onClick: onPrev,
-                enabled: canGoPrev,
-                variant: .ghost
-            )
-
-            Spacer()
-
-            LemonadeUi.Text(
-                headerLabel,
-                textStyle: LemonadeTypography.shared.bodySmallSemiBold,
-                color: LemonadeTheme.colors.content.contentPrimary
-            )
-
-            Spacer()
-
-            LemonadeUi.IconButton(
-                icon: .chevronRight,
-                contentDescription: "Next month",
-                onClick: onNext,
-                enabled: canGoNext,
-                variant: .ghost
-            )
+        .onChange(of: displayedMonthOffset) { _ in
+            onMonthDisplayed?(currentYearMonth)
         }
     }
 }
@@ -341,19 +328,22 @@ private struct MonthGridView: View {
     let onDateSelected: (Date) -> Void
 
     private let calendar = Calendar.current
-    private let today = DatePickerUtils.startOfDay(Date())
+    private let today = CalendarUtils.startOfDay(Date())
 
     private var yearMonth: DateComponents {
-        let target = calendar.date(byAdding: .month, value: monthOffset, to: baseDate)!
+        guard let target = calendar.date(byAdding: .month, value: monthOffset, to: baseDate) else {
+            return calendar.dateComponents([.year, .month], from: baseDate)
+        }
         return calendar.dateComponents([.year, .month], from: target)
     }
 
     private var days: [Date] {
-        DatePickerUtils.generateMonthDays(year: yearMonth.year!, month: yearMonth.month!, calendar: calendar)
+        guard let year = yearMonth.year, let month = yearMonth.month else { return [] }
+        return CalendarUtils.generateMonthDays(year: year, month: month, calendar: calendar)
     }
 
     private var normalizedSelectedDates: Set<Date> {
-        Set(selectedDates.map { DatePickerUtils.startOfDay($0) })
+        Set(selectedDates.map { CalendarUtils.startOfDay($0) })
     }
 
     var body: some View {
@@ -369,24 +359,26 @@ private struct MonthGridView: View {
 
                 HStack(spacing: 0) {
                     ForEach(Array(weekDays.enumerated()), id: \.offset) { _, current in
-                        let normalized = DatePickerUtils.startOfDay(current)
+                        let normalized = CalendarUtils.startOfDay(current)
                         let isInRange = isRangeComplete &&
-                            normalized >= rangeStart! &&
-                            normalized <= rangeEnd!
+                            rangeStart.map { normalized >= $0 } ?? false &&
+                            rangeEnd.map { normalized <= $0 } ?? false
 
                         let currentMonth = calendar.component(.month, from: current)
-                        let isOutsideMonth = currentMonth != yearMonth.month!
+                        let isOutsideMonth = currentMonth != yearMonth.month
 
-                        let isBeforeMin = minDate != nil && normalized < DatePickerUtils.startOfDay(minDate!)
-                        let isAfterMax = maxDate != nil && normalized > DatePickerUtils.startOfDay(maxDate!)
+                        let isBeforeMin = minDate.map { normalized < CalendarUtils.startOfDay($0) } ?? false
+                        let isAfterMax = maxDate.map { normalized > CalendarUtils.startOfDay($0) } ?? false
 
-                        ContentCellView(
+                        CalendarDayCell(
+                            date: current,
                             text: "\(calendar.component(.day, from: current))",
                             isCurrent: normalized == today,
                             isSelected: normalizedSelectedDates.contains(normalized),
                             isEnabled: !isBeforeMin && !isAfterMax,
                             isOutsideVisibleRange: isOutsideMonth,
                             isInsideSelectedRange: isInRange,
+                            showWeekdayLabel: false,
                             onClick: { onDateSelected(normalized) }
                         )
                         .padding(.horizontal, LemonadeTheme.spaces.spacing200)
@@ -399,8 +391,8 @@ private struct MonthGridView: View {
                             let padding = LemonadeTheme.spaces.spacing200
                             let radius = LemonadeTheme.radius.radius200
 
-                            let startIdx = weekDays.firstIndex { DatePickerUtils.startOfDay($0) >= rangeStart }
-                            let endIdx = weekDays.lastIndex { DatePickerUtils.startOfDay($0) <= rangeEnd }
+                            let startIdx = weekDays.firstIndex { CalendarUtils.startOfDay($0) >= rangeStart }
+                            let endIdx = weekDays.lastIndex { CalendarUtils.startOfDay($0) <= rangeEnd }
 
                             if let startIdx = startIdx, let endIdx = endIdx {
                                 let left = cellWidth * CGFloat(startIdx) + padding
@@ -416,125 +408,6 @@ private struct MonthGridView: View {
                 )
             }
         }
-    }
-}
-
-// MARK: - Content Cell View
-
-private struct ContentCellView: View {
-    let text: String
-    let isCurrent: Bool
-    let isSelected: Bool
-    let isEnabled: Bool
-    let isOutsideVisibleRange: Bool
-    let isInsideSelectedRange: Bool
-    let onClick: () -> Void
-
-    private var textColor: Color {
-        if !isEnabled {
-            return LemonadeTheme.colors.content.contentTertiary
-        } else if isSelected || isInsideSelectedRange {
-            return LemonadeTheme.colors.content.contentOnBrandHigh
-        } else if isCurrent {
-            return LemonadeTheme.colors.content.contentBrand
-        } else if isOutsideVisibleRange {
-            return LemonadeTheme.colors.content.contentSecondary
-        } else {
-            return LemonadeTheme.colors.content.contentPrimary
-        }
-    }
-
-    private var textStyle: LemonadeTextStyle {
-        isCurrent
-            ? LemonadeTypography.shared.bodyMediumSemiBold
-            : LemonadeTypography.shared.bodyMediumMedium
-    }
-
-    private var backgroundColor: Color {
-        isSelected
-            ? LemonadeTheme.colors.interaction.bgBrandInteractive
-            : Color.clear
-    }
-
-    var body: some View {
-        SwiftUI.Button(action: {
-            if isEnabled { onClick() }
-        }) {
-            ZStack(alignment: .bottom) {
-                LemonadeUi.Text(
-                    text,
-                    textStyle: textStyle,
-                    color: textColor
-                )
-                .padding(.vertical, LemonadeTheme.spaces.spacing200)
-
-                if isCurrent {
-                    Circle()
-                        .fill(textColor)
-                        .frame(
-                            width: LemonadeTheme.spaces.spacing100,
-                            height: LemonadeTheme.spaces.spacing100
-                        )
-                        .padding(.bottom, LemonadeTheme.spaces.spacing100)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .background(
-                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200)
-                    .fill(backgroundColor)
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(!isEnabled)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-}
-
-// MARK: - Utilities
-
-private enum DatePickerUtils {
-    static func startOfDay(_ date: Date, calendar: Calendar = .current) -> Date {
-        calendar.startOfDay(for: date)
-    }
-
-    static func lastDayOfMonth(year: Int, month: Int, calendar: Calendar) -> Date {
-        var components = DateComponents(year: year, month: month)
-        let range = calendar.range(of: .day, in: .month, for: calendar.date(from: components)!)!
-        components.day = range.upperBound - 1
-        return calendar.date(from: components)!
-    }
-
-    /// Generate 42 dates (6 weeks) for a given month, with leading/trailing days.
-    static func generateMonthDays(year: Int, month: Int, calendar: Calendar) -> [Date] {
-        let firstOfMonth = calendar.date(from: DateComponents(year: year, month: month, day: 1))!
-        let weekday = calendar.component(.weekday, from: firstOfMonth) // 1=Sun, 7=Sat
-        let firstDayOffset = (weekday - calendar.firstWeekday + 7) % 7
-
-        var days: [Date] = []
-
-        // Previous month trailing days
-        for i in (0..<firstDayOffset).reversed() {
-            let date = calendar.date(byAdding: .day, value: -(i + 1), to: firstOfMonth)!
-            days.append(date)
-        }
-
-        // Current month days
-        let range = calendar.range(of: .day, in: .month, for: firstOfMonth)!
-        for day in range {
-            let date = calendar.date(from: DateComponents(year: year, month: month, day: day))!
-            days.append(date)
-        }
-
-        // Next month leading days
-        var nextDay = 1
-        let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: firstOfMonth)!
-        while days.count < 42 {
-            let date = calendar.date(byAdding: .day, value: nextDay - 1, to: nextMonthStart)!
-            days.append(date)
-            nextDay += 1
-        }
-
-        return days
     }
 }
 


### PR DESCRIPTION
## Summary

[Figma link](https://www.figma.com/design/skjFZ42nUMrFEFTvUZW6wT/Teya-App-2026?node-id=6646-793&m=dev)

- Add `LemonadeInlineCalendar`, a horizontal day-strip calendar for KMP and SwiftUI, using index-based virtual scrolling over a +-5 year range (3,650 items) for seamless continuous scrolling with no snap-back
- Extract shared calendar building blocks (`ContentCell`, `CalendarDayCell`, `CalendarMonthHeader`, `CalendarUtils`, `DayLabelFormat`) from the existing `DatePicker` on both platforms
- Refactor both `DatePicker` implementations to consume the shared building blocks, adding `onMonthDisplayed` callback

## Changes

### Shared building blocks (refactored from DatePicker)
- `ContentCell` / `ContentCellView` - extracted day number cell with selection, today, disabled, outside-month states. Added `showSelectionBackground` flag to support both DatePicker (yellow) and InlineCalendar (dark) selection styles
- `CalendarDayCell` - wrapper adding weekday label + trailing content slot. Selected state uses dark (`bgAlwaysDark`/`bgDefaultInverse`) full-cell rounded-rect background
- `CalendarMonthHeader` - unified month/year header with `onPrev`/`onNext` callbacks
- `CalendarUtils` - date generation, peek days, locale-aware weekday/month labels
- `DayLabelFormat` - enum with `.narrow` (M) and `.short` (Mon) variants

### InlineCalendar component
- `InlineCalendarState` / `LemonadeInlineCalendarState` - state holder with `selectedDate`, `displayedMonth`, `selectDate()`, `navigateToMonth()`. KMP uses `rememberSaveable` with custom `Saver` for config change survival
- `InlineCalendar` composable / view - horizontal `LazyRow`/`LazyHStack` with index-based virtual scrolling. Header month derived from scroll position via `derivedStateOf` (KMP) / `scrollPosition(id:)` (SwiftUI iOS 17+). Snap-to-cell via `SnapFlingBehavior` / `.scrollTargetBehavior(.viewAligned)`
- Parameters: `dayLabelFormat`, `enabledDates`, `onMonthDisplayed`, `trailingContent`, `weekdayLabels`/`monthFormatter` (KMP)
- Accessibility labels on day cells, `collectionInfo` semantics

### Demo / Previews
- KMP: `InlineCalendarDisplay` with 4 variants, registered in `Displays` + `HomeDisplay`
- SwiftUI: `#if DEBUG` previews with default, trailing dots, short labels, constrained range

<table>
<tr>
<th>iOS</th>
<th>Android</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/21ffc434-9cff-4360-a549-f4c76276a55a

</td>
<td>

https://github.com/user-attachments/assets/f149f604-da0e-4810-950b-0072d7218aae

</td>
</tr>
</table>


### DatePicker changes
- Both platforms now consume shared building blocks instead of private copies
- Added optional `onMonthDisplayed` callback (backward compatible, defaults to nil)

## Notes

- The InlineCalendar uses `@ExperimentalLemonadeComponent` on KMP since the stateful API pattern may evolve
- KMP weekday/month labels default to English; callers should pass `weekdayLabels`/`monthFormatter` for localization (matching the existing `DatePicker` pattern)
- SwiftUI supports iOS 15+ with a `ScrollViewReader` fallback for iOS 15-16 (no scroll-position tracking in legacy path)
