### PR TITLE
feat: add size tokens and icon-only layout to SegmentedControl

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeSegmentedControlSize
@@ -127,10 +129,10 @@ internal fun SegmentedControlDisplay() {
                 },
                 selectedTab = selectedIconOnly,
                 size = LemonadeSegmentedControlSize.Small,
+                modifier = Modifier.width(IntrinsicSize.Min),
                 properties = listOf(
-                    TabButtonProperties.icon(icon = LemonadeIcons.Heart),
-                    TabButtonProperties.icon(icon = LemonadeIcons.Star),
-                    TabButtonProperties.icon(icon = LemonadeIcons.Gear),
+                    TabButtonProperties.icon(icon = LemonadeIcons.List),
+                    TabButtonProperties.icon(icon = LemonadeIcons.StackThree),
                 ),
             )
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SegmentedControlDisplay.kt
@@ -2,13 +2,13 @@ package com.teya.lemonade
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeSegmentedControlSize

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -201,6 +202,10 @@ internal fun CoreSegmentedControl(
 
     Box(
         modifier = modifier
+            .defaultMinSize(
+                minWidth = size.buttonMinWidth(),
+                minHeight = size.buttonMinHeight(),
+            )
             .height(height = size.containerHeight())
             .background(
                 color = LocalColors.current.background.bgElevated,
@@ -336,6 +341,28 @@ private fun LemonadeSegmentedControlSize.containerPadding(): Dp {
         LemonadeSegmentedControlSize.Medium,
         LemonadeSegmentedControlSize.Large,
         -> spaces.spacing100
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.buttonMinWidth(): Dp {
+    val sizes = LocalSizes.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> sizes.size800
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> sizes.size1200
+    }
+}
+
+@Composable
+private fun LemonadeSegmentedControlSize.buttonMinHeight(): Dp {
+    val sizes = LocalSizes.current
+    return when (this) {
+        LemonadeSegmentedControlSize.Small -> sizes.size700
+        LemonadeSegmentedControlSize.Medium,
+        LemonadeSegmentedControlSize.Large,
+        -> sizes.size800
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -205,8 +205,7 @@ internal fun CoreSegmentedControl(
             .defaultMinSize(
                 minWidth = size.buttonMinWidth(),
                 minHeight = size.buttonMinHeight(),
-            )
-            .height(height = size.containerHeight())
+            ).height(height = size.containerHeight())
             .background(
                 color = LocalColors.current.background.bgElevated,
                 shape = pillShape,

--- a/swiftui/SampleApp/SegmentedControlDisplayView.swift
+++ b/swiftui/SampleApp/SegmentedControlDisplayView.swift
@@ -95,14 +95,14 @@ struct SegmentedControlDisplayView: View {
                     VStack(spacing: 16) {
                         LemonadeUi.SegmentedControl(
                             properties: [
-                                .icon(.heart),
-                                .icon(.star),
-                                .icon(.gear),
+                                .icon(.list),
+                                .icon(.stackThree),
                             ],
                             selectedTab: selectedTabIconOnly,
                             size: .small,
                             onTabSelected: { selectedTabIconOnly = $0 }
                         )
+                        .fixedSize(horizontal: true, vertical: false)
                     }
                 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -164,7 +164,16 @@ private struct LemonadeSegmentedControlView: View {
             )
             .frame(height: size.containerHeight)
         } else {
-            // Fallback on earlier versions
+            labelsOverlay
+                .frame(
+                    minWidth: size.buttonMinWidth,
+                    minHeight: size.buttonMinHeight
+                )
+                .frame(height: size.containerHeight)
+                .background(
+                    RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
+                        .fill(LemonadeTheme.colors.background.bgElevated)
+                )
         }
         #else
         labelsOverlay
@@ -269,20 +278,30 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
         // Inset the control by containerPadding so its segments align with the overlay buttons
         control.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(control)
-        NSLayoutConstraint.activate([
-            control.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: containerPadding),
-            control.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -containerPadding),
-            control.topAnchor.constraint(equalTo: container.topAnchor, constant: containerPadding),
-            control.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -containerPadding),
-        ])
+
+        let leading = control.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: containerPadding)
+        let trailing = control.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -containerPadding)
+        let top = control.topAnchor.constraint(equalTo: container.topAnchor, constant: containerPadding)
+        let bottom = control.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -containerPadding)
+        NSLayoutConstraint.activate([leading, trailing, top, bottom])
 
         context.coordinator.control = control
