### PR TITLE
[SwiftUI] Update LemonadeBadge to use modifier instead of direct argument

### DIFF
--- a/swiftui/SampleApp/BadgeDisplayView.swift
+++ b/swiftui/SampleApp/BadgeDisplayView.swift
@@ -9,39 +9,49 @@ struct BadgeDisplayView: View {
                 sectionView(title: "Sizes") {
                     HStack(spacing: 16) {
                         VStack(spacing: 8) {
-                            LemonadeUi.Badge(text: "New", size: .xSmall)
+                            LemonadeUi.Badge(text: "New")
+                                .badgeSize(.xSmall)
                             Text("XSmall")
                                 .font(.caption)
                         }
-
+                        
                         VStack(spacing: 8) {
-                            LemonadeUi.Badge(text: "New", size: .small)
+                            LemonadeUi.Badge(text: "New")
+                                .badgeSize(.small)
                             Text("Small")
                                 .font(.caption)
                         }
                     }
                 }
-
+                
                 // With Numbers
                 sectionView(title: "With Numbers") {
                     HStack(spacing: 16) {
-                        LemonadeUi.Badge(text: "1", size: .xSmall)
-                        LemonadeUi.Badge(text: "5", size: .small)
-                        LemonadeUi.Badge(text: "99", size: .small)
-                        LemonadeUi.Badge(text: "99+", size: .small)
+                        LemonadeUi.Badge(text: "1")
+                            .badgeSize(.xSmall)
+                        LemonadeUi.Badge(text: "5")
+                            .badgeSize(.small)
+                        LemonadeUi.Badge(text: "99")
+                            .badgeSize(.small)
+                        LemonadeUi.Badge(text: "99+")
+                            .badgeSize(.small)
                     }
                 }
-
+                
                 // Labels
                 sectionView(title: "Labels") {
                     HStack(spacing: 16) {
-                        LemonadeUi.Badge(text: "New", size: .small)
-                        LemonadeUi.Badge(text: "Hot", size: .small)
-                        LemonadeUi.Badge(text: "Sale", size: .small)
-                        LemonadeUi.Badge(text: "Beta", size: .small)
+                        LemonadeUi.Badge(text: "New")
+                            .badgeSize(.xSmall)
+                        LemonadeUi.Badge(text: "Hot")
+                            .badgeSize(.xSmall)
+                        LemonadeUi.Badge(text: "Sale")
+                            .badgeSize(.xSmall)
+                        LemonadeUi.Badge(text: "Beta")
+                            .badgeSize(.xSmall)
                     }
                 }
-
+                
                 // In Context
                 sectionView(title: "In Context") {
                     VStack(spacing: 24) {
@@ -53,31 +63,34 @@ struct BadgeDisplayView: View {
                                     contentDescription: "Notifications",
                                     size: .large
                                 )
-                                LemonadeUi.Badge(text: "3", size: .xSmall)
+                                LemonadeUi.Badge(text: "3")
+                                    .badgeSize(.xSmall)
                                     .offset(x: 8, y: -8)
                             }
-
+                            
                             ZStack(alignment: .topTrailing) {
                                 LemonadeUi.Icon(
                                     icon: .envelope,
                                     contentDescription: "Messages",
                                     size: .large
                                 )
-                                LemonadeUi.Badge(text: "12", size: .xSmall)
+                                LemonadeUi.Badge(text: "12")
+                                    .badgeSize(.xSmall)
                                     .offset(x: 8, y: -8)
                             }
-
+                            
                             ZStack(alignment: .topTrailing) {
                                 LemonadeUi.Icon(
                                     icon: .shoppingBag,
                                     contentDescription: "Cart",
                                     size: .large
                                 )
-                                LemonadeUi.Badge(text: "99+", size: .xSmall)
+                                LemonadeUi.Badge(text: "99+")
+                                    .badgeSize(.xSmall)
                                     .offset(x: 12, y: -8)
                             }
                         }
-
+                        
                         // Menu item with badge
                         HStack {
                             LemonadeUi.Icon(
@@ -87,12 +100,13 @@ struct BadgeDisplayView: View {
                             )
                             Text("Inbox")
                             Spacer()
-                            LemonadeUi.Badge(text: "5", size: .small)
+                            LemonadeUi.Badge(text: "5")
+                                .badgeSize(.small)
                         }
                         .padding()
                         .background(.bg.bgSubtle)
                         .clipShape(.rect(cornerRadius: 12))
-
+                        
                         // Tab-like item with badge
                         HStack(spacing: 24) {
                             VStack(spacing: 4) {
@@ -106,7 +120,7 @@ struct BadgeDisplayView: View {
                                 Text("Home")
                                     .font(.caption)
                             }
-
+                            
                             VStack(spacing: 4) {
                                 ZStack(alignment: .topTrailing) {
                                     LemonadeUi.Icon(
@@ -114,13 +128,14 @@ struct BadgeDisplayView: View {
                                         contentDescription: nil,
                                         size: .medium
                                     )
-                                    LemonadeUi.Badge(text: "2", size: .xSmall)
+                                    LemonadeUi.Badge(text: "2")
+                                        .badgeSize(.xSmall)
                                         .offset(x: 8, y: -8)
                                 }
                                 Text("Alerts")
                                     .font(.caption)
                             }
-
+                            
                             VStack(spacing: 4) {
                                 ZStack(alignment: .topTrailing) {
                                     LemonadeUi.Icon(
@@ -128,7 +143,8 @@ struct BadgeDisplayView: View {
                                         contentDescription: nil,
                                         size: .medium
                                     )
-                                    LemonadeUi.Badge(text: "New", size: .xSmall)
+                                    LemonadeUi.Badge(text: "New")
+                                        .badgeSize(.xSmall)
                                         .offset(x: 12, y: -8)
                                 }
                                 Text("Profile")
@@ -142,13 +158,13 @@ struct BadgeDisplayView: View {
         }
         .navigationTitle("Badge")
     }
-
+    
     private func sectionView<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.headline)
                 .foregroundStyle(.content.contentSecondary)
-
+            
             content()
         }
     }

--- a/swiftui/SampleApp/ListItemDisplayView.swift
+++ b/swiftui/SampleApp/ListItemDisplayView.swift
@@ -216,7 +216,8 @@ struct ActionListItemPreview: View {
                         )
                     },
                     trailingSlot: {
-                        LemonadeUi.Badge(text: "3", size: .small)
+                        LemonadeUi.Badge(text: "3")
+                            .badgeSize(.small)
                     }
                 )
                 

--- a/swiftui/SampleApp/SymbolContainerDisplayView.swift
+++ b/swiftui/SampleApp/SymbolContainerDisplayView.swift
@@ -10,7 +10,7 @@ struct SymbolContainerDisplayView: View {
         (.xLarge, "XLarge"),
         (.xxLarge, "XXLarge"),
     ]
-
+    
     private let allVoices: [(SymbolContainerVoice, String, LemonadeIcon)] = [
         (.neutral, "Neutral", .heart),
         (.critical, "Critical", .circleX),
@@ -20,19 +20,19 @@ struct SymbolContainerDisplayView: View {
         (.brand, "Brand", .star),
         (.brandSubtle, "Brand Subtle", .star),
     ]
-
+    
     private let allShapes: [(SymbolContainerShape, String)] = [
         (.circle, "Circle"),
         (.rounded, "Rounded"),
     ]
-
+    
     private let badgeSizes: [(SymbolContainerSize, String)] = [
         (.small, "Small"),
         (.medium, "Medium"),
         (.large, "Large"),
         (.xLarge, "XLarge"),
     ]
-
+    
     private let imageSizes: [(SymbolContainerSize, String)] = [
         (.small, "Small"),
         (.medium, "Medium"),
@@ -40,7 +40,7 @@ struct SymbolContainerDisplayView: View {
         (.xLarge, "XLarge"),
         (.xxLarge, "XXLarge"),
     ]
-
+    
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
@@ -56,9 +56,9 @@ struct SymbolContainerDisplayView: View {
         }
         .navigationTitle("SymbolContainer")
     }
-
+    
     // MARK: - Sizes
-
+    
     private var sizesSection: some View {
         sectionView(title: "Sizes (Icon)") {
             FlowLayout(spacing: 16) {
@@ -75,9 +75,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Voices
-
+    
     private var voicesSection: some View {
         sectionView(title: "Voices") {
             FlowLayout(spacing: 16) {
@@ -95,15 +95,15 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Shapes
-
+    
     private let roundedScalingSizes: [(SymbolContainerSize, String)] = [
         (.large, "Rounded L"),
         (.xLarge, "Rounded XL"),
         (.xxLarge, "Rounded XXL"),
     ]
-
+    
     private var shapesSection: some View {
         sectionView(title: "Shapes") {
             VStack(alignment: .leading, spacing: 16) {
@@ -136,9 +136,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Badge
-
+    
     private var badgeSection: some View {
         sectionView(title: "With Badge") {
             HStack(spacing: 24) {
@@ -149,7 +149,8 @@ struct SymbolContainerDisplayView: View {
                             contentDescription: nil,
                             size: size
                         ) {
-                            LemonadeUi.Badge(text: "3", size: .xSmall)
+                            LemonadeUi.Badge(text: "3")
+                                .badgeSize(.xSmall)
                         }
                         Text(label).font(.caption)
                     }
@@ -157,9 +158,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Image
-
+    
     private var imageSection: some View {
         sectionView(title: "Image Variants") {
             VStack(alignment: .leading, spacing: 16) {
@@ -177,7 +178,7 @@ struct SymbolContainerDisplayView: View {
                         }
                     }
                 }
-
+                
                 Text("fill = true").font(.subheadline)
                 HStack(spacing: 16) {
                     ForEach(allShapes, id: \.0) { shape, label in
@@ -196,9 +197,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Text
-
+    
     private var textSection: some View {
         sectionView(title: "Text Variant") {
             FlowLayout(spacing: 16) {
@@ -215,9 +216,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Custom Content
-
+    
     private var customContentSection: some View {
         sectionView(title: "Custom Content") {
             HStack(spacing: 16) {
@@ -225,7 +226,7 @@ struct SymbolContainerDisplayView: View {
                     Image(systemName: "star.fill")
                         .foregroundStyle(.yellow)
                 }
-
+                
                 LemonadeUi.SymbolContainer(voice: .info, size: .large) {
                     Image(systemName: "person.fill")
                         .foregroundStyle(.content.contentInfo)
@@ -233,9 +234,9 @@ struct SymbolContainerDisplayView: View {
             }
         }
     }
-
+    
     // MARK: - Helpers
-
+    
     private func sectionView<Content: View>(
         title: String,
         @ViewBuilder content: () -> Content
@@ -253,12 +254,12 @@ struct SymbolContainerDisplayView: View {
 
 private struct FlowLayout: Layout {
     var spacing: CGFloat = 8
-
+    
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         let result = arrange(proposal: proposal, subviews: subviews)
         return result.size
     }
-
+    
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
         let result = arrange(proposal: proposal, subviews: subviews)
         for (index, position) in result.positions.enumerated() {
@@ -268,7 +269,7 @@ private struct FlowLayout: Layout {
             )
         }
     }
-
+    
     private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (positions: [CGPoint], size: CGSize) {
         let maxWidth = proposal.width ?? .infinity
         var positions: [CGPoint] = []
@@ -276,7 +277,7 @@ private struct FlowLayout: Layout {
         var y: CGFloat = 0
         var rowHeight: CGFloat = 0
         var totalSize: CGSize = .zero
-
+        
         for subview in subviews {
             let size = subview.sizeThatFits(.unspecified)
             if x + size.width > maxWidth, x > 0 {
@@ -290,7 +291,7 @@ private struct FlowLayout: Layout {
             totalSize.width = max(totalSize.width, x - spacing)
             totalSize.height = max(totalSize.height, y + rowHeight)
         }
-
+        
         return (positions, totalSize)
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
@@ -6,39 +6,39 @@ import SwiftUI
 public enum LemonadeBadgeSize {
     case xSmall
     case small
-
+    
     var height: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.sizes.size400
         case .small: return LemonadeTheme.sizes.size500
         }
     }
-
+    
     var horizontalPadding: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.spaces.spacing50
         case .small: return LemonadeTheme.spaces.spacing100
         }
     }
-
+    
     var textHorizontalPadding: CGFloat {
         LemonadeTheme.spaces.spacing50
     }
-
+    
     var textVerticalPadding: CGFloat {
         switch self {
         case .xSmall: return 1
         case .small: return 2
         }
     }
-
+    
     var fontSize: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.sizes.size250
         case .small: return LemonadeTheme.sizes.size300
         }
     }
-
+    
     var lineHeight: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.sizes.size350
@@ -49,33 +49,70 @@ public enum LemonadeBadgeSize {
 
 // MARK: - Badge Component
 
-public extension LemonadeUi {
-    /// Badge component to highlight new or unread items, or to indicate status.
+private struct LemonadeBadgeSizeKey: EnvironmentKey {
+    static let defaultValue: LemonadeBadgeSize = .small
+}
+
+extension EnvironmentValues {
+    var lemonadeBadgeSize: LemonadeBadgeSize {
+        get { self[LemonadeBadgeSizeKey.self] }
+        set { self[LemonadeBadgeSizeKey.self] = newValue }
+    }
+}
+
+// MARK: - Modifier
+
+private struct LemonadeBadgeSizeModifier: ViewModifier {
+    let size: LemonadeBadgeSize
+    
+    func body(content: Content) -> some View {
+        content.environment(\.lemonadeBadgeSize, size)
+    }
+}
+
+public extension View {
+
+    /// Sets the size of a `LemonadeBadge`.
     ///
-    /// Badges are small, rounded indicators that can be used to draw attention
-    /// to specific elements. They typically display counts, statuses, or categories.
+    /// This modifier should only be used with `LemonadeUi.Badge(...)`.
+    ///
+    /// - Parameter size: The badge size configuration
+    /// - Returns: A view with the updated badge size environment value
+    func badgeSize(_ size: LemonadeBadgeSize) -> some View {
+        modifier(LemonadeBadgeSizeModifier(size: size))
+    }
+}
+
+// MARK: - Public API
+
+public extension LemonadeUi {
+
+    /// Badge component to highlight new or unread items, or to indicate status.
     ///
     /// ## Usage
     /// ```swift
-    /// LemonadeUi.Badge(
-    ///     text: "New",
-    ///     size: .small
-    /// )
+    /// LemonadeUi.Badge(text: "New")
+    ///     .badgeSize(.small)
     /// ```
     ///
-    /// - Parameters:
+    ///  Parameters:
     ///   - text: The text to be displayed inside the badge
-    ///   - size: The size of the badge. Defaults to .small
     /// - Returns: A styled Badge view
     @ViewBuilder
     static func Badge(
-        text: String,
-        size: LemonadeBadgeSize = .small
+        text: String
     ) -> some View {
-        LemonadeBadgeView(
-            text: text,
-            size: size
-        )
+        LemonadeBadgeView(text: text)
+    }
+    
+    @available(*, deprecated, message: "Use LemonadeUi.Badge(text:).badgeSize(_:) instead.")
+    @ViewBuilder
+    static func Badge(
+        text: String,
+        size: LemonadeBadgeSize
+    ) -> some View {
+        LemonadeBadgeView(text: text)
+            .badgeSize(size)
     }
 }
 
@@ -83,8 +120,10 @@ public extension LemonadeUi {
 
 private struct LemonadeBadgeView: View {
     let text: String
-    let size: LemonadeBadgeSize
-
+    
+    @Environment(\.lemonadeBadgeSize)
+    private var size
+    
     private var gradientColors: [Color] {
         let brandHighlight = LemonadeTheme.colors.background.bgBrandHigh
         return [
@@ -92,9 +131,9 @@ private struct LemonadeBadgeView: View {
             brandHighlight.opacity(0)
         ]
     }
-
+    
     var body: some View {
-        SwiftUI.Text(text)
+        Text(text)
             .font(.custom(LemonadeTypography.fontFamily, size: size.fontSize).weight(.semibold))
             .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
             .lineLimit(1)
@@ -106,7 +145,7 @@ private struct LemonadeBadgeView: View {
                 ZStack {
                     Capsule()
                         .fill(LemonadeTheme.colors.background.bgBrand)
-
+                    
                     Capsule()
                         .fill(
                             LinearGradient(
@@ -128,16 +167,23 @@ struct LemonadeBadge_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 24) {
             HStack(spacing: 16) {
-                LemonadeUi.Badge(text: "New", size: .xSmall)
-                LemonadeUi.Badge(text: "New", size: .small)
+                LemonadeUi.Badge(text: "New")
+                    .badgeSize(.xSmall)
+                
+                LemonadeUi.Badge(text: "New")
+                    .badgeSize(.small)
             }
-
+            
             HStack(spacing: 16) {
-                LemonadeUi.Badge(text: "5", size: .xSmall)
-                LemonadeUi.Badge(text: "99+", size: .small)
+                LemonadeUi.Badge(text: "5")
+                    .badgeSize(.xSmall)
+                
+                LemonadeUi.Badge(text: "99+")
+                    .badgeSize(.small)
             }
-
-            LemonadeUi.Badge(text: "Label", size: .small)
+            
+            LemonadeUi.Badge(text: "Label")
+                .badgeSize(.small)
         }
         .padding()
         .previewLayout(.sizeThatFits)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
@@ -11,7 +11,7 @@ public enum SymbolContainerVoice {
     case positive
     case brand
     case brandSubtle
-
+    
     var tintColor: Color {
         switch self {
         case .neutral: return LemonadeTheme.colors.content.contentPrimary
@@ -23,7 +23,7 @@ public enum SymbolContainerVoice {
         case .brandSubtle: return LemonadeTheme.colors.content.contentOnBrandHigh
         }
     }
-
+    
     var containerColor: Color {
         switch self {
         case .neutral: return LemonadeTheme.colors.background.bgNeutralSubtle
@@ -47,7 +47,7 @@ public enum SymbolContainerSize {
     case large
     case xLarge
     case xxLarge
-
+    
     var containerSize: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.sizes.size600
@@ -58,7 +58,7 @@ public enum SymbolContainerSize {
         case .xxLarge: return LemonadeTheme.sizes.size2000
         }
     }
-
+    
     var contentSize: CGFloat {
         switch self {
         case .xSmall: return LemonadeTheme.sizes.size300
@@ -69,7 +69,7 @@ public enum SymbolContainerSize {
         case .xxLarge: return LemonadeTheme.sizes.size1000
         }
     }
-
+    
     var iconSize: LemonadeUiIconSize {
         switch self {
         case .xSmall: return .xSmall
@@ -80,7 +80,7 @@ public enum SymbolContainerSize {
         case .xxLarge: return .xxLarge
         }
     }
-
+    
     var textStyle: LemonadeTextStyle {
         switch self {
         case .xSmall: return LemonadeTypography.shared.bodyXSmallSemiBold
@@ -104,9 +104,9 @@ public enum SymbolContainerShape {
 // MARK: - SymbolContainer Component
 
 public extension LemonadeUi {
-
+    
     // MARK: Icon
-
+    
     /// A versatile container used to display an icon with consistent sizing and tone.
     ///
     /// - Parameters:
@@ -135,7 +135,7 @@ public extension LemonadeUi {
             )
         }
     }
-
+    
     /// A versatile container used to display an icon with consistent sizing and tone (no badge).
     @ViewBuilder
     static func SymbolContainer(
@@ -154,9 +154,9 @@ public extension LemonadeUi {
             badgeSlot: { EmptyView() }
         )
     }
-
+    
     // MARK: Text
-
+    
     /// A versatile container used to display text with consistent sizing and tone.
     ///
     /// - Parameters:
@@ -182,7 +182,7 @@ public extension LemonadeUi {
             )
         }
     }
-
+    
     /// A versatile container used to display text with consistent sizing and tone (no badge).
     @ViewBuilder
     static func SymbolContainer(
@@ -199,9 +199,9 @@ public extension LemonadeUi {
             badgeSlot: { EmptyView() }
         )
     }
-
+    
     // MARK: Image
-
+    
     /// A versatile container used to display an image with consistent sizing and tone.
     ///
     /// - Parameters:
@@ -233,7 +233,7 @@ public extension LemonadeUi {
             )
         }
     }
-
+    
     /// A versatile container used to display an image with consistent sizing and tone (no badge).
     @ViewBuilder
     static func SymbolContainer(
@@ -254,9 +254,9 @@ public extension LemonadeUi {
             badgeSlot: { EmptyView() }
         )
     }
-
+    
     // MARK: Custom Content
-
+    
     /// A versatile container used to display custom content with consistent sizing and tone.
     ///
     /// - Parameters:
@@ -279,7 +279,7 @@ public extension LemonadeUi {
                 .frame(width: size.contentSize, height: size.contentSize)
         }
     }
-
+    
     /// A versatile container used to display custom content with consistent sizing and tone (no badge).
     @ViewBuilder
     static func SymbolContainer<Content: View>(
@@ -306,7 +306,7 @@ private struct SymbolContainerImageContent: View {
     let fill: Bool
     let containerSize: CGFloat
     let contentSize: CGFloat
-
+    
     var body: some View {
         image
             .resizable()
@@ -329,13 +329,13 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
     let shape: SymbolContainerShape
     let badgeSlot: () -> Badge
     let content: () -> Content
-
+    
     @ViewBuilder
     private var containerView: some View {
         let base = content()
             .frame(width: size.containerSize, height: size.containerSize)
             .background(voice.containerColor)
-
+        
         switch shape {
         case .circle:
             base.clipShape(Circle())
@@ -343,7 +343,7 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
             base.clipShape(RoundedRectangle(cornerRadius: roundedRadius(for: size)))
         }
     }
-
+    
     private func roundedRadius(for size: SymbolContainerSize) -> CGFloat {
         switch size {
         case .xSmall: LemonadeTheme.radius.radius200
@@ -354,14 +354,14 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
         case .xxLarge: LemonadeTheme.radius.radius600
         }
     }
-
+    
     var body: some View {
         if Badge.self == EmptyView.self {
             containerView
         } else {
             ZStack(alignment: .bottomTrailing) {
                 containerView
-
+                
                 badgeSlot()
                     .offset(
                         x: LemonadeTheme.spaces.spacing100,
@@ -387,7 +387,7 @@ struct LemonadeSymbolContainer_Previews: PreviewProvider {
                 LemonadeUi.SymbolContainer(icon: .heart, contentDescription: "Heart", size: .xLarge)
                 LemonadeUi.SymbolContainer(icon: .heart, contentDescription: "Heart", size: .xxLarge)
             }
-
+            
             // Text variant - all voices
             HStack(spacing: 8) {
                 LemonadeUi.SymbolContainer(text: "A", voice: .neutral)
@@ -396,19 +396,19 @@ struct LemonadeSymbolContainer_Previews: PreviewProvider {
                 LemonadeUi.SymbolContainer(text: "D", voice: .info)
                 LemonadeUi.SymbolContainer(text: "E", voice: .positive)
             }
-
+            
             // Shapes
             HStack(spacing: 8) {
                 LemonadeUi.SymbolContainer(icon: .heart, contentDescription: "Circle", shape: .circle)
                 LemonadeUi.SymbolContainer(icon: .heart, contentDescription: "Rounded", shape: .rounded)
             }
-
+            
             // Brand voices
             HStack(spacing: 8) {
                 LemonadeUi.SymbolContainer(icon: .star, contentDescription: "Star", voice: .brand)
                 LemonadeUi.SymbolContainer(icon: .star, contentDescription: "Star", voice: .brandSubtle)
             }
-
+            
             // With badge
             HStack(spacing: 16) {
                 LemonadeUi.SymbolContainer(
@@ -416,7 +416,8 @@ struct LemonadeSymbolContainer_Previews: PreviewProvider {
                     contentDescription: "Heart",
                     size: .medium
                 ) {
-                    LemonadeUi.Badge(text: "3", size: .xSmall)
+                    LemonadeUi.Badge(text: "3")
+                        .badgeSize(.xSmall)
                 }
             }
         }


### PR DESCRIPTION
# Summary
<!--Please provide a short summary, describing the changes made by the PR if necessary. -->
Update the LemonadeBadge to use a modifier 

```
LemonadeUi.Badge(text: "New")
          .badgeSize(.small)
```

It makes it more flexible to use and extend. 


## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->
https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---New-App-Components?node-id=2201-68&p=f&t=QwYH3DuXBSAEjzV4-0

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->

<img width="220" height="214" alt="Screenshot 2026-04-16 at 13 36 10" src="https://github.com/user-attachments/assets/f23f3867-d0f8-469f-862c-01fc83535131" />

