### PR TITLE
fix: prevent SegmentedControl indicator animation replay on recomposition

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -2,7 +2,8 @@ package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,10 +22,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +47,7 @@ import com.teya.lemonade.core.LemonadeSegmentedControlSize
 import com.teya.lemonade.core.LemonadeShadow
 import com.teya.lemonade.core.LemonadeTextStyle
 import com.teya.lemonade.core.TabButtonProperties
+import kotlinx.coroutines.launch
 
 /**
  * A horizontal control used to select a single option from a set of two or more segments.
@@ -185,20 +189,30 @@ internal fun CoreSegmentedControl(
         targetOffset = baseOffset
     }
 
-    val indicatorWidth by animateDpAsState(
-        targetValue = targetWidth,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMediumLow,
-        ),
-    )
-    val indicatorOffset by animateDpAsState(
-        targetValue = targetOffset,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMediumLow,
-        ),
-    )
+    val indicatorWidthAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
+    val indicatorOffsetAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
+    val hasInitialized = remember { mutableStateOf(false) }
+
+    LaunchedEffect(targetWidth, targetOffset, hasMeasurements) {
+        if (!hasMeasurements) return@LaunchedEffect
+
+        if (!hasInitialized.value) {
+            // First measurement after (re)composition — snap to avoid entrance animation
+            indicatorWidthAnimatable.snapTo(targetWidth)
+            indicatorOffsetAnimatable.snapTo(targetOffset)
+            hasInitialized.value = true
+        } else {
+            val springSpec = spring<Dp>(
+                dampingRatio = Spring.DampingRatioLowBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+            )
+            launch { indicatorWidthAnimatable.animateTo(targetWidth, springSpec) }
+            launch { indicatorOffsetAnimatable.animateTo(targetOffset, springSpec) }
+        }
+    }
+
+    val indicatorWidth = indicatorWidthAnimatable.value
+    val indicatorOffset = indicatorOffsetAnimatable.value
 
     Box(
         modifier = modifier

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -1,9 +1,9 @@
 package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -46,7 +45,6 @@ import com.teya.lemonade.core.LemonadeSegmentedControlSize
 import com.teya.lemonade.core.LemonadeShadow
 import com.teya.lemonade.core.LemonadeTextStyle
 import com.teya.lemonade.core.TabButtonProperties
-import kotlinx.coroutines.launch
 
 /**
  * A horizontal control used to select a single option from a set of two or more segments.
@@ -188,26 +186,21 @@ internal fun CoreSegmentedControl(
         targetOffset = baseOffset
     }
 
-    val indicatorWidthAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
-    val indicatorOffsetAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
-    val hasInitialized = remember { booleanArrayOf(false) }
+    val hasInitialMeasurement = remember { booleanArrayOf(false) }
+    val animationSpec = if (hasInitialMeasurement[0]) IndicatorSpringSpec else snap()
 
-    LaunchedEffect(targetWidth, targetOffset, hasMeasurements) {
-        if (!hasMeasurements) return@LaunchedEffect
-
-        if (!hasInitialized[0]) {
-            // First measurement after (re)composition — snap to avoid entrance animation
-            indicatorWidthAnimatable.snapTo(targetWidth)
-            indicatorOffsetAnimatable.snapTo(targetOffset)
-            hasInitialized[0] = true
-        } else {
-            launch { indicatorWidthAnimatable.animateTo(targetWidth, IndicatorSpringSpec) }
-            launch { indicatorOffsetAnimatable.animateTo(targetOffset, IndicatorSpringSpec) }
-        }
+    SideEffect {
+        if (hasMeasurements) hasInitialMeasurement[0] = true
     }
 
-    val indicatorWidth = indicatorWidthAnimatable.value
-    val indicatorOffset = indicatorOffsetAnimatable.value
+    val indicatorWidth by animateDpAsState(
+        targetValue = targetWidth,
+        animationSpec = animationSpec,
+    )
+    val indicatorOffset by animateDpAsState(
+        targetValue = targetOffset,
+        animationSpec = animationSpec,
+    )
 
     Box(
         modifier = modifier

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -191,23 +190,19 @@ internal fun CoreSegmentedControl(
 
     val indicatorWidthAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
     val indicatorOffsetAnimatable = remember { Animatable(0.dp, Dp.VectorConverter) }
-    val hasInitialized = remember { mutableStateOf(false) }
+    val hasInitialized = remember { booleanArrayOf(false) }
 
     LaunchedEffect(targetWidth, targetOffset, hasMeasurements) {
         if (!hasMeasurements) return@LaunchedEffect
 
-        if (!hasInitialized.value) {
+        if (!hasInitialized[0]) {
             // First measurement after (re)composition — snap to avoid entrance animation
             indicatorWidthAnimatable.snapTo(targetWidth)
             indicatorOffsetAnimatable.snapTo(targetOffset)
-            hasInitialized.value = true
+            hasInitialized[0] = true
         } else {
-            val springSpec = spring<Dp>(
-                dampingRatio = Spring.DampingRatioLowBouncy,
-                stiffness = Spring.StiffnessMediumLow,
-            )
-            launch { indicatorWidthAnimatable.animateTo(targetWidth, springSpec) }
-            launch { indicatorOffsetAnimatable.animateTo(targetOffset, springSpec) }
+            launch { indicatorWidthAnimatable.animateTo(targetWidth, IndicatorSpringSpec) }
+            launch { indicatorOffsetAnimatable.animateTo(targetOffset, IndicatorSpringSpec) }
         }
     }
 
@@ -411,6 +406,11 @@ private fun LemonadeSegmentedControlSize.textStyle(): LemonadeTextStyle {
         -> typography.bodySmallMedium
     }
 }
+
+private val IndicatorSpringSpec = spring<Dp>(
+    dampingRatio = Spring.DampingRatioLowBouncy,
+    stiffness = Spring.StiffnessMediumLow,
+)
 
 @LemonadePreview
 @Composable

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SegmentedControl.kt
@@ -1,8 +1,8 @@
 package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background


### PR DESCRIPTION
## Summary

- Fix SegmentedControl indicator replaying its entrance animation when the component scrolls out of view and back into view
- Root cause: `animateDpAsState` starts from `0.dp` on recomposition (since `remember` maps are cleared), then animates to the measured position with a bouncy spring
- Replace `animateDpAsState` with `Animatable` that `snapTo` on first measurement and `animateTo` on subsequent user-driven changes

## Test plan

- [ ] Open the SegmentedControl display screen on Android
- [ ] Scroll the SegmentedControl off screen and back — indicator should appear instantly without bouncy animation
- [ ] Tap different tabs — spring animation should still work normally
- [ ] Press and hold non-selected tabs — stretch animation should still work
- [ ] Verify on HomeDisplay (Light/Dark, Standard/Expressive segmented controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)