+        context.coordinator.leadingConstraint = leading
+        context.coordinator.trailingConstraint = trailing
+        context.coordinator.topConstraint = top
+        context.coordinator.bottomConstraint = bottom
         return container
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
         guard let control = context.coordinator.control else { return }
         context.coordinator.onSelectionChanged = onSelectionChanged
+
+        // Update padding constraints if size changed
+        context.coordinator.leadingConstraint?.constant = containerPadding
+        context.coordinator.trailingConstraint?.constant = -containerPadding
+        context.coordinator.topConstraint?.constant = containerPadding
+        context.coordinator.bottomConstraint?.constant = -containerPadding
 
         // Reconcile segment count if properties changed
         if control.numberOfSegments != segmentLabels.count {
@@ -304,6 +323,10 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
     class Coordinator: NSObject {
         var onSelectionChanged: (Int) -> Void
         weak var control: UISegmentedControl?
+        var leadingConstraint: NSLayoutConstraint?
+        var trailingConstraint: NSLayoutConstraint?
+        var topConstraint: NSLayoutConstraint?
+        var bottomConstraint: NSLayoutConstraint?
 
         init(onSelectionChanged: @escaping (Int) -> Void) {
             self.onSelectionChanged = onSelectionChanged

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -55,6 +55,34 @@ private extension LemonadeSegmentedControlSize {
         }
     }
 
+    var containerPadding: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.spaces.spacing50
+        case .medium, .large: return LemonadeTheme.spaces.spacing100
+        }
+    }
+
+    var buttonMinWidth: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.sizes.size800
+        case .medium, .large: return LemonadeTheme.sizes.size1200
+        }
+    }
+
+    var buttonMinHeight: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.sizes.size700
+        case .medium, .large: return LemonadeTheme.sizes.size800
+        }
+    }
+
+    var buttonHorizontalPadding: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.spaces.spacing200
+        case .medium, .large: return LemonadeTheme.spaces.spacing300
+        }
+    }
+
     var textStyle: LemonadeTextStyle {
         switch self {
         case .small: return LemonadeTypography.shared.bodyXSmallMedium
@@ -123,18 +151,27 @@ private struct LemonadeSegmentedControlView: View {
                 LemonadeNativeSegmentedControl(
                     segmentLabels: properties.map { $0.label ?? $0.icon?.rawValue ?? "" },
                     selectedIndex: clampedSelectedTab,
+                    containerPadding: size.containerPadding,
                     onSelectionChanged: onTabSelected
                 )
-                
+
                 labelsOverlay
+                    .allowsHitTesting(false)
             }
+            .frame(
+                minWidth: size.buttonMinWidth,
+                minHeight: size.buttonMinHeight
+            )
             .frame(height: size.containerHeight)
-//            .glassEffect(.regular.tint(.clear).interactive())
         } else {
             // Fallback on earlier versions
         }
         #else
         labelsOverlay
+            .frame(
+                minWidth: size.buttonMinWidth,
+                minHeight: size.buttonMinHeight
+            )
             .frame(height: size.containerHeight)
             .background(
                 RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
@@ -174,12 +211,14 @@ private struct LemonadeSegmentedControlView: View {
                             )
                         }
                     }
+                    .padding(.horizontal, size.buttonHorizontalPadding)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .buttonStyle(SegmentPressStyle())
                 .frame(maxWidth: .infinity)
             }
         }
+        .padding(size.containerPadding)
         .animation(.easeInOut(duration: 0.2), value: clampedSelectedTab)
     }
 }
