### PR TITLE
feat: update Card component with new Figma features

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
@@ -58,10 +58,10 @@ internal fun CardDisplay() {
 
                 LemonadeUi.Card(
                     contentPadding = LemonadeCardPadding.Medium,
-                    background = LemonadeCardBackground.SubtleHigh,
+                    background = LemonadeCardBackground.Elevated,
                 ) {
                     LemonadeUi.Text(
-                        text = "Subtle High",
+                        text = "Elevated",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
@@ -183,6 +183,27 @@ internal fun CardDisplay() {
                 }
             }
         }
+
+        // Footer Action
+        CardSection(title = "Footer Action") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+            ) {
+                LemonadeUi.Card(
+                    contentPadding = LemonadeCardPadding.Medium,
+                    header = CardHeaderConfig(title = "Card with Footer"),
+                    footerAction = CardFooterActionConfig(
+                        label = "Action",
+                        onClick = {},
+                    ),
+                ) {
+                    LemonadeUi.Text(
+                        text = "Card content with a footer action button.",
+                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CardDisplay.kt
@@ -3,19 +3,17 @@ package com.teya.lemonade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeCardBackground
+import com.teya.lemonade.core.LemonadeCardHeadingStyle
 import com.teya.lemonade.core.LemonadeCardPadding
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.TagVoice
@@ -33,54 +31,8 @@ internal fun CardDisplay() {
             .navigationBarsPadding()
             .padding(LemonadeTheme.spaces.spacing400),
     ) {
-        // Basic Card
-        CardSection(title = "Basic Card") {
-            LemonadeUi.Card(contentPadding = LemonadeCardPadding.Medium) {
-                LemonadeUi.Text(
-                    text = "This is a basic card with medium padding.",
-                    textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                )
-            }
-        }
-
-        // Padding Variants
-        CardSection(title = "Padding Variants") {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
-            ) {
-                LemonadeUi.Card(contentPadding = LemonadeCardPadding.None) {
-                    LemonadeUi.Text(
-                        text = "No padding",
-                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                        modifier = Modifier.padding(LemonadeTheme.spaces.spacing400),
-                    )
-                }
-
-                LemonadeUi.Card(contentPadding = LemonadeCardPadding.XSmall) {
-                    LemonadeUi.Text(
-                        text = "XSmall padding",
-                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                    )
-                }
-
-                LemonadeUi.Card(contentPadding = LemonadeCardPadding.Small) {
-                    LemonadeUi.Text(
-                        text = "Small padding",
-                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                    )
-                }
-
-                LemonadeUi.Card(contentPadding = LemonadeCardPadding.Medium) {
-                    LemonadeUi.Text(
-                        text = "Medium padding",
-                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                    )
-                }
-            }
-        }
-
         // Background Variants
-        CardSection(title = "Background Variants") {
+        CardSection(title = "Backgrounds") {
             Column(
                 verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
             ) {
@@ -89,7 +41,7 @@ internal fun CardDisplay() {
                     background = LemonadeCardBackground.Default,
                 ) {
                     LemonadeUi.Text(
-                        text = "Default background",
+                        text = "Default",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }
@@ -99,24 +51,55 @@ internal fun CardDisplay() {
                     background = LemonadeCardBackground.Subtle,
                 ) {
                     LemonadeUi.Text(
-                        text = "Subtle background",
+                        text = "Subtle",
+                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
+                    )
+                }
+
+                LemonadeUi.Card(
+                    contentPadding = LemonadeCardPadding.Medium,
+                    background = LemonadeCardBackground.SubtleHigh,
+                ) {
+                    LemonadeUi.Text(
+                        text = "Subtle High",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }
             }
         }
 
-        // With Header
-        CardSection(title = "With Header") {
+        // Spacing Variants
+        CardSection(title = "Spacing") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+            ) {
+                LemonadeCardPadding.entries.forEach { padding ->
+                    LemonadeUi.Card(contentPadding = padding) {
+                        LemonadeUi.Text(
+                            text = padding.name,
+                            textStyle = LemonadeTheme.typography.bodyMediumRegular,
+                        )
+                    }
+                }
+            }
+        }
+
+        // Heading Styles
+        CardSection(title = "Heading Styles") {
             Column(
                 verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
             ) {
                 LemonadeUi.Card(
                     contentPadding = LemonadeCardPadding.Medium,
-                    header = CardHeaderConfig(title = "Card Title"),
+                    header = CardHeaderConfig(
+                        title = "Default Heading",
+                        trailingSlot = {
+                            LemonadeUi.Tag(label = "Tag", voice = TagVoice.Neutral)
+                        },
+                    ),
                 ) {
                     LemonadeUi.Text(
-                        text = "Card content goes here. This is an example of a card with a header.",
+                        text = "Card with default heading style.",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }
@@ -124,14 +107,41 @@ internal fun CardDisplay() {
                 LemonadeUi.Card(
                     contentPadding = LemonadeCardPadding.Medium,
                     header = CardHeaderConfig(
-                        title = "With Trailing Slot",
+                        title = "Overline Heading",
+                        headingStyle = LemonadeCardHeadingStyle.Overline,
                         trailingSlot = {
-                            LemonadeUi.Tag(label = "New", voice = TagVoice.Positive)
+                            LemonadeUi.Tag(label = "Tag", voice = TagVoice.Neutral)
                         },
                     ),
                 ) {
                     LemonadeUi.Text(
-                        text = "This card has a header with a trailing tag.",
+                        text = "Card with overline heading style.",
+                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
+                    )
+                }
+            }
+        }
+
+        // Header Slots
+        CardSection(title = "Header Slots") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+            ) {
+                LemonadeUi.Card(
+                    contentPadding = LemonadeCardPadding.Medium,
+                    header = CardHeaderConfig(
+                        title = "Leading Icon",
+                        leadingSlot = {
+                            LemonadeUi.Icon(
+                                icon = LemonadeIcons.Store,
+                                contentDescription = null,
+                                size = LemonadeAssetSize.Medium,
+                            )
+                        },
+                    ),
+                ) {
+                    LemonadeUi.Text(
+                        text = "Header with leading slot.",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }
@@ -139,152 +149,37 @@ internal fun CardDisplay() {
                 LemonadeUi.Card(
                     contentPadding = LemonadeCardPadding.Medium,
                     header = CardHeaderConfig(
-                        title = "Actions",
-                        trailingSlot = {
-                            LemonadeUi.Icon(
-                                icon = LemonadeIcons.EllipsisVertical,
-                                contentDescription = "More options",
-                                size = LemonadeAssetSize.Medium,
-                            )
-                        },
+                        title = "Navigation",
+                        showNavigationIndicator = true,
                     ),
                 ) {
                     LemonadeUi.Text(
-                        text = "Card with action icon in header.",
+                        text = "Header with navigation indicator.",
                         textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
                 }
-            }
-        }
 
-        // Complex Content
-        CardSection(title = "Complex Content") {
-            LemonadeUi.Card(
-                contentPadding = LemonadeCardPadding.Medium,
-                header = CardHeaderConfig(
-                    title = "Order Summary",
-                    trailingSlot = {
-                        LemonadeUi.Tag(label = "Confirmed", voice = TagVoice.Positive)
-                    },
-                ),
-            ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                LemonadeUi.Card(
+                    contentPadding = LemonadeCardPadding.Medium,
+                    header = CardHeaderConfig(
+                        title = "All Slots",
+                        leadingSlot = {
+                            LemonadeUi.Icon(
+                                icon = LemonadeIcons.Store,
+                                contentDescription = null,
+                                size = LemonadeAssetSize.Medium,
+                            )
+                        },
+                        trailingSlot = {
+                            LemonadeUi.Tag(label = "Active", voice = TagVoice.Positive)
+                        },
+                        showNavigationIndicator = true,
+                    ),
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        LemonadeUi.Text(
-                            text = "Subtotal",
-                            textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                        )
-                        LemonadeUi.Text(
-                            text = "$99.00",
-                            textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                        )
-                    }
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        LemonadeUi.Text(
-                            text = "Shipping",
-                            textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                        )
-                        LemonadeUi.Text(
-                            text = "$5.00",
-                            textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                        )
-                    }
-
-                    LemonadeUi.HorizontalDivider(
-                        modifier = Modifier.fillMaxWidth(),
+                    LemonadeUi.Text(
+                        text = "Leading, trailing, and navigation combined.",
+                        textStyle = LemonadeTheme.typography.bodyMediumRegular,
                     )
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        LemonadeUi.Text(
-                            text = "Total",
-                            textStyle = LemonadeTheme.typography.bodyMediumSemiBold,
-                        )
-                        LemonadeUi.Text(
-                            text = "$104.00",
-                            textStyle = LemonadeTheme.typography.bodyMediumSemiBold,
-                        )
-                    }
-                }
-            }
-        }
-
-        // Nested Cards
-        CardSection(title = "Nested Cards") {
-            LemonadeUi.Card(
-                contentPadding = LemonadeCardPadding.Medium,
-                header = CardHeaderConfig(title = "Payment Methods"),
-            ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-                ) {
-                    LemonadeUi.Card(
-                        contentPadding = LemonadeCardPadding.Small,
-                        background = LemonadeCardBackground.Subtle,
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            LemonadeUi.Icon(
-                                icon = LemonadeIcons.Card,
-                                contentDescription = null,
-                                size = LemonadeAssetSize.Medium,
-                            )
-                            Column(modifier = Modifier.weight(1f)) {
-                                LemonadeUi.Text(
-                                    text = "Visa ending in 4242",
-                                    textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                                )
-                                LemonadeUi.Text(
-                                    text = "Expires 12/25",
-                                    textStyle = LemonadeTheme.typography.bodySmallRegular,
-                                    color = LemonadeTheme.colors.content.contentSecondary,
-                                )
-                            }
-                            LemonadeUi.Tag(label = "Default", voice = TagVoice.Info)
-                        }
-                    }
-
-                    LemonadeUi.Card(
-                        contentPadding = LemonadeCardPadding.Small,
-                        background = LemonadeCardBackground.Subtle,
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            LemonadeUi.Icon(
-                                icon = LemonadeIcons.Card,
-                                contentDescription = null,
-                                size = LemonadeAssetSize.Medium,
-                            )
-                            Column(modifier = Modifier.weight(1f)) {
-                                LemonadeUi.Text(
-                                    text = "Mastercard ending in 1234",
-                                    textStyle = LemonadeTheme.typography.bodyMediumRegular,
-                                )
-                                LemonadeUi.Text(
-                                    text = "Expires 06/24",
-                                    textStyle = LemonadeTheme.typography.bodySmallRegular,
-                                    color = LemonadeTheme.colors.content.contentSecondary,
-                                )
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeCard.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeCard.kt
@@ -10,7 +10,7 @@ public enum class LemonadeCardPadding {
 public enum class LemonadeCardBackground {
     Default,
     Subtle,
-    SubtleHigh,
+    Elevated,
 }
 
 public enum class LemonadeCardHeadingStyle {

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeCard.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeCard.kt
@@ -10,4 +10,10 @@ public enum class LemonadeCardPadding {
 public enum class LemonadeCardBackground {
     Default,
     Subtle,
+    SubtleHigh,
+}
+
+public enum class LemonadeCardHeadingStyle {
+    Default,
+    Overline,
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -1,8 +1,8 @@
 package com.teya.lemonade
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -141,9 +141,7 @@ public data class CardFooterActionConfig(
 )
 
 @Composable
-private fun CardFooterAction(
-    config: CardFooterActionConfig,
-) {
+private fun CardFooterAction(config: CardFooterActionConfig) {
     LemonadeUi.HorizontalDivider(
         modifier = Modifier.fillMaxWidth(),
     )
@@ -154,10 +152,11 @@ private fun CardFooterAction(
             .fillMaxWidth()
             .clickable(onClick = config.onClick)
             .padding(
-                horizontal = LocalSpaces.current.spacing400,
-                vertical = LocalSpaces.current.spacing200,
-            )
-            .padding(bottom = LocalSpaces.current.spacing200),
+                start = LocalSpaces.current.spacing400,
+                top = LocalSpaces.current.spacing200,
+                end = LocalSpaces.current.spacing400,
+                bottom = LocalSpaces.current.spacing400,
+            ),
     ) {
         LemonadeUi.Text(
             text = config.label,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -18,8 +18,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
+import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeCardBackground
+import com.teya.lemonade.core.LemonadeCardHeadingStyle
 import com.teya.lemonade.core.LemonadeCardPadding
+import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.LemonadeTextStyle
 import com.teya.lemonade.core.TagVoice
 
 @Composable
@@ -47,24 +51,14 @@ private fun CoreCard(
     header: CardHeaderConfig? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val hasHeader = header !== null
-    val headerConfig = if (hasHeader) {
-        CardHeaderConfig(
-            title = header.title,
-            trailingSlot = header.trailingSlot,
-        )
-    } else {
-        null
-    }
-
     Column(
         modifier = modifier
             .fillMaxWidth()
             .clip(shape = LocalShapes.current.semantic.radiusContainerDefault)
             .background(color = background.background),
     ) {
-        if (hasHeader) {
-            CardHeader(config = headerConfig)
+        if (header != null) {
+            CardHeader(config = header)
         }
 
         Column(
@@ -78,7 +72,10 @@ private fun CoreCard(
 
 public data class CardHeaderConfig(
     val title: String,
+    val headingStyle: LemonadeCardHeadingStyle = LemonadeCardHeadingStyle.Default,
+    val leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     val trailingSlot: (@Composable RowScope.() -> Unit)? = null,
+    val showNavigationIndicator: Boolean = false,
 )
 
 @Composable
@@ -88,7 +85,10 @@ private fun CardHeader(
 ) {
     if (config == null) return
 
-    val (title, trailingSlot) = config
+    val (title, headingStyle, leadingSlot, trailingSlot, showNavigationIndicator) = config
+
+    val titleTextStyle = headingStyle.textStyle
+    val titleColor = headingStyle.color
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(LocalSpaces.current.spacing200),
@@ -101,9 +101,14 @@ private fun CardHeader(
                 bottom = LocalSpaces.current.spacing0,
             ),
     ) {
+        if (leadingSlot !== null) {
+            leadingSlot()
+        }
+
         LemonadeUi.Text(
             text = title,
-            textStyle = LocalTypographies.current.headingXXSmall,
+            textStyle = titleTextStyle,
+            color = titleColor,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1F),
@@ -112,8 +117,33 @@ private fun CardHeader(
         if (trailingSlot !== null) {
             trailingSlot()
         }
+
+        if (showNavigationIndicator) {
+            LemonadeUi.Icon(
+                icon = LemonadeIcons.ChevronRight,
+                contentDescription = null,
+                size = LemonadeAssetSize.Medium,
+                tint = LocalColors.current.content.contentSecondary,
+            )
+        }
     }
 }
+
+private val LemonadeCardHeadingStyle.textStyle: LemonadeTextStyle
+    @Composable get() {
+        return when (this) {
+            LemonadeCardHeadingStyle.Default -> LocalTypographies.current.headingXXSmall
+            LemonadeCardHeadingStyle.Overline -> LocalTypographies.current.bodyXSmallOverline
+        }
+    }
+
+private val LemonadeCardHeadingStyle.color: Color
+    @Composable get() {
+        return when (this) {
+            LemonadeCardHeadingStyle.Default -> LocalColors.current.content.contentPrimary
+            LemonadeCardHeadingStyle.Overline -> LocalColors.current.content.contentSecondary
+        }
+    }
 
 private val LemonadeCardPadding.spacing: Dp
     @Composable get() {
@@ -130,6 +160,7 @@ private val LemonadeCardBackground.background: Color
         return when (this) {
             LemonadeCardBackground.Default -> LocalColors.current.background.bgDefault
             LemonadeCardBackground.Subtle -> LocalColors.current.background.bgSubtle
+            LemonadeCardBackground.SubtleHigh -> LocalColors.current.background.bgElevated
         }
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -85,10 +85,8 @@ private fun CardHeader(
 ) {
     if (config == null) return
 
-    val (title, headingStyle, leadingSlot, trailingSlot, showNavigationIndicator) = config
-
-    val titleTextStyle = headingStyle.textStyle
-    val titleColor = headingStyle.color
+    val titleTextStyle = config.headingStyle.textStyle
+    val titleColor = config.headingStyle.color
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(LocalSpaces.current.spacing200),
@@ -101,12 +99,12 @@ private fun CardHeader(
                 bottom = LocalSpaces.current.spacing0,
             ),
     ) {
-        if (leadingSlot !== null) {
-            leadingSlot()
+        if (config.leadingSlot !== null) {
+            config.leadingSlot.invoke(this)
         }
 
         LemonadeUi.Text(
-            text = title,
+            text = config.title,
             textStyle = titleTextStyle,
             color = titleColor,
             maxLines = 1,
@@ -114,11 +112,11 @@ private fun CardHeader(
             modifier = Modifier.weight(1F),
         )
 
-        if (trailingSlot !== null) {
-            trailingSlot()
+        if (config.trailingSlot !== null) {
+            config.trailingSlot.invoke(this)
         }
 
-        if (showNavigationIndicator) {
+        if (config.showNavigationIndicator) {
             LemonadeUi.Icon(
                 icon = LemonadeIcons.ChevronRight,
                 contentDescription = null,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -2,6 +2,7 @@ package com.teya.lemonade
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -32,6 +33,7 @@ public fun LemonadeUi.Card(
     contentPadding: LemonadeCardPadding = LemonadeCardPadding.None,
     background: LemonadeCardBackground = LemonadeCardBackground.Default,
     header: CardHeaderConfig? = null,
+    footerAction: CardFooterActionConfig? = null,
     content: (@Composable ColumnScope.() -> Unit),
 ) {
     CoreCard(
@@ -39,6 +41,7 @@ public fun LemonadeUi.Card(
         contentPadding = contentPadding,
         background = background,
         header = header,
+        footerAction = footerAction,
         content = content,
     )
 }
@@ -49,6 +52,7 @@ private fun CoreCard(
     contentPadding: LemonadeCardPadding,
     background: LemonadeCardBackground = LemonadeCardBackground.Default,
     header: CardHeaderConfig? = null,
+    footerAction: CardFooterActionConfig? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
@@ -66,6 +70,10 @@ private fun CoreCard(
                 .padding(contentPadding.spacing),
         ) {
             content()
+        }
+
+        if (footerAction != null) {
+            CardFooterAction(config = footerAction)
         }
     }
 }
@@ -124,6 +132,38 @@ private fun CardHeader(
                 tint = LocalColors.current.content.contentSecondary,
             )
         }
+    }
+}
+
+public data class CardFooterActionConfig(
+    val label: String,
+    val onClick: () -> Unit,
+)
+
+@Composable
+private fun CardFooterAction(
+    config: CardFooterActionConfig,
+) {
+    LemonadeUi.HorizontalDivider(
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = config.onClick)
+            .padding(
+                horizontal = LocalSpaces.current.spacing400,
+                vertical = LocalSpaces.current.spacing200,
+            )
+            .padding(bottom = LocalSpaces.current.spacing200),
+    ) {
+        LemonadeUi.Text(
+            text = config.label,
+            textStyle = LocalTypographies.current.bodySmallSemiBold,
+            color = LocalColors.current.content.contentPrimary,
+        )
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -158,7 +158,7 @@ private val LemonadeCardBackground.background: Color
         return when (this) {
             LemonadeCardBackground.Default -> LocalColors.current.background.bgDefault
             LemonadeCardBackground.Subtle -> LocalColors.current.background.bgSubtle
-            LemonadeCardBackground.SubtleHigh -> LocalColors.current.background.bgElevated
+            LemonadeCardBackground.Elevated -> LocalColors.current.background.bgElevated
         }
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -157,13 +157,12 @@ private fun CardFooterAction(config: CardFooterActionConfig) {
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxWidth()
+            .alpha(alpha = alpha)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = config.onClick,
-            )
-            .alpha(alpha = alpha)
-            .padding(
+            ).padding(
                 start = LocalSpaces.current.spacing400,
                 top = LocalSpaces.current.spacing200,
                 end = LocalSpaces.current.spacing400,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -99,7 +99,7 @@ private fun CardHeader(
                 bottom = LocalSpaces.current.spacing0,
             ),
     ) {
-        if (config.leadingSlot !== null) {
+        if (config.leadingSlot != null) {
             config.leadingSlot.invoke(this)
         }
 
@@ -112,7 +112,7 @@ private fun CardHeader(
             modifier = Modifier.weight(1F),
         )
 
-        if (config.trailingSlot !== null) {
+        if (config.trailingSlot != null) {
             config.trailingSlot.invoke(this)
         }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -1,7 +1,10 @@
 package com.teya.lemonade
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -11,8 +14,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
@@ -142,15 +148,23 @@ public data class CardFooterActionConfig(
 
 @Composable
 private fun CardFooterAction(config: CardFooterActionConfig) {
-    LemonadeUi.HorizontalDivider(
-        modifier = Modifier.fillMaxWidth(),
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val alpha by animateFloatAsState(
+        targetValue = if (isPressed) 0.5f else 1f,
+        label = "CardFooterActionAlpha",
     )
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = config.onClick)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = config.onClick,
+            )
+            .alpha(alpha = alpha)
             .padding(
                 start = LocalSpaces.current.spacing400,
                 top = LocalSpaces.current.spacing200,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -94,11 +94,9 @@ public data class CardHeaderConfig(
 
 @Composable
 private fun CardHeader(
+    config: CardHeaderConfig,
     modifier: Modifier = Modifier,
-    config: CardHeaderConfig? = null,
 ) {
-    if (config == null) return
-
     val titleTextStyle = config.headingStyle.textStyle
     val titleColor = config.headingStyle.color
 

--- a/swiftui/SampleApp/CardDisplayView.swift
+++ b/swiftui/SampleApp/CardDisplayView.swift
@@ -123,6 +123,20 @@ struct CardDisplayView: View {
                         }
                     }
                 }
+
+                // Footer Action
+                sectionView(title: "Footer Action") {
+                    LemonadeUi.Card(
+                        contentPadding: .medium,
+                        header: CardHeaderConfig(title: "Card with Footer"),
+                        footerAction: CardFooterActionConfig(
+                            label: "Action",
+                            onClick: {}
+                        )
+                    ) {
+                        LemonadeUi.Text("Card content with a footer action button.")
+                    }
+                }
             }
             .padding()
         }

--- a/swiftui/SampleApp/CardDisplayView.swift
+++ b/swiftui/SampleApp/CardDisplayView.swift
@@ -5,158 +5,121 @@ struct CardDisplayView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
-                // Basic Card
-                sectionView(title: "Basic Card") {
-                    LemonadeUi.Card(contentPadding: .medium) {
-                        LemonadeUi.Text("This is a basic card with medium padding.")
-                    }
-                }
-
-                // Padding Variants
-                sectionView(title: "Padding Variants") {
-                    VStack(spacing: 16) {
-                        LemonadeUi.Card(contentPadding: .none) {
-                            LemonadeUi.Text("No padding")
-                                .padding()
-                        }
-
-                        LemonadeUi.Card(contentPadding: .xSmall) {
-                            LemonadeUi.Text("XSmall padding")
-                        }
-
-                        LemonadeUi.Card(contentPadding: .small) {
-                            LemonadeUi.Text("Small padding")
-                        }
-
-                        LemonadeUi.Card(contentPadding: .medium) {
-                            LemonadeUi.Text("Medium padding")
-                        }
-                    }
-                }
-
                 // Background Variants
-                sectionView(title: "Background Variants") {
+                sectionView(title: "Backgrounds") {
                     VStack(spacing: 16) {
                         LemonadeUi.Card(contentPadding: .medium, background: .default) {
-                            LemonadeUi.Text("Default background")
+                            LemonadeUi.Text("Default")
                         }
 
                         LemonadeUi.Card(contentPadding: .medium, background: .subtle) {
-                            LemonadeUi.Text("Subtle background")
+                            LemonadeUi.Text("Subtle")
+                        }
+
+                        LemonadeUi.Card(contentPadding: .medium, background: .subtleHigh) {
+                            LemonadeUi.Text("Subtle High")
                         }
                     }
                 }
 
-                // With Header
-                sectionView(title: "With Header") {
+                // Spacing Variants
+                sectionView(title: "Spacing") {
+                    VStack(spacing: 16) {
+                        LemonadeUi.Card(contentPadding: .none) {
+                            LemonadeUi.Text("None")
+                        }
+
+                        LemonadeUi.Card(contentPadding: .xSmall) {
+                            LemonadeUi.Text("XSmall")
+                        }
+
+                        LemonadeUi.Card(contentPadding: .small) {
+                            LemonadeUi.Text("Small")
+                        }
+
+                        LemonadeUi.Card(contentPadding: .medium) {
+                            LemonadeUi.Text("Medium")
+                        }
+                    }
+                }
+
+                // Heading Styles
+                sectionView(title: "Heading Styles") {
                     VStack(spacing: 16) {
                         LemonadeUi.Card(
                             contentPadding: .medium,
-                            header: CardHeaderConfig(title: "Card Title")
-                        ) {
-                            LemonadeUi.Text("Card content goes here. This is an example of a card with a header.")
-                        }
-
-                        LemonadeUi.Card(
-                            contentPadding: .medium,
                             header: CardHeaderConfig(
-                                title: "With Trailing Slot",
+                                title: "Default Heading",
                                 trailingSlot: {
-                                    LemonadeUi.Tag(label: "New", voice: .positive)
+                                    LemonadeUi.Tag(label: "Tag", voice: .neutral)
                                 }
                             )
                         ) {
-                            LemonadeUi.Text("This card has a header with a trailing tag.")
+                            LemonadeUi.Text("Card with default heading style.")
                         }
 
                         LemonadeUi.Card(
                             contentPadding: .medium,
                             header: CardHeaderConfig(
-                                title: "Actions",
+                                title: "Overline Heading",
+                                headingStyle: .overline,
                                 trailingSlot: {
+                                    LemonadeUi.Tag(label: "Tag", voice: .neutral)
+                                }
+                            )
+                        ) {
+                            LemonadeUi.Text("Card with overline heading style.")
+                        }
+                    }
+                }
+
+                // Header Slots
+                sectionView(title: "Header Slots") {
+                    VStack(spacing: 16) {
+                        LemonadeUi.Card(
+                            contentPadding: .medium,
+                            header: CardHeaderConfig(
+                                title: "Leading Icon",
+                                leadingSlot: {
                                     LemonadeUi.Icon(
-                                        icon: .ellipsisVertical,
-                                        contentDescription: "More options",
+                                        icon: .store,
+                                        contentDescription: nil,
                                         size: .medium
                                     )
                                 }
                             )
                         ) {
-                            LemonadeUi.Text("Card with action icon in header.")
+                            LemonadeUi.Text("Header with leading slot.")
                         }
-                    }
-                }
 
-                // Complex Content
-                sectionView(title: "Complex Content") {
-                    LemonadeUi.Card(
-                        contentPadding: .medium,
-                        header: CardHeaderConfig(
-                            title: "Order Summary",
-                            trailingSlot: {
-                                LemonadeUi.Tag(label: "Confirmed", voice: .positive)
-                            }
-                        )
-                    ) {
-                        VStack(alignment: .leading, spacing: 12) {
-                            HStack {
-                                Text("Subtotal")
-                                Spacer()
-                                Text("$99.00")
-                            }
-
-                            HStack {
-                                Text("Shipping")
-                                Spacer()
-                                Text("$5.00")
-                            }
-
-                            Divider()
-
-                            HStack {
-                                Text("Total")
-                                    .fontWeight(.bold)
-                                Spacer()
-                                Text("$104.00")
-                                    .fontWeight(.bold)
-                            }
+                        LemonadeUi.Card(
+                            contentPadding: .medium,
+                            header: CardHeaderConfig(
+                                title: "Navigation",
+                                showNavigationIndicator: true
+                            )
+                        ) {
+                            LemonadeUi.Text("Header with navigation indicator.")
                         }
-                    }
-                }
 
-                // Nested Cards
-                sectionView(title: "Nested Cards") {
-                    LemonadeUi.Card(
-                        contentPadding: .medium,
-                        header: CardHeaderConfig(title: "Payment Methods")
-                    ) {
-                        VStack(spacing: 12) {
-                            LemonadeUi.Card(contentPadding: .small, background: .subtle) {
-                                HStack {
-                                    LemonadeUi.Icon(icon: .card, contentDescription: nil, size: .medium)
-                                    VStack(alignment: .leading) {
-                                        Text("Visa ending in 4242")
-                                        Text("Expires 12/25")
-                                            .font(.caption)
-                                            .foregroundStyle(.content.contentSecondary)
-                                    }
-                                    Spacer()
-                                    LemonadeUi.Tag(label: "Default", voice: .info)
-                                }
-                            }
-
-                            LemonadeUi.Card(contentPadding: .small, background: .subtle) {
-                                HStack {
-                                    LemonadeUi.Icon(icon: .card, contentDescription: nil, size: .medium)
-                                    VStack(alignment: .leading) {
-                                        Text("Mastercard ending in 1234")
-                                        Text("Expires 06/24")
-                                            .font(.caption)
-                                            .foregroundStyle(.content.contentSecondary)
-                                    }
-                                    Spacer()
-                                }
-                            }
+                        LemonadeUi.Card(
+                            contentPadding: .medium,
+                            header: CardHeaderConfig(
+                                title: "All Slots",
+                                leadingSlot: {
+                                    LemonadeUi.Icon(
+                                        icon: .store,
+                                        contentDescription: nil,
+                                        size: .medium
+                                    )
+                                },
+                                trailingSlot: {
+                                    LemonadeUi.Tag(label: "Active", voice: .positive)
+                                },
+                                showNavigationIndicator: true
+                            )
+                        ) {
+                            LemonadeUi.Text("Leading, trailing, and navigation combined.")
                         }
                     }
                 }

--- a/swiftui/SampleApp/CardDisplayView.swift
+++ b/swiftui/SampleApp/CardDisplayView.swift
@@ -16,8 +16,8 @@ struct CardDisplayView: View {
                             LemonadeUi.Text("Subtle")
                         }
 
-                        LemonadeUi.Card(contentPadding: .medium, background: .subtleHigh) {
-                            LemonadeUi.Text("Subtle High")
+                        LemonadeUi.Card(contentPadding: .medium, background: .elevated) {
+                            LemonadeUi.Text("Elevated")
                         }
                     }
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -189,35 +189,7 @@ private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingCon
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if let header = header {
-                HStack(spacing: LemonadeTheme.spaces.spacing200) {
-                    if let leadingSlot = header.leadingSlot {
-                        leadingSlot()
-                    }
-
-                    LemonadeUi.Text(
-                        header.title,
-                        textStyle: header.headingStyle.textStyle,
-                        color: header.headingStyle.textColor,
-                        overflow: .tail,
-                        maxLines: 1
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    if let trailingSlot = header.trailingSlot {
-                        trailingSlot()
-                    }
-
-                    if header.showNavigationIndicator {
-                        LemonadeUi.Icon(
-                            icon: .chevronRight,
-                            contentDescription: nil,
-                            size: .medium,
-                            tint: LemonadeTheme.colors.content.contentSecondary
-                        )
-                    }
-                }
-                .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-                .padding(.top, LemonadeTheme.spaces.spacing400)
+                LemonadeCardHeader(config: header)
             }
 
             VStack(alignment: .leading, spacing: 0) {
@@ -228,6 +200,42 @@ private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingCon
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(background.color)
         .clipShape(LemonadeTheme.shapes.semantic.radiusContainerDefault)
+    }
+}
+
+private struct LemonadeCardHeader<LeadingContent: View, TrailingContent: View>: View {
+    let config: CardHeaderConfig<LeadingContent, TrailingContent>
+
+    var body: some View {
+        HStack(spacing: LemonadeTheme.spaces.spacing200) {
+            if let leadingSlot = config.leadingSlot {
+                leadingSlot()
+            }
+
+            LemonadeUi.Text(
+                config.title,
+                textStyle: config.headingStyle.textStyle,
+                color: config.headingStyle.textColor,
+                overflow: .tail,
+                maxLines: 1
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let trailingSlot = config.trailingSlot {
+                trailingSlot()
+            }
+
+            if config.showNavigationIndicator {
+                LemonadeUi.Icon(
+                    icon: .chevronRight,
+                    contentDescription: nil,
+                    size: .medium,
+                    tint: LemonadeTheme.colors.content.contentSecondary
+                )
+            }
+        }
+        .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+        .padding(.top, LemonadeTheme.spaces.spacing400)
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -205,20 +205,6 @@ private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingCon
     let footerAction: CardFooterActionConfig?
     let content: () -> Content
 
-    init(
-        contentPadding: LemonadeCardPadding,
-        background: LemonadeCardBackground,
-        header: CardHeaderConfig<LeadingContent, TrailingContent>?,
-        footerAction: CardFooterActionConfig? = nil,
-        content: @escaping () -> Content
-    ) {
-        self.contentPadding = contentPadding
-        self.background = background
-        self.header = header
-        self.footerAction = footerAction
-        self.content = content
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if let header = header {
@@ -288,8 +274,8 @@ private struct LemonadeCardFooterAction: View {
             )
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-            .padding(.vertical, LemonadeTheme.spaces.spacing200)
-            .padding(.bottom, LemonadeTheme.spaces.spacing200)
+            .padding(.top, LemonadeTheme.spaces.spacing200)
+            .padding(.bottom, LemonadeTheme.spaces.spacing400)
         }
         .buttonStyle(.plain)
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -130,6 +130,19 @@ extension CardHeaderConfig where TrailingContent == EmptyView {
     }
 }
 
+// MARK: - Card Footer Action Config
+
+/// Configuration for the Card footer action.
+public struct CardFooterActionConfig {
+    let label: String
+    let onClick: () -> Void
+
+    public init(label: String, onClick: @escaping () -> Void) {
+        self.label = label
+        self.onClick = onClick
+    }
+}
+
 // MARK: - Card Component
 
 public extension LemonadeUi {
@@ -146,12 +159,14 @@ public extension LemonadeUi {
         contentPadding: LemonadeCardPadding = .none,
         background: LemonadeCardBackground = .default,
         header: CardHeaderConfig<LeadingContent, TrailingContent>? = nil,
+        footerAction: CardFooterActionConfig? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         LemonadeCardView(
             contentPadding: contentPadding,
             background: background,
             header: header,
+            footerAction: footerAction,
             content: content
         )
     }
@@ -161,18 +176,21 @@ public extension LemonadeUi {
     /// - Parameters:
     ///   - contentPadding: LemonadeCardPadding for the content area. Defaults to .none
     ///   - background: LemonadeCardBackground style. Defaults to .default
+    ///   - footerAction: Optional CardFooterActionConfig for the footer action
     ///   - content: Content to display inside the card
     /// - Returns: A styled Card view
     @ViewBuilder
     static func Card<Content: View>(
         contentPadding: LemonadeCardPadding = .none,
         background: LemonadeCardBackground = .default,
+        footerAction: CardFooterActionConfig? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         LemonadeCardView<Content, EmptyView, EmptyView>(
             contentPadding: contentPadding,
             background: background,
             header: nil,
+            footerAction: footerAction,
             content: content
         )
     }
@@ -184,7 +202,22 @@ private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingCon
     let contentPadding: LemonadeCardPadding
     let background: LemonadeCardBackground
     let header: CardHeaderConfig<LeadingContent, TrailingContent>?
+    let footerAction: CardFooterActionConfig?
     let content: () -> Content
+
+    init(
+        contentPadding: LemonadeCardPadding,
+        background: LemonadeCardBackground,
+        header: CardHeaderConfig<LeadingContent, TrailingContent>?,
+        footerAction: CardFooterActionConfig? = nil,
+        content: @escaping () -> Content
+    ) {
+        self.contentPadding = contentPadding
+        self.background = background
+        self.header = header
+        self.footerAction = footerAction
+        self.content = content
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -196,6 +229,10 @@ private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingCon
                 content()
             }
             .padding(contentPadding.spacing)
+
+            if let footerAction = footerAction {
+                LemonadeCardFooterAction(config: footerAction)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(background.color)
@@ -236,6 +273,27 @@ private struct LemonadeCardHeader<LeadingContent: View, TrailingContent: View>: 
         }
         .padding(.horizontal, LemonadeTheme.spaces.spacing400)
         .padding(.top, LemonadeTheme.spaces.spacing400)
+    }
+}
+
+private struct LemonadeCardFooterAction: View {
+    let config: CardFooterActionConfig
+
+    var body: some View {
+        LemonadeUi.HorizontalDivider()
+
+        Button(action: config.onClick) {
+            LemonadeUi.Text(
+                config.label,
+                textStyle: LemonadeTypography.shared.bodySmallSemiBold,
+                color: LemonadeTheme.colors.content.contentPrimary
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+            .padding(.vertical, LemonadeTheme.spaces.spacing200)
+            .padding(.bottom, LemonadeTheme.spaces.spacing200)
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -280,8 +280,6 @@ private struct LemonadeCardFooterAction: View {
     let config: CardFooterActionConfig
 
     var body: some View {
-        LemonadeUi.HorizontalDivider()
-
         Button(action: config.onClick) {
             LemonadeUi.Text(
                 config.label,

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -8,7 +8,7 @@ public enum LemonadeCardPadding {
     case xSmall
     case small
     case medium
-    
+
     var spacing: CGFloat {
         switch self {
         case .none: return LemonadeTheme.spaces.spacing0
@@ -25,11 +25,35 @@ public enum LemonadeCardPadding {
 public enum LemonadeCardBackground {
     case `default`
     case subtle
-    
+    case subtleHigh
+
     var color: Color {
         switch self {
         case .default: return LemonadeTheme.colors.background.bgDefault
         case .subtle: return LemonadeTheme.colors.background.bgSubtle
+        case .subtleHigh: return LemonadeTheme.colors.background.bgElevated
+        }
+    }
+}
+
+// MARK: - Card Heading Style
+
+/// Heading style options for Card header.
+public enum LemonadeCardHeadingStyle {
+    case `default`
+    case overline
+
+    var textStyle: LemonadeTextStyle {
+        switch self {
+        case .default: return LemonadeTypography.shared.headingXXSmall
+        case .overline: return LemonadeTypography.shared.bodyXSmallOverline
+        }
+    }
+
+    var textColor: Color {
+        switch self {
+        case .default: return LemonadeTheme.colors.content.contentPrimary
+        case .overline: return LemonadeTheme.colors.content.contentSecondary
         }
     }
 }
@@ -37,21 +61,72 @@ public enum LemonadeCardBackground {
 // MARK: - Card Header Config
 
 /// Configuration for the Card header.
-public struct CardHeaderConfig<TrailingContent: View> {
+public struct CardHeaderConfig<LeadingContent: View, TrailingContent: View> {
     let title: String
+    let headingStyle: LemonadeCardHeadingStyle
+    let leadingSlot: (() -> LeadingContent)?
     let trailingSlot: (() -> TrailingContent)?
-    
-    public init(title: String, trailingSlot: (() -> TrailingContent)? = nil) {
+    let showNavigationIndicator: Bool
+
+    public init(
+        title: String,
+        headingStyle: LemonadeCardHeadingStyle = .default,
+        leadingSlot: (() -> LeadingContent)? = nil,
+        trailingSlot: (() -> TrailingContent)? = nil,
+        showNavigationIndicator: Bool = false
+    ) {
         self.title = title
+        self.headingStyle = headingStyle
+        self.leadingSlot = leadingSlot
         self.trailingSlot = trailingSlot
+        self.showNavigationIndicator = showNavigationIndicator
     }
 }
 
-// Convenience initializer without trailing content
-extension CardHeaderConfig where TrailingContent == EmptyView {
-    public init(title: String) {
+// Convenience initializer without leading or trailing content
+extension CardHeaderConfig where LeadingContent == EmptyView, TrailingContent == EmptyView {
+    public init(
+        title: String,
+        headingStyle: LemonadeCardHeadingStyle = .default,
+        showNavigationIndicator: Bool = false
+    ) {
         self.title = title
+        self.headingStyle = headingStyle
+        self.leadingSlot = nil
         self.trailingSlot = nil
+        self.showNavigationIndicator = showNavigationIndicator
+    }
+}
+
+// Convenience initializer with only trailing content
+extension CardHeaderConfig where LeadingContent == EmptyView {
+    public init(
+        title: String,
+        headingStyle: LemonadeCardHeadingStyle = .default,
+        trailingSlot: (() -> TrailingContent)? = nil,
+        showNavigationIndicator: Bool = false
+    ) {
+        self.title = title
+        self.headingStyle = headingStyle
+        self.leadingSlot = nil
+        self.trailingSlot = trailingSlot
+        self.showNavigationIndicator = showNavigationIndicator
+    }
+}
+
+// Convenience initializer with only leading content
+extension CardHeaderConfig where TrailingContent == EmptyView {
+    public init(
+        title: String,
+        headingStyle: LemonadeCardHeadingStyle = .default,
+        leadingSlot: (() -> LeadingContent)? = nil,
+        showNavigationIndicator: Bool = false
+    ) {
+        self.title = title
+        self.headingStyle = headingStyle
+        self.leadingSlot = leadingSlot
+        self.trailingSlot = nil
+        self.showNavigationIndicator = showNavigationIndicator
     }
 }
 
@@ -60,17 +135,6 @@ extension CardHeaderConfig where TrailingContent == EmptyView {
 public extension LemonadeUi {
     /// A card container component with optional header and configurable padding and background.
     ///
-    /// ## Usage
-    /// ```swift
-    /// LemonadeUi.Card(
-    ///     contentPadding: .medium,
-    ///     background: .default,
-    ///     header: CardHeaderConfig(title: "Card Title")
-    /// ) {
-    ///     Text("Card content goes here")
-    /// }
-    /// ```
-    ///
     /// - Parameters:
     ///   - contentPadding: LemonadeCardPadding for the content area. Defaults to .none
     ///   - background: LemonadeCardBackground style. Defaults to .default
@@ -78,10 +142,10 @@ public extension LemonadeUi {
     ///   - content: Content to display inside the card
     /// - Returns: A styled Card view
     @ViewBuilder
-    static func Card<Content: View, TrailingContent: View>(
+    static func Card<Content: View, LeadingContent: View, TrailingContent: View>(
         contentPadding: LemonadeCardPadding = .none,
         background: LemonadeCardBackground = .default,
-        header: CardHeaderConfig<TrailingContent>? = nil,
+        header: CardHeaderConfig<LeadingContent, TrailingContent>? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         LemonadeCardView(
@@ -91,7 +155,7 @@ public extension LemonadeUi {
             content: content
         )
     }
-    
+
     /// A card container component without header.
     ///
     /// - Parameters:
@@ -105,7 +169,7 @@ public extension LemonadeUi {
         background: LemonadeCardBackground = .default,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        LemonadeCardView<Content, EmptyView>(
+        LemonadeCardView<Content, EmptyView, EmptyView>(
             contentPadding: contentPadding,
             background: background,
             header: nil,
@@ -116,34 +180,46 @@ public extension LemonadeUi {
 
 // MARK: - Internal Card View
 
-private struct LemonadeCardView<Content: View, TrailingContent: View>: View {
+private struct LemonadeCardView<Content: View, LeadingContent: View, TrailingContent: View>: View {
     let contentPadding: LemonadeCardPadding
     let background: LemonadeCardBackground
-    let header: CardHeaderConfig<TrailingContent>?
+    let header: CardHeaderConfig<LeadingContent, TrailingContent>?
     let content: () -> Content
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
             if let header = header {
                 HStack(spacing: LemonadeTheme.spaces.spacing200) {
+                    if let leadingSlot = header.leadingSlot {
+                        leadingSlot()
+                    }
+
                     LemonadeUi.Text(
                         header.title,
-                        textStyle: LemonadeTypography.shared.headingXXSmall,
+                        textStyle: header.headingStyle.textStyle,
+                        color: header.headingStyle.textColor,
                         overflow: .tail,
                         maxLines: 1
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    
+
                     if let trailingSlot = header.trailingSlot {
                         trailingSlot()
+                    }
+
+                    if header.showNavigationIndicator {
+                        LemonadeUi.Icon(
+                            icon: .chevronRight,
+                            contentDescription: nil,
+                            size: .medium,
+                            tint: LemonadeTheme.colors.content.contentSecondary
+                        )
                     }
                 }
                 .padding(.horizontal, LemonadeTheme.spaces.spacing400)
                 .padding(.top, LemonadeTheme.spaces.spacing400)
             }
-            
-            // Content
+
             VStack(alignment: .leading, spacing: 0) {
                 content()
             }
@@ -165,7 +241,7 @@ struct LemonadeCard_Previews: PreviewProvider {
             LemonadeUi.Card(contentPadding: .medium) {
                 LemonadeUi.Text("This is card content")
             }
-            
+
             // Card with header
             LemonadeUi.Card(
                 contentPadding: .medium,
@@ -173,7 +249,7 @@ struct LemonadeCard_Previews: PreviewProvider {
             ) {
                 LemonadeUi.Text("Content with header")
             }
-            
+
             // Card with header and trailing slot
             LemonadeUi.Card(
                 contentPadding: .medium,
@@ -186,13 +262,35 @@ struct LemonadeCard_Previews: PreviewProvider {
             ) {
                 LemonadeUi.Text("Content with header and trailing tag")
             }
-            
-            // Subtle background
+
+            // Card with overline heading
             LemonadeUi.Card(
                 contentPadding: .medium,
-                background: .subtle
+                header: CardHeaderConfig(
+                    title: "Overline Title",
+                    headingStyle: .overline
+                )
             ) {
-                LemonadeUi.Text("Subtle background card")
+                LemonadeUi.Text("Content with overline heading")
+            }
+
+            // Card with navigation indicator
+            LemonadeUi.Card(
+                contentPadding: .medium,
+                header: CardHeaderConfig(
+                    title: "Navigable Card",
+                    showNavigationIndicator: true
+                )
+            ) {
+                LemonadeUi.Text("Card with navigation indicator")
+            }
+
+            // Subtle High background
+            LemonadeUi.Card(
+                contentPadding: .medium,
+                background: .subtleHigh
+            ) {
+                LemonadeUi.Text("Subtle High background card")
             }
         }
         .padding()

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -25,13 +25,13 @@ public enum LemonadeCardPadding {
 public enum LemonadeCardBackground {
     case `default`
     case subtle
-    case subtleHigh
+    case elevated
 
     var color: Color {
         switch self {
         case .default: return LemonadeTheme.colors.background.bgDefault
         case .subtle: return LemonadeTheme.colors.background.bgSubtle
-        case .subtleHigh: return LemonadeTheme.colors.background.bgElevated
+        case .elevated: return LemonadeTheme.colors.background.bgElevated
         }
     }
 }
@@ -293,12 +293,12 @@ struct LemonadeCard_Previews: PreviewProvider {
                 LemonadeUi.Text("Card with navigation indicator")
             }
 
-            // Subtle High background
+            // Elevated background
             LemonadeUi.Card(
                 contentPadding: .medium,
-                background: .subtleHigh
+                background: .elevated
             ) {
-                LemonadeUi.Text("Subtle High background card")
+                LemonadeUi.Text("Elevated background card")
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- Add **SubtleHigh** background variant (mapped to `bgElevated` token) to Card component
- Add **Overline** heading style with `bodyXSmallOverline` typography and `contentSecondary` color
- Add **leading slot** support in Card header for icons/content before the title
- Add **navigation indicator** (chevron-right) option in Card header
- Simplify KMP and SwiftUI sample apps to 4 focused sections covering all new features

<img width="342" height="727" alt="image" src="https://github.com/user-attachments/assets/9e2b2db6-88fe-4163-b10d-2545869dac22" />


<img width="342" height="2622" alt="image" src="https://github.com/user-attachments/assets/6e91b8c4-2f43-42b5-9df8-39af638e6652" />


### Platforms
- KMP (Kotlin/Compose)
- SwiftUI


## Test plan
- [x] KMP `:ui` module compiles
- [x] KMP `:composeApp` compiles and installs on Pixel 7 Pro emulator
- [x] SwiftUI `Lemonade` framework builds
- [x] SwiftUI `LemonadeSampleApp` builds and installs on iPhone 17 Pro simulator
- [ ] Visual review of Card samples on Android emulator
- [ ] Visual review of Card samples on iOS simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)