### PR TITLE
fix: center-align KMP Button content vertically

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -386,6 +386,7 @@ private fun CoreButton(
             leadingSlot?.invoke(this, colors)
             Row(
                 horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
                 content = contentSlot,
                 modifier = Modifier
                     .then(


### PR DESCRIPTION
## Summary
- Inner `Row` wrapping `contentSlot` in `CoreButton` was missing `verticalAlignment`, defaulting to `Alignment.Top`.
- At Medium/Large sizes the icon (20dp) and text lineHeight (24dp) differ, so leading/trailing icons sat ~2dp above the text glyph center.
- Added `verticalAlignment = Alignment.CenterVertically` to match the outer `Row` intent.

## Notes
- SwiftUI side (`LemonadeButton.swift`) was inspected: outer/inner `HStack`s rely on default `.center` alignment and `.frame(height:)` centering — no code-level bug found. Flagging here in case the iOS symptom turns out to be font-metric related.

## Test plan
- [ ] Run composeApp sample, verify Medium/Large Button with `leadingIcon`/`trailingIcon` — icons and text visually centered
- [ ] Verify XSmall/Small Button still look unchanged (icon size = lineHeight)
- [ ] Verify label-only Button unchanged
- [ ] Verify loading spinner still centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)