@@ -200,18 +239,20 @@ import UIKit
 private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
     let segmentLabels: [String]
     let selectedIndex: Int
+    let containerPadding: CGFloat
     let onSelectionChanged: (Int) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onSelectionChanged: onSelectionChanged)
     }
 
-    func makeUIView(context: Context) -> UISegmentedControl {
+    func makeUIView(context: Context) -> UIView {
+        let container = UIView()
+        container.backgroundColor = .clear
+
         let control = UISegmentedControl(items: segmentLabels)
         control.selectedSegmentIndex = min(selectedIndex, segmentLabels.count - 1)
         control.backgroundColor = .clear
-        control.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        control.setContentHuggingPriority(.defaultLow, for: .vertical)
         control.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
         // Hide native text — custom SwiftUI overlay handles visuals
@@ -224,31 +265,45 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
             action: #selector(Coordinator.segmentChanged(_:)),
             for: .valueChanged
         )
-        return control
+
+        // Inset the control by containerPadding so its segments align with the overlay buttons
+        control.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(control)
+        NSLayoutConstraint.activate([
+            control.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: containerPadding),
+            control.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -containerPadding),
+            control.topAnchor.constraint(equalTo: container.topAnchor, constant: containerPadding),
+            control.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -containerPadding),
+        ])
+
+        context.coordinator.control = control
+        return container
     }
 
-    func updateUIView(_ uiView: UISegmentedControl, context: Context) {
+    func updateUIView(_ uiView: UIView, context: Context) {
+        guard let control = context.coordinator.control else { return }
         context.coordinator.onSelectionChanged = onSelectionChanged
 
         // Reconcile segment count if properties changed
-        if uiView.numberOfSegments != segmentLabels.count {
-            uiView.removeAllSegments()
+        if control.numberOfSegments != segmentLabels.count {
+            control.removeAllSegments()
             for (index, label) in segmentLabels.enumerated() {
-                uiView.insertSegment(withTitle: label, at: index, animated: false)
+                control.insertSegment(withTitle: label, at: index, animated: false)
             }
             let clearAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.clear]
-            uiView.setTitleTextAttributes(clearAttributes, for: .normal)
-            uiView.setTitleTextAttributes(clearAttributes, for: .selected)
+            control.setTitleTextAttributes(clearAttributes, for: .normal)
+            control.setTitleTextAttributes(clearAttributes, for: .selected)
         }
 
         let clampedIndex = min(selectedIndex, segmentLabels.count - 1)
-        if uiView.selectedSegmentIndex != clampedIndex {
-            uiView.selectedSegmentIndex = clampedIndex
+        if control.selectedSegmentIndex != clampedIndex {
+            control.selectedSegmentIndex = clampedIndex
         }
     }
 
     class Coordinator: NSObject {
         var onSelectionChanged: (Int) -> Void
+        weak var control: UISegmentedControl?
 
         init(onSelectionChanged: @escaping (Int) -> Void) {
             self.onSelectionChanged = onSelectionChanged
@@ -312,6 +367,7 @@ struct LemonadeSegmentedControl_Previews: PreviewProvider {
                 size: .small,
                 onTabSelected: { _ in }
             )
+            .fixedSize(horizontal: true, vertical: false)
         }
         .padding()
         .previewLayout(.sizeThatFits)


### PR DESCRIPTION
# Summary

Add missing size tokens (`buttonMinWidth`, `buttonMinHeight`, `containerPadding`, `buttonHorizontalPadding`) to the SegmentedControl component on both KMP and iOS, matching the Figma spec. Icon-only variants no longer stretch to full width and instead use intrinsic sizing.

## Screenshot

| Android | iOS |
|---------|-----|
| <video src="https://github.com/user-attachments/assets/a8490c31-b981-49d9-80d5-2742a3ff8b41" /> | <video src="https://github.com/user-attachments/assets/2c658ced-cde0-47d5-8297-f31ce76a867f" /> |
