### PR TITLE
Update Tile component to match new Figma spec [Breaking changes added]

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -77,29 +77,13 @@ internal fun TileDisplay() {
                     verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
                 ) {
                     LemonadeUi.Tile(
-                        label = "Filled",
+                        label = "Selected",
                         icon = LemonadeIcons.CircleCheck,
                         variant = LemonadeTileVariant.Filled,
                         isSelected = true,
                     )
                     LemonadeUi.Text(
-                        text = "Filled + Selected",
-                        textStyle = LemonadeTheme.typography.bodySmallRegular,
-                    )
-                }
-
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                ) {
-                    LemonadeUi.Tile(
-                        label = "Outlined",
-                        icon = LemonadeIcons.CircleCheck,
-                        variant = LemonadeTileVariant.Outlined,
-                        isSelected = true,
-                    )
-                    LemonadeUi.Text(
-                        text = "Outlined + Selected",
+                        text = "Selected",
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                     )
                 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTileVariant
 
@@ -72,21 +73,18 @@ internal fun TileDisplay() {
                 horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                ) {
-                    LemonadeUi.Tile(
-                        label = "Selected",
-                        icon = LemonadeIcons.CircleCheck,
-                        variant = LemonadeTileVariant.Filled,
-                        isSelected = true,
-                    )
-                    LemonadeUi.Text(
-                        text = "Selected",
-                        textStyle = LemonadeTheme.typography.bodySmallRegular,
-                    )
-                }
+                LemonadeUi.Tile(
+                    label = "Filled",
+                    icon = LemonadeIcons.CircleCheck,
+                    variant = LemonadeTileVariant.Filled,
+                    isSelected = true,
+                )
+                LemonadeUi.Tile(
+                    label = "Outlined",
+                    icon = LemonadeIcons.CircleCheck,
+                    variant = LemonadeTileVariant.Outlined,
+                    isSelected = true,
+                )
             }
         }
 
@@ -112,28 +110,23 @@ internal fun TileDisplay() {
             }
         }
 
-        // Alignment
-        TileSection(title = "Alignment") {
+        // Top Accessory
+        TileSection(title = "Top Accessory") {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
             ) {
                 LemonadeUi.Tile(
-                    label = "Start",
-                    icon = LemonadeIcons.ArrowLeft,
-                    alignment = Alignment.Start,
-                )
-
-                LemonadeUi.Tile(
-                    label = "Center",
-                    icon = LemonadeIcons.ArrowLeftRight,
-                    alignment = Alignment.CenterHorizontally,
-                )
-
-                LemonadeUi.Tile(
-                    label = "End",
-                    icon = LemonadeIcons.ArrowRight,
-                    alignment = Alignment.End,
+                    label = "Accessory",
+                    icon = LemonadeIcons.Heart,
+                    variant = LemonadeTileVariant.Filled,
+                    topAccessory = {
+                        LemonadeUi.Icon(
+                            icon = LemonadeIcons.CircleInfo,
+                            size = LemonadeAssetSize.Small,
+                            contentDescription = null,
+                        )
+                    },
                 )
             }
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
@@ -69,6 +73,8 @@ internal fun TileDisplay() {
 
         // Selected
         TileSection(title = "Selected") {
+            var isFilledSelected by remember { mutableStateOf(value = true) }
+            var isOutlinedSelected by remember { mutableStateOf(value = true) }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
@@ -77,13 +83,15 @@ internal fun TileDisplay() {
                     label = "Filled",
                     icon = LemonadeIcons.CircleCheck,
                     variant = LemonadeTileVariant.Filled,
-                    isSelected = true,
+                    isSelected = isFilledSelected,
+                    onClick = { isFilledSelected = !isFilledSelected },
                 )
                 LemonadeUi.Tile(
                     label = "Outlined",
                     icon = LemonadeIcons.CircleCheck,
                     variant = LemonadeTileVariant.Outlined,
-                    isSelected = true,
+                    isSelected = isOutlinedSelected,
+                    onClick = { isOutlinedSelected = !isOutlinedSelected },
                 )
             }
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.teya.lemonade.core.LemonadeBadgeSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTileVariant
 
@@ -155,32 +154,6 @@ internal fun TileDisplay() {
             }
         }
 
-        // With Addon (Badge)
-        TileSection(title = "With Addon (Badge)") {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
-                modifier = Modifier.horizontalScroll(rememberScrollState()),
-            ) {
-                LemonadeUi.Tile(
-                    label = "Messages",
-                    icon = LemonadeIcons.Envelope,
-                    variant = LemonadeTileVariant.Filled,
-                    addon = {
-                        LemonadeUi.Badge(text = "5", size = LemonadeBadgeSize.XSmall)
-                    },
-                )
-
-                LemonadeUi.Tile(
-                    label = "Updates",
-                    icon = LemonadeIcons.Bell,
-                    variant = LemonadeTileVariant.Filled,
-                    addon = {
-                        LemonadeUi.Badge(text = "New", size = LemonadeBadgeSize.XSmall)
-                    },
-                )
-            }
-        }
-
         // Interactive
         TileSection(title = "Interactive") {
             Row(
@@ -293,9 +266,6 @@ internal fun TileDisplay() {
                         icon = LemonadeIcons.ShoppingBag,
                         onClick = {},
                         variant = LemonadeTileVariant.Outlined,
-                        addon = {
-                            LemonadeUi.Badge(text = "3", size = LemonadeBadgeSize.XSmall)
-                        },
                     )
                     LemonadeUi.Tile(
                         label = "Inventory",

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -131,6 +131,26 @@ internal fun TileDisplay() {
             }
         }
 
+        // Leading Slot
+        TileSection(title = "Leading Slot") {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+            ) {
+                LemonadeUi.Tile(
+                    label = "Custom",
+                    variant = LemonadeTileVariant.Filled,
+                    leadingSlot = {
+                        LemonadeUi.Icon(
+                            icon = LemonadeIcons.ShoppingBag,
+                            size = LemonadeAssetSize.Medium,
+                            contentDescription = null,
+                        )
+                    },
+                )
+            }
+        }
+
         // Interactive
         TileSection(title = "Interactive") {
             Row(

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -1,22 +1,18 @@
 package com.teya.lemonade
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import com.teya.lemonade.core.LemonadeBadgeSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTileVariant
@@ -44,12 +40,12 @@ internal fun TileDisplay() {
                     verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
                 ) {
                     LemonadeUi.Tile(
-                        label = "Neutral",
+                        label = "Filled",
                         icon = LemonadeIcons.Heart,
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                     LemonadeUi.Text(
-                        text = "Neutral",
+                        text = "Filled",
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                     )
                 }
@@ -59,53 +55,76 @@ internal fun TileDisplay() {
                     verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
                 ) {
                     LemonadeUi.Tile(
-                        label = "Muted",
+                        label = "Outlined",
                         icon = LemonadeIcons.Star,
-                        variant = LemonadeTileVariant.Muted,
+                        variant = LemonadeTileVariant.Outlined,
                     )
                     LemonadeUi.Text(
-                        text = "Muted",
-                        textStyle = LemonadeTheme.typography.bodySmallRegular,
-                    )
-                }
-
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                ) {
-                    LemonadeUi.Tile(
-                        label = "Selected",
-                        icon = LemonadeIcons.CircleCheck,
-                        variant = LemonadeTileVariant.Selected,
-                    )
-                    LemonadeUi.Text(
-                        text = "Selected",
+                        text = "Outlined",
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                     )
                 }
             }
         }
 
-        // OnColor Variant
-        TileSection(title = "OnColor Variant") {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(LemonadeTheme.radius.radius300))
-                    .background(LemonadeTheme.colors.background.bgBrand)
-                    .padding(LemonadeTheme.spaces.spacing400),
+        // Selected
+        TileSection(title = "Selected") {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.Tile(
+                        label = "Filled",
+                        icon = LemonadeIcons.CircleCheck,
+                        variant = LemonadeTileVariant.Filled,
+                        isSelected = true,
+                    )
+                    LemonadeUi.Text(
+                        text = "Filled + Selected",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.Tile(
+                        label = "Outlined",
+                        icon = LemonadeIcons.CircleCheck,
+                        variant = LemonadeTileVariant.Outlined,
+                        isSelected = true,
+                    )
+                    LemonadeUi.Text(
+                        text = "Outlined + Selected",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
+            }
+        }
+
+        // Support Text
+        TileSection(title = "Support Text") {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
             ) {
                 LemonadeUi.Tile(
-                    label = "OnColor",
-                    icon = LemonadeIcons.Check,
-                    variant = LemonadeTileVariant.OnColor,
+                    label = "Filled",
+                    icon = LemonadeIcons.Heart,
+                    variant = LemonadeTileVariant.Filled,
+                    supportText = "Support text",
                 )
-                LemonadeUi.Text(
-                    text = "Use on brand backgrounds",
-                    textStyle = LemonadeTheme.typography.bodySmallRegular,
-                    color = LemonadeTheme.colors.content.contentOnBrandHigh,
+
+                LemonadeUi.Tile(
+                    label = "Outlined",
+                    icon = LemonadeIcons.Star,
+                    variant = LemonadeTileVariant.Outlined,
+                    supportText = "Support text",
                 )
             }
         }
@@ -145,7 +164,7 @@ internal fun TileDisplay() {
                 LemonadeUi.Tile(
                     label = "Messages",
                     icon = LemonadeIcons.Envelope,
-                    variant = LemonadeTileVariant.Neutral,
+                    variant = LemonadeTileVariant.Filled,
                     addon = {
                         LemonadeUi.Badge(text = "5", size = LemonadeBadgeSize.XSmall)
                     },
@@ -154,7 +173,7 @@ internal fun TileDisplay() {
                 LemonadeUi.Tile(
                     label = "Updates",
                     icon = LemonadeIcons.Bell,
-                    variant = LemonadeTileVariant.Neutral,
+                    variant = LemonadeTileVariant.Filled,
                     addon = {
                         LemonadeUi.Badge(text = "New", size = LemonadeBadgeSize.XSmall)
                     },
@@ -172,14 +191,14 @@ internal fun TileDisplay() {
                     label = "Tap me",
                     icon = LemonadeIcons.HandCoins,
                     onClick = { println("Tile tapped!") },
-                    variant = LemonadeTileVariant.Neutral,
+                    variant = LemonadeTileVariant.Filled,
                 )
 
                 LemonadeUi.Tile(
                     label = "Click",
                     icon = LemonadeIcons.FingerPrint,
                     onClick = { println("Click!") },
-                    variant = LemonadeTileVariant.Muted,
+                    variant = LemonadeTileVariant.Outlined,
                 )
             }
         }
@@ -194,14 +213,14 @@ internal fun TileDisplay() {
                     label = "Disabled",
                     icon = LemonadeIcons.Padlock,
                     enabled = false,
-                    variant = LemonadeTileVariant.Neutral,
+                    variant = LemonadeTileVariant.Filled,
                 )
 
                 LemonadeUi.Tile(
                     label = "Disabled",
                     icon = LemonadeIcons.Padlock,
                     enabled = false,
-                    variant = LemonadeTileVariant.Muted,
+                    variant = LemonadeTileVariant.Outlined,
                 )
             }
         }
@@ -219,19 +238,19 @@ internal fun TileDisplay() {
                         label = "Transfer",
                         icon = LemonadeIcons.ArrowLeftRight,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                     LemonadeUi.Tile(
                         label = "Pay",
                         icon = LemonadeIcons.Card,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                     LemonadeUi.Tile(
                         label = "Request",
                         icon = LemonadeIcons.Download,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                 }
                 Row(
@@ -242,19 +261,19 @@ internal fun TileDisplay() {
                         label = "Scan",
                         icon = LemonadeIcons.QrCode,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                     LemonadeUi.Tile(
                         label = "Top Up",
                         icon = LemonadeIcons.Plus,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                     LemonadeUi.Tile(
                         label = "More",
                         icon = LemonadeIcons.EllipsisHorizontal,
                         onClick = {},
-                        variant = LemonadeTileVariant.Neutral,
+                        variant = LemonadeTileVariant.Filled,
                     )
                 }
             }
@@ -273,7 +292,7 @@ internal fun TileDisplay() {
                         label = "Orders",
                         icon = LemonadeIcons.ShoppingBag,
                         onClick = {},
-                        variant = LemonadeTileVariant.Muted,
+                        variant = LemonadeTileVariant.Outlined,
                         addon = {
                             LemonadeUi.Badge(text = "3", size = LemonadeBadgeSize.XSmall)
                         },
@@ -282,7 +301,7 @@ internal fun TileDisplay() {
                         label = "Inventory",
                         icon = LemonadeIcons.Package,
                         onClick = {},
-                        variant = LemonadeTileVariant.Muted,
+                        variant = LemonadeTileVariant.Outlined,
                     )
                 }
                 Row(
@@ -293,13 +312,13 @@ internal fun TileDisplay() {
                         label = "Reports",
                         icon = LemonadeIcons.Chart,
                         onClick = {},
-                        variant = LemonadeTileVariant.Muted,
+                        variant = LemonadeTileVariant.Outlined,
                     )
                     LemonadeUi.Tile(
                         label = "Settings",
                         icon = LemonadeIcons.Gear,
                         onClick = {},
-                        variant = LemonadeTileVariant.Muted,
+                        variant = LemonadeTileVariant.Outlined,
                     )
                 }
             }

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tile.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tile.kt
@@ -5,28 +5,4 @@ package com.teya.lemonade.core
 public enum class LemonadeTileVariant {
     Filled,
     Outlined,
-
-    @Deprecated(
-        message = "Use Filled instead",
-        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
-    )
-    Neutral,
-
-    @Deprecated(
-        message = "Use Outlined instead",
-        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Outlined"),
-    )
-    Muted,
-
-    @Deprecated(
-        message = "Use Filled instead. OnColor variant has been removed.",
-        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
-    )
-    OnColor,
-
-    @Deprecated(
-        message = "Use Filled with isSelected = true instead",
-        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
-    )
-    Selected,
 }

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tile.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tile.kt
@@ -3,8 +3,30 @@
 package com.teya.lemonade.core
 
 public enum class LemonadeTileVariant {
+    Filled,
+    Outlined,
+
+    @Deprecated(
+        message = "Use Filled instead",
+        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
+    )
     Neutral,
+
+    @Deprecated(
+        message = "Use Outlined instead",
+        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Outlined"),
+    )
     Muted,
+
+    @Deprecated(
+        message = "Use Filled instead. OnColor variant has been removed.",
+        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
+    )
     OnColor,
+
+    @Deprecated(
+        message = "Use Filled with isSelected = true instead",
+        replaceWith = ReplaceWith(expression = "LemonadeTileVariant.Filled"),
+    )
     Selected,
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -52,14 +52,10 @@ import com.teya.lemonade.core.LemonadeTileVariant
  * @param enabled - [Boolean] flag to enable or disable the Tile.
  * @param isSelected - [Boolean] flag to apply selected styling to the Tile.
  * @param supportText - Optional [String] to be displayed below the label.
- * @param alignment - **Deprecated**: Alignment is no longer configurable per Figma spec.
- *  The tile always uses [Alignment.Start]. Kept for backward compatibility.
  * @param topAccessory - Optional composable rendered at the top-right of the tile, next to the icon.
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
  * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
- * @param addon - **Deprecated**: Use [topAccessory] instead.
- *  Addon badge overlay has been replaced by an internal top accessory slot.
  */
 @Suppress("LongParameterList")
 @Composable
@@ -70,15 +66,11 @@ public fun LemonadeUi.Tile(
     enabled: Boolean = true,
     isSelected: Boolean = false,
     supportText: String? = null,
-    alignment: Alignment.Horizontal = Alignment.Start,
     topAccessory: (@Composable () -> Unit)? = null,
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
-    addon: (@Composable () -> Unit)? = null,
 ) {
-    val effectiveTopAccessory = topAccessory ?: addon
-
     val contentColor = if (isSelected) {
         LocalColors.current.content.contentOnBrandHigh
     } else {
@@ -95,13 +87,12 @@ public fun LemonadeUi.Tile(
         content = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-                horizontalAlignment = alignment,
+                horizontalAlignment = Alignment.Start,
                 modifier = Modifier
                     .defaultMinSize(
                         minWidth = 120.dp,
                         minHeight = 88.dp,
-                    )
-                    .padding(all = LocalSpaces.current.spacing300),
+                    ).padding(all = LocalSpaces.current.spacing300),
             ) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -115,15 +106,15 @@ public fun LemonadeUi.Tile(
                         tint = contentColor,
                     )
 
-                    if (effectiveTopAccessory != null) {
-                        effectiveTopAccessory()
+                    if (topAccessory != null) {
+                        topAccessory()
                     }
                 }
 
                 Spacer(modifier = Modifier.weight(weight = 1f))
 
                 Column(
-                    horizontalAlignment = alignment,
+                    horizontalAlignment = Alignment.Start,
                 ) {
                     LemonadeUi.Text(
                         text = label,
@@ -165,8 +156,6 @@ public fun LemonadeUi.Tile(
  * @param enabled - [Boolean] flag to enable or disable the Tile.
  * @param isSelected - [Boolean] flag to apply selected styling to the Tile.
  * @param supportText - Optional [String] to be displayed below the label.
- * @param alignment - [Alignment.Horizontal] to align the Tile's content horizontally.
- *  **Deprecated**: Tiles now always use Start alignment per the design spec.
  * @param topAccessory - Optional composable rendered at the top-right of the Tile.
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
@@ -180,7 +169,6 @@ public fun LemonadeUi.Tile(
     enabled: Boolean = true,
     isSelected: Boolean = false,
     supportText: String? = null,
-    alignment: Alignment.Horizontal = Alignment.Start,
     topAccessory: (@Composable () -> Unit)? = null,
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -203,13 +191,12 @@ public fun LemonadeUi.Tile(
         content = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-                horizontalAlignment = alignment,
+                horizontalAlignment = Alignment.Start,
                 modifier = Modifier
                     .defaultMinSize(
                         minWidth = 120.dp,
                         minHeight = 88.dp,
-                    )
-                    .padding(all = LocalSpaces.current.spacing300),
+                    ).padding(all = LocalSpaces.current.spacing300),
             ) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -226,7 +213,7 @@ public fun LemonadeUi.Tile(
                 Spacer(modifier = Modifier.weight(weight = 1f))
 
                 Column(
-                    horizontalAlignment = alignment,
+                    horizontalAlignment = Alignment.Start,
                 ) {
                     LemonadeUi.Text(
                         text = label,
@@ -358,10 +345,7 @@ internal data class TileData(
 internal val LemonadeTileVariant.data: TileData
     @Composable get() {
         return when (this) {
-            LemonadeTileVariant.Filled,
-            @Suppress("DEPRECATION")
-            LemonadeTileVariant.Neutral,
-            -> TileData(
+            LemonadeTileVariant.Filled -> TileData(
                 backgroundColor = LocalColors.current.background.bgElevated,
                 backgroundPressedColor = LocalColors.current.interaction.bgElevatedPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
@@ -369,35 +353,12 @@ internal val LemonadeTileVariant.data: TileData
                 shadow = null,
             )
 
-            LemonadeTileVariant.Outlined,
-            @Suppress("DEPRECATION")
-            LemonadeTileVariant.Muted,
-            -> TileData(
+            LemonadeTileVariant.Outlined -> TileData(
                 backgroundColor = LocalColors.current.background.bgDefault,
                 backgroundPressedColor = LocalColors.current.interaction.bgDefaultPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
                 borderWidth = LocalBorderWidths.current.base.border25,
                 shadow = LemonadeShadow.Xsmall,
-            )
-
-            @Suppress("DEPRECATION")
-            LemonadeTileVariant.OnColor,
-            -> TileData(
-                backgroundColor = LocalColors.current.background.bgBrandElevated,
-                backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
-                borderColor = LocalColors.current.border.borderNeutralMediumInverse,
-                borderWidth = LocalBorderWidths.current.base.border25,
-                shadow = null,
-            )
-
-            @Suppress("DEPRECATION")
-            LemonadeTileVariant.Selected,
-            -> TileData(
-                backgroundColor = LocalColors.current.background.bgBrandSubtle,
-                backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
-                borderColor = LocalColors.current.border.borderSelected,
-                borderWidth = LocalBorderWidths.current.base.border50,
-                shadow = null,
             )
         }
     }
@@ -411,8 +372,8 @@ private data class TilePreviewData(
 private class TilePreviewProvider : PreviewParameterProvider<TilePreviewData> {
     override val values: Sequence<TilePreviewData> = buildAllVariants()
 
-    private fun buildAllVariants(): Sequence<TilePreviewData> {
-        return buildList {
+    private fun buildAllVariants(): Sequence<TilePreviewData> =
+        buildList {
             listOf(true, false).forEach { enabled ->
                 listOf(
                     LemonadeTileVariant.Filled,
@@ -430,7 +391,6 @@ private class TilePreviewProvider : PreviewParameterProvider<TilePreviewData> {
                 }
             }
         }.asSequence()
-    }
 }
 
 @LemonadePreview

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -89,10 +89,8 @@ public fun LemonadeUi.Tile(
                 verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
-                    .defaultMinSize(
-                        minWidth = 120.dp,
-                        minHeight = 88.dp,
-                    ).padding(all = LocalSpaces.current.spacing300),
+                    .defaultMinSize(minWidth = 120.dp)
+                    .padding(all = LocalSpaces.current.spacing300),
             ) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -193,10 +191,8 @@ public fun LemonadeUi.Tile(
                 verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
-                    .defaultMinSize(
-                        minWidth = 120.dp,
-                        minHeight = 88.dp,
-                    ).padding(all = LocalSpaces.current.spacing300),
+                    .defaultMinSize(minWidth = 120.dp)
+                    .padding(all = LocalSpaces.current.spacing300),
             ) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
@@ -55,7 +54,6 @@ import com.teya.lemonade.core.LemonadeTileVariant
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
  * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
- * @param addon - Optional composable content displayed as a badge overlay on the Tile.
  */
 @Composable
 public fun LemonadeUi.Tile(
@@ -69,11 +67,9 @@ public fun LemonadeUi.Tile(
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
-    addon: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     CoreTile(
         modifier = modifier,
-        addon = addon,
         variant = variant,
         onClick = onClick,
         enabled = enabled,
@@ -128,7 +124,6 @@ public fun LemonadeUi.Tile(
 @Composable
 private fun CoreTile(
     variant: LemonadeTileVariant,
-    addon: (@Composable BoxScope.() -> Unit)?,
     content: @Composable BoxScope.() -> Unit,
     enabled: Boolean,
     isSelected: Boolean,
@@ -165,71 +160,58 @@ private fun CoreTile(
         targetValue = tileData.borderWidth,
     )
 
-    val spaces = LocalSpaces.current
-    LemonadeBadgeBox(
-        modifier = modifier,
-        badgeOffset = {
-            DpOffset(
-                x = spaces.spacing200,
-                y = spaces.spacing200,
-            )
-        },
-        badge = { addon?.invoke(this) },
-        content = {
-            Box(
-                contentAlignment = Alignment.Center,
-                content = content,
-                modifier = Modifier
-                    .then(
-                        other = if (!enabled) {
-                            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                        } else {
-                            Modifier
-                        },
-                    ).then(
-                        other = if (isFocused) {
-                            Modifier
-                                .border(
-                                    width = LocalBorderWidths.current.base.border25,
-                                    color = LocalColors.current.border.borderSelected,
-                                    shape = tileShape,
-                                ).padding(all = LocalSpaces.current.spacing50)
-                        } else {
-                            Modifier
-                        },
-                    ).then(
-                        other = tileData.shadow?.let { lemonadeShadow ->
-                            Modifier.lemonadeShadow(
-                                shadow = lemonadeShadow,
-                                shape = tileShape,
-                            )
-                        }
-                            ?: Modifier,
-                    ).then(
-                        other = Modifier.border(
-                            color = animatedBorderColor,
+    Box(
+        contentAlignment = Alignment.Center,
+        content = content,
+        modifier = modifier
+            .then(
+                other = if (!enabled) {
+                    Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+                } else {
+                    Modifier
+                },
+            ).then(
+                other = if (isFocused) {
+                    Modifier
+                        .border(
+                            width = LocalBorderWidths.current.base.border25,
+                            color = LocalColors.current.border.borderSelected,
                             shape = tileShape,
-                            width = animatedBorderWidth,
-                        ),
-                    ).clip(shape = tileShape)
-                    .then(
-                        other = if (onClick != null) {
-                            Modifier.clickable(
-                                onClick = onClick,
-                                interactionSource = interactionSource,
-                                role = Role.Button,
-                                enabled = enabled,
-                                indication = LocalEffects.current.interactionIndication,
-                            )
-                        } else {
-                            Modifier
-                        },
-                    ).background(
-                        color = animatedBackgroundColor,
+                        ).padding(all = LocalSpaces.current.spacing50)
+                } else {
+                    Modifier
+                },
+            ).then(
+                other = tileData.shadow?.let { lemonadeShadow ->
+                    Modifier.lemonadeShadow(
+                        shadow = lemonadeShadow,
                         shape = tileShape,
-                    ),
-            )
-        },
+                    )
+                }
+                    ?: Modifier,
+            ).then(
+                other = Modifier.border(
+                    color = animatedBorderColor,
+                    shape = tileShape,
+                    width = animatedBorderWidth,
+                ),
+            ).clip(shape = tileShape)
+            .then(
+                other = if (onClick != null) {
+                    Modifier.clickable(
+                        onClick = onClick,
+                        interactionSource = interactionSource,
+                        role = Role.Button,
+                        enabled = enabled,
+                        indication = LocalEffects.current.interactionIndication,
+                    )
+                } else {
+                    Modifier
+                },
+            ).background(
+                color = animatedBackgroundColor,
+                shape = tileShape,
+            ),
     )
 }
 
@@ -290,7 +272,6 @@ internal val LemonadeTileVariant.data: TileData
 
 private data class TilePreviewData(
     val enabled: Boolean,
-    val withAddon: Boolean,
     val variant: LemonadeTileVariant,
     val alignment: Alignment.Horizontal,
     val isSelected: Boolean,
@@ -302,27 +283,24 @@ private class TilePreviewProvider : PreviewParameterProvider<TilePreviewData> {
     private fun buildAllVariants(): Sequence<TilePreviewData> {
         return buildList {
             listOf(true, false).forEach { enabled ->
-                listOf(true, false).forEach { withAddon ->
+                listOf(
+                    LemonadeTileVariant.Filled,
+                    LemonadeTileVariant.Outlined,
+                ).forEach { variant ->
                     listOf(
-                        LemonadeTileVariant.Filled,
-                        LemonadeTileVariant.Outlined,
-                    ).forEach { variant ->
-                        listOf(
-                            Alignment.Start,
-                            Alignment.CenterHorizontally,
-                            Alignment.End,
-                        ).forEach { alignment ->
-                            listOf(true, false).forEach { selected ->
-                                add(
-                                    TilePreviewData(
-                                        enabled = enabled,
-                                        withAddon = withAddon,
-                                        variant = variant,
-                                        alignment = alignment,
-                                        isSelected = selected,
-                                    ),
-                                )
-                            }
+                        Alignment.Start,
+                        Alignment.CenterHorizontally,
+                        Alignment.End,
+                    ).forEach { alignment ->
+                        listOf(true, false).forEach { selected ->
+                            add(
+                                TilePreviewData(
+                                    enabled = enabled,
+                                    variant = variant,
+                                    alignment = alignment,
+                                    isSelected = selected,
+                                ),
+                            )
                         }
                     }
                 }
@@ -353,13 +331,6 @@ private fun LemonadeTilePreview(
             isSelected = previewData.isSelected,
             alignment = previewData.alignment,
             variant = previewData.variant,
-            addon = if (previewData.withAddon) {
-                {
-                    LemonadeUi.Badge(text = "Addon")
-                }
-            } else {
-                null
-            },
         )
     }
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -142,6 +142,7 @@ private fun CoreTile(
             backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
             borderColor = LocalColors.current.border.borderSelected,
             borderWidth = LocalBorderWidths.current.base.border50,
+            shadow = null,
         )
     } else {
         baseTileData

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -50,11 +52,16 @@ import com.teya.lemonade.core.LemonadeTileVariant
  * @param enabled - [Boolean] flag to enable or disable the Tile.
  * @param isSelected - [Boolean] flag to apply selected styling to the Tile.
  * @param supportText - Optional [String] to be displayed below the label.
- * @param alignment - [Alignment.Horizontal] to align the Tile's content horizontally.
+ * @param alignment - **Deprecated**: Alignment is no longer configurable per Figma spec.
+ *  The tile always uses [Alignment.Start]. Kept for backward compatibility.
+ * @param topAccessory - Optional composable rendered at the top-right of the tile, next to the icon.
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
  * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
+ * @param addon - **Deprecated**: Use [topAccessory] instead.
+ *  Addon badge overlay has been replaced by an internal top accessory slot.
  */
+@Suppress("LongParameterList")
 @Composable
 public fun LemonadeUi.Tile(
     label: String,
@@ -63,11 +70,21 @@ public fun LemonadeUi.Tile(
     enabled: Boolean = true,
     isSelected: Boolean = false,
     supportText: String? = null,
-    alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    alignment: Alignment.Horizontal = Alignment.Start,
+    topAccessory: (@Composable () -> Unit)? = null,
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
+    addon: (@Composable () -> Unit)? = null,
 ) {
+    val effectiveTopAccessory = topAccessory ?: addon
+
+    val contentColor = if (isSelected) {
+        LocalColors.current.content.contentOnBrandHigh
+    } else {
+        LocalColors.current.content.contentPrimary
+    }
+
     CoreTile(
         modifier = modifier,
         variant = variant,
@@ -86,11 +103,22 @@ public fun LemonadeUi.Tile(
                     )
                     .padding(all = LocalSpaces.current.spacing300),
             ) {
-                LemonadeUi.Icon(
-                    icon = icon,
-                    size = LemonadeAssetSize.Medium,
-                    contentDescription = null,
-                )
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    LemonadeUi.Icon(
+                        icon = icon,
+                        size = LemonadeAssetSize.Medium,
+                        contentDescription = null,
+                        tint = contentColor,
+                    )
+
+                    if (effectiveTopAccessory != null) {
+                        effectiveTopAccessory()
+                    }
+                }
 
                 Spacer(modifier = Modifier.weight(weight = 1f))
 
@@ -100,7 +128,7 @@ public fun LemonadeUi.Tile(
                     LemonadeUi.Text(
                         text = label,
                         textStyle = LocalTypographies.current.bodySmallMedium,
-                        color = LocalColors.current.content.contentPrimary,
+                        color = contentColor,
                         overflow = TextOverflow.Ellipsis,
                         maxLines = 1,
                     )
@@ -274,7 +302,6 @@ internal val LemonadeTileVariant.data: TileData
 private data class TilePreviewData(
     val enabled: Boolean,
     val variant: LemonadeTileVariant,
-    val alignment: Alignment.Horizontal,
     val isSelected: Boolean,
 )
 
@@ -288,21 +315,14 @@ private class TilePreviewProvider : PreviewParameterProvider<TilePreviewData> {
                     LemonadeTileVariant.Filled,
                     LemonadeTileVariant.Outlined,
                 ).forEach { variant ->
-                    listOf(
-                        Alignment.Start,
-                        Alignment.CenterHorizontally,
-                        Alignment.End,
-                    ).forEach { alignment ->
-                        listOf(true, false).forEach { selected ->
-                            add(
-                                TilePreviewData(
-                                    enabled = enabled,
-                                    variant = variant,
-                                    alignment = alignment,
-                                    isSelected = selected,
-                                ),
-                            )
-                        }
+                    listOf(true, false).forEach { selected ->
+                        add(
+                            TilePreviewData(
+                                enabled = enabled,
+                                variant = variant,
+                                isSelected = selected,
+                            ),
+                        )
                     }
                 }
             }
@@ -330,7 +350,6 @@ private fun LemonadeTilePreview(
             icon = LemonadeIcons.Heart,
             enabled = previewData.enabled,
             isSelected = previewData.isSelected,
-            alignment = previewData.alignment,
             variant = previewData.variant,
         )
     }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -48,6 +49,8 @@ import com.teya.lemonade.core.LemonadeTileVariant
  * @param icon - [LemonadeIcons] displayed above the label.
  * @param modifier - [Modifier] to be applied to the Tile.
  * @param enabled - [Boolean] flag to enable or disable the Tile.
+ * @param isSelected - [Boolean] flag to apply selected styling to the Tile.
+ * @param supportText - Optional [String] to be displayed below the label.
  * @param alignment - [Alignment.Horizontal] to align the Tile's content horizontally.
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
@@ -60,10 +63,12 @@ public fun LemonadeUi.Tile(
     icon: LemonadeIcons,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    isSelected: Boolean = false,
+    supportText: String? = null,
     alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    variant: LemonadeTileVariant = LemonadeTileVariant.Neutral,
+    variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
     addon: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     CoreTile(
@@ -72,14 +77,18 @@ public fun LemonadeUi.Tile(
         variant = variant,
         onClick = onClick,
         enabled = enabled,
+        isSelected = isSelected,
         interactionSource = interactionSource,
         content = {
             Column(
-                verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing400),
+                verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
                 horizontalAlignment = alignment,
                 modifier = Modifier
-                    .defaultMinSize(minWidth = 120.dp)
-                    .padding(all = LocalSpaces.current.spacing400),
+                    .defaultMinSize(
+                        minWidth = 120.dp,
+                        minHeight = 88.dp,
+                    )
+                    .padding(all = LocalSpaces.current.spacing300),
             ) {
                 LemonadeUi.Icon(
                     icon = icon,
@@ -87,13 +96,29 @@ public fun LemonadeUi.Tile(
                     contentDescription = null,
                 )
 
-                LemonadeUi.Text(
-                    text = label,
-                    textStyle = LocalTypographies.current.bodySmallSemiBold,
-                    color = LocalColors.current.content.contentPrimary,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                )
+                Spacer(modifier = Modifier.weight(weight = 1f))
+
+                Column(
+                    horizontalAlignment = alignment,
+                ) {
+                    LemonadeUi.Text(
+                        text = label,
+                        textStyle = LocalTypographies.current.bodySmallMedium,
+                        color = LocalColors.current.content.contentPrimary,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                    )
+
+                    if (supportText != null) {
+                        LemonadeUi.Text(
+                            text = supportText,
+                            textStyle = LocalTypographies.current.bodySmallRegular,
+                            color = LocalColors.current.content.contentSecondary,
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                        )
+                    }
+                }
             }
         },
     )
@@ -106,6 +131,7 @@ private fun CoreTile(
     addon: (@Composable BoxScope.() -> Unit)?,
     content: @Composable BoxScope.() -> Unit,
     enabled: Boolean,
+    isSelected: Boolean,
     onClick: (() -> Unit)?,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
@@ -114,18 +140,29 @@ private fun CoreTile(
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     val tileShape = LocalShapes.current.radius500
+    val baseTileData = variant.data
+    val tileData = if (isSelected) {
+        baseTileData.copy(
+            backgroundColor = LocalColors.current.background.bgBrandSubtle,
+            backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
+            borderColor = LocalColors.current.border.borderSelected,
+            borderWidth = LocalBorderWidths.current.base.border50,
+        )
+    } else {
+        baseTileData
+    }
     val animatedBackgroundColor by animateColorAsState(
         targetValue = if (isPressed) {
-            variant.data.backgroundPressedColor
+            tileData.backgroundPressedColor
         } else {
-            variant.data.backgroundColor
+            tileData.backgroundColor
         },
     )
     val animatedBorderColor by animateColorAsState(
-        targetValue = variant.data.borderColor,
+        targetValue = tileData.borderColor,
     )
     val animatedBorderWidth by animateDpAsState(
-        targetValue = variant.data.borderWidth,
+        targetValue = tileData.borderWidth,
     )
 
     val spaces = LocalSpaces.current
@@ -161,7 +198,7 @@ private fun CoreTile(
                             Modifier
                         },
                     ).then(
-                        other = variant.data.shadow?.let { lemonadeShadow ->
+                        other = tileData.shadow?.let { lemonadeShadow ->
                             Modifier.lemonadeShadow(
                                 shadow = lemonadeShadow,
                                 shape = tileShape,
@@ -207,7 +244,10 @@ internal data class TileData(
 internal val LemonadeTileVariant.data: TileData
     @Composable get() {
         return when (this) {
-            LemonadeTileVariant.Neutral -> TileData(
+            LemonadeTileVariant.Filled,
+            @Suppress("DEPRECATION")
+            LemonadeTileVariant.Neutral,
+            -> TileData(
                 backgroundColor = LocalColors.current.background.bgElevated,
                 backgroundPressedColor = LocalColors.current.interaction.bgElevatedPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
@@ -215,7 +255,10 @@ internal val LemonadeTileVariant.data: TileData
                 shadow = null,
             )
 
-            LemonadeTileVariant.Muted -> TileData(
+            LemonadeTileVariant.Outlined,
+            @Suppress("DEPRECATION")
+            LemonadeTileVariant.Muted,
+            -> TileData(
                 backgroundColor = LocalColors.current.background.bgDefault,
                 backgroundPressedColor = LocalColors.current.interaction.bgDefaultPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
@@ -223,7 +266,9 @@ internal val LemonadeTileVariant.data: TileData
                 shadow = LemonadeShadow.Xsmall,
             )
 
-            LemonadeTileVariant.OnColor -> TileData(
+            @Suppress("DEPRECATION")
+            LemonadeTileVariant.OnColor,
+            -> TileData(
                 backgroundColor = LocalColors.current.background.bgBrandElevated,
                 backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
                 borderColor = LocalColors.current.border.borderNeutralMediumInverse,
@@ -231,7 +276,9 @@ internal val LemonadeTileVariant.data: TileData
                 shadow = null,
             )
 
-            LemonadeTileVariant.Selected -> TileData(
+            @Suppress("DEPRECATION")
+            LemonadeTileVariant.Selected,
+            -> TileData(
                 backgroundColor = LocalColors.current.background.bgBrandSubtle,
                 backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
                 borderColor = LocalColors.current.border.borderSelected,
@@ -246,34 +293,42 @@ private data class TilePreviewData(
     val withAddon: Boolean,
     val variant: LemonadeTileVariant,
     val alignment: Alignment.Horizontal,
+    val isSelected: Boolean,
 )
 
 private class TilePreviewProvider : PreviewParameterProvider<TilePreviewData> {
     override val values: Sequence<TilePreviewData> = buildAllVariants()
 
-    private fun buildAllVariants(): Sequence<TilePreviewData> =
-        buildList {
+    private fun buildAllVariants(): Sequence<TilePreviewData> {
+        return buildList {
             listOf(true, false).forEach { enabled ->
                 listOf(true, false).forEach { withAddon ->
-                    LemonadeTileVariant.entries.forEach { variant ->
+                    listOf(
+                        LemonadeTileVariant.Filled,
+                        LemonadeTileVariant.Outlined,
+                    ).forEach { variant ->
                         listOf(
                             Alignment.Start,
                             Alignment.CenterHorizontally,
                             Alignment.End,
                         ).forEach { alignment ->
-                            add(
-                                TilePreviewData(
-                                    enabled = enabled,
-                                    withAddon = withAddon,
-                                    variant = variant,
-                                    alignment = alignment,
-                                ),
-                            )
+                            listOf(true, false).forEach { selected ->
+                                add(
+                                    TilePreviewData(
+                                        enabled = enabled,
+                                        withAddon = withAddon,
+                                        variant = variant,
+                                        alignment = alignment,
+                                        isSelected = selected,
+                                    ),
+                                )
+                            }
                         }
                     }
                 }
             }
         }.asSequence()
+    }
 }
 
 @LemonadePreview
@@ -286,22 +341,16 @@ private fun LemonadeTilePreview(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .background(
-                color = if (
-                    previewData.variant == LemonadeTileVariant.OnColor ||
-                    previewData.variant == LemonadeTileVariant.Selected
-                ) {
-                    LocalColors.current.background.bgBrand
-                } else {
-                    LocalColors.current.background.bgBrand.copy(
-                        alpha = LocalOpacities.current.base.opacity0,
-                    )
-                },
-            ).padding(30.dp),
+                color = LocalColors.current.background.bgBrand.copy(
+                    alpha = LocalOpacities.current.base.opacity0,
+                ),
+            ).padding(all = 30.dp),
     ) {
         LemonadeUi.Tile(
             label = "Label",
             icon = LemonadeIcons.Heart,
             enabled = previewData.enabled,
+            isSelected = previewData.isSelected,
             alignment = previewData.alignment,
             variant = previewData.variant,
             addon = if (previewData.withAddon) {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -148,6 +148,109 @@ public fun LemonadeUi.Tile(
     )
 }
 
+/**
+ * Lemonade tile component with a custom leading slot instead of an icon.
+ * ## Usage
+ * ```kotlin
+ * LemonadeUi.Tile(
+ *   label = "Custom",
+ *   leadingSlot = {
+ *     // Custom composable content
+ *   },
+ * )
+ * ```
+ * @param label - [String] to be displayed as the Tile's label.
+ * @param leadingSlot - Custom composable content displayed in the leading position.
+ * @param modifier - [Modifier] to be applied to the Tile.
+ * @param enabled - [Boolean] flag to enable or disable the Tile.
+ * @param isSelected - [Boolean] flag to apply selected styling to the Tile.
+ * @param supportText - Optional [String] to be displayed below the label.
+ * @param alignment - [Alignment.Horizontal] to align the Tile's content horizontally.
+ *  **Deprecated**: Tiles now always use Start alignment per the design spec.
+ * @param topAccessory - Optional composable rendered at the top-right of the Tile.
+ * @param onClick - Callback to be invoked when the Tile is clicked.
+ * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
+ * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
+ */
+@Suppress("LongParameterList")
+@Composable
+public fun LemonadeUi.Tile(
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isSelected: Boolean = false,
+    supportText: String? = null,
+    alignment: Alignment.Horizontal = Alignment.Start,
+    topAccessory: (@Composable () -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
+    leadingSlot: @Composable () -> Unit,
+) {
+    val contentColor = if (isSelected) {
+        LocalColors.current.content.contentOnBrandHigh
+    } else {
+        LocalColors.current.content.contentPrimary
+    }
+
+    CoreTile(
+        modifier = modifier,
+        variant = variant,
+        onClick = onClick,
+        enabled = enabled,
+        isSelected = isSelected,
+        interactionSource = interactionSource,
+        content = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
+                horizontalAlignment = alignment,
+                modifier = Modifier
+                    .defaultMinSize(
+                        minWidth = 120.dp,
+                        minHeight = 88.dp,
+                    )
+                    .padding(all = LocalSpaces.current.spacing300),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    leadingSlot()
+
+                    if (topAccessory != null) {
+                        topAccessory()
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(weight = 1f))
+
+                Column(
+                    horizontalAlignment = alignment,
+                ) {
+                    LemonadeUi.Text(
+                        text = label,
+                        textStyle = LocalTypographies.current.bodySmallMedium,
+                        color = contentColor,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                    )
+
+                    if (supportText != null) {
+                        LemonadeUi.Text(
+                            text = supportText,
+                            textStyle = LocalTypographies.current.bodySmallRegular,
+                            color = LocalColors.current.content.contentSecondary,
+                            overflow = TextOverflow.Ellipsis,
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
 @Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun CoreTile(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -33,7 +32,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
-import com.teya.lemonade.core.LemonadeShadow
 import com.teya.lemonade.core.LemonadeTileVariant
 
 /**
@@ -113,6 +111,7 @@ public fun LemonadeUi.Tile(
 
                 Column(
                     horizontalAlignment = Alignment.Start,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     LemonadeUi.Text(
                         text = label,
@@ -210,6 +209,7 @@ public fun LemonadeUi.Tile(
 
                 Column(
                     horizontalAlignment = Alignment.Start,
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     LemonadeUi.Text(
                         text = label,
@@ -245,7 +245,6 @@ private fun CoreTile(
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
 ) {
-    val isPressed by interactionSource.collectIsPressedAsState()
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     val tileShape = LocalShapes.current.radius500
@@ -253,20 +252,14 @@ private fun CoreTile(
     val tileData = if (isSelected) {
         baseTileData.copy(
             backgroundColor = LocalColors.current.background.bgBrandSubtle,
-            backgroundPressedColor = LocalColors.current.interaction.bgBrandElevatedPressed,
             borderColor = LocalColors.current.border.borderSelected,
             borderWidth = LocalBorderWidths.current.base.border50,
-            shadow = null,
         )
     } else {
         baseTileData
     }
     val animatedBackgroundColor by animateColorAsState(
-        targetValue = if (isPressed) {
-            tileData.backgroundPressedColor
-        } else {
-            tileData.backgroundColor
-        },
+        targetValue = tileData.backgroundColor,
     )
     val animatedBorderColor by animateColorAsState(
         targetValue = tileData.borderColor,
@@ -297,14 +290,6 @@ private fun CoreTile(
                     Modifier
                 },
             ).then(
-                other = tileData.shadow?.let { lemonadeShadow ->
-                    Modifier.lemonadeShadow(
-                        shadow = lemonadeShadow,
-                        shape = tileShape,
-                    )
-                }
-                    ?: Modifier,
-            ).then(
                 other = Modifier.border(
                     color = animatedBorderColor,
                     shape = tileShape,
@@ -332,10 +317,8 @@ private fun CoreTile(
 
 internal data class TileData(
     val backgroundColor: Color,
-    val backgroundPressedColor: Color,
     val borderColor: Color,
     val borderWidth: Dp,
-    val shadow: LemonadeShadow?,
 )
 
 internal val LemonadeTileVariant.data: TileData
@@ -343,18 +326,14 @@ internal val LemonadeTileVariant.data: TileData
         return when (this) {
             LemonadeTileVariant.Filled -> TileData(
                 backgroundColor = LocalColors.current.background.bgElevated,
-                backgroundPressedColor = LocalColors.current.interaction.bgElevatedPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
-                borderWidth = LocalBorderWidths.current.base.border25,
-                shadow = null,
+                borderWidth = 0.dp,
             )
 
             LemonadeTileVariant.Outlined -> TileData(
                 backgroundColor = LocalColors.current.background.bgDefault,
-                backgroundPressedColor = LocalColors.current.interaction.bgDefaultPressed,
                 borderColor = LocalColors.current.border.borderNeutralMedium,
-                borderWidth = LocalBorderWidths.current.base.border25,
-                shadow = LemonadeShadow.Xsmall,
+                borderWidth = LocalBorderWidths.current.base.border40,
             )
         }
     }

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -36,21 +36,12 @@ struct TileDisplayView: View {
 
                 // MARK: - Selected
                 sectionView(title: "Selected") {
-                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
-                        LemonadeUi.Tile(
-                            label: "Filled",
-                            icon: .heart,
-                            isSelected: true,
-                            variant: .filled
-                        )
-
-                        LemonadeUi.Tile(
-                            label: "Outlined",
-                            icon: .star,
-                            isSelected: true,
-                            variant: .outlined
-                        )
-                    }
+                    LemonadeUi.Tile(
+                        label: "Selected",
+                        icon: .circleCheck,
+                        isSelected: true,
+                        variant: .filled
+                    )
                 }
 
                 // MARK: - Support Text

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -36,12 +36,20 @@ struct TileDisplayView: View {
 
                 // MARK: - Selected
                 sectionView(title: "Selected") {
-                    LemonadeUi.Tile(
-                        label: "Selected",
-                        icon: .circleCheck,
-                        isSelected: true,
-                        variant: .filled
-                    )
+                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
+                        LemonadeUi.Tile(
+                            label: "Filled",
+                            icon: .circleCheck,
+                            isSelected: true,
+                            variant: .filled
+                        )
+                        LemonadeUi.Tile(
+                            label: "Outlined",
+                            icon: .circleCheck,
+                            isSelected: true,
+                            variant: .outlined
+                        )
+                    }
                 }
 
                 // MARK: - Support Text
@@ -63,28 +71,20 @@ struct TileDisplayView: View {
                     }
                 }
 
-                sectionView(title: "Alignment") {
+                // MARK: - Top Accessory
+                sectionView(title: "Top Accessory") {
                     HStack(spacing: LemonadeTheme.spaces.spacing400) {
                         LemonadeUi.Tile(
-                            label: "Start",
-                            icon: .arrowLeft,
-                            variant: .filled,
-                            alignment: .leading
-                        )
-
-                        LemonadeUi.Tile(
-                            label: "Center",
-                            icon: .arrowLeftRight,
-                            variant: .filled,
-                            alignment: .center
-                        )
-
-                        LemonadeUi.Tile(
-                            label: "End",
-                            icon: .arrowRight,
-                            variant: .filled,
-                            alignment: .trailing
-                        )
+                            label: "Accessory",
+                            icon: .heart,
+                            variant: .filled
+                        ) {
+                            LemonadeUi.Icon(
+                                icon: .circleInfo,
+                                contentDescription: nil,
+                                size: .small
+                            )
+                        }
                     }
                 }
 

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -10,59 +10,66 @@ struct TileDisplayView: View {
                     HStack(spacing: LemonadeTheme.spaces.spacing400) {
                         VStack(spacing: LemonadeTheme.spaces.spacing200) {
                             LemonadeUi.Tile(
-                                label: "Neutral",
+                                label: "Filled",
                                 icon: .heart,
-                                variant: .neutral
+                                variant: .filled
                             )
                             LemonadeUi.Text(
-                                "Neutral",
+                                "Filled",
                                 textStyle: LemonadeTypography.shared.bodySmallRegular
                             )
                         }
 
                         VStack(spacing: LemonadeTheme.spaces.spacing200) {
                             LemonadeUi.Tile(
-                                label: "Muted",
+                                label: "Outlined",
                                 icon: .star,
-                                variant: .muted
+                                variant: .outlined
                             )
                             LemonadeUi.Text(
-                                "Muted",
-                                textStyle: LemonadeTypography.shared.bodySmallRegular
-                            )
-                        }
-
-                        VStack(spacing: LemonadeTheme.spaces.spacing200) {
-                            LemonadeUi.Tile(
-                                label: "Selected",
-                                icon: .circleCheck,
-                                variant: .selected
-                            )
-                            LemonadeUi.Text(
-                                "Selected",
+                                "Outlined",
                                 textStyle: LemonadeTypography.shared.bodySmallRegular
                             )
                         }
                     }
                 }
 
-                sectionView(title: "OnColor Variant") {
-                    VStack(spacing: LemonadeTheme.spaces.spacing200) {
+                // MARK: - Selected
+                sectionView(title: "Selected") {
+                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
                         LemonadeUi.Tile(
-                            label: "OnColor",
-                            icon: .check,
-                            variant: .onColor
+                            label: "Filled",
+                            icon: .heart,
+                            isSelected: true,
+                            variant: .filled
                         )
-                        LemonadeUi.Text(
-                            "Use on brand backgrounds",
-                            textStyle: LemonadeTypography.shared.bodySmallRegular,
-                            color: .content.contentOnBrandHigh
+
+                        LemonadeUi.Tile(
+                            label: "Outlined",
+                            icon: .star,
+                            isSelected: true,
+                            variant: .outlined
                         )
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(LemonadeTheme.spaces.spacing400)
-                    .background(.bg.bgBrand)
-                    .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius300))
+                }
+
+                // MARK: - Support Text
+                sectionView(title: "Support Text") {
+                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
+                        LemonadeUi.Tile(
+                            label: "Filled",
+                            icon: .heart,
+                            supportText: "Support",
+                            variant: .filled
+                        )
+
+                        LemonadeUi.Tile(
+                            label: "Outlined",
+                            icon: .star,
+                            supportText: "Support",
+                            variant: .outlined
+                        )
+                    }
                 }
 
                 sectionView(title: "Alignment") {
@@ -70,21 +77,21 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "Start",
                             icon: .arrowLeft,
-                            variant: .neutral,
+                            variant: .filled,
                             alignment: .leading
                         )
 
                         LemonadeUi.Tile(
                             label: "Center",
                             icon: .arrowLeftRight,
-                            variant: .neutral,
+                            variant: .filled,
                             alignment: .center
                         )
 
                         LemonadeUi.Tile(
                             label: "End",
                             icon: .arrowRight,
-                            variant: .neutral,
+                            variant: .filled,
                             alignment: .trailing
                         )
                     }
@@ -96,7 +103,7 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "Messages",
                             icon: .envelope,
-                            variant: .neutral
+                            variant: .filled
                         ) {
                             LemonadeUi.Badge(text: "5", size: .xSmall)
                         }
@@ -104,7 +111,7 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "Updates",
                             icon: .bell,
-                            variant: .neutral
+                            variant: .filled
                         ) {
                             LemonadeUi.Badge(text: "New", size: .xSmall)
                         }
@@ -119,7 +126,7 @@ struct TileDisplayView: View {
                             onClick: {
                                 print("Tile tapped!")
                             },
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
@@ -128,7 +135,7 @@ struct TileDisplayView: View {
                             onClick: {
                                 print("Click!")
                             },
-                            variant: .muted
+                            variant: .outlined
                         )
                     }
                 }
@@ -139,14 +146,14 @@ struct TileDisplayView: View {
                             label: "Disabled",
                             icon: .padlock,
                             enabled: false,
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Disabled",
                             icon: .padlock,
                             enabled: false,
-                            variant: .muted
+                            variant: .outlined
                         )
                     }
                 }
@@ -156,7 +163,7 @@ struct TileDisplayView: View {
                     LemonadeUi.Tile(
                         label: "Default",
                         icon: .heart,
-                        variant: .neutral
+                        variant: .filled
                     )
                 }
 
@@ -165,7 +172,7 @@ struct TileDisplayView: View {
                         label: "Single Stretched",
                         icon: .heart,
                         onClick: {},
-                        variant: .neutral,
+                        variant: .filled,
                         stretched: true
                     )
 
@@ -174,7 +181,7 @@ struct TileDisplayView: View {
                             label: "Transfer",
                             icon: .arrowLeftRight,
                             onClick: {},
-                            variant: .neutral,
+                            variant: .filled,
                             stretched: true
                         )
 
@@ -182,7 +189,7 @@ struct TileDisplayView: View {
                             label: "Pay",
                             icon: .card,
                             onClick: {},
-                            variant: .neutral,
+                            variant: .filled,
                             stretched: true
                         )
 
@@ -190,7 +197,7 @@ struct TileDisplayView: View {
                             label: "Request",
                             icon: .download,
                             onClick: {},
-                            variant: .neutral,
+                            variant: .filled,
                             stretched: true
                         )
                     }
@@ -201,19 +208,19 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "One",
                             icon: .heart,
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Two",
                             icon: .star,
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Three",
                             icon: .check,
-                            variant: .neutral
+                            variant: .filled
                         )
                     }
                     .frame(width: 200)
@@ -230,42 +237,42 @@ struct TileDisplayView: View {
                             label: "Transfer",
                             icon: .arrowLeftRight,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Pay",
                             icon: .card,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Request",
                             icon: .download,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Scan",
                             icon: .qrCode,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Top Up",
                             icon: .plus,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "More",
                             icon: .ellipsisHorizontal,
                             onClick: {},
-                            variant: .neutral
+                            variant: .filled
                         )
                     }
                 }
@@ -277,7 +284,7 @@ struct TileDisplayView: View {
                                 label: "Orders",
                                 icon: .shoppingBag,
                                 onClick: {},
-                                variant: .muted
+                                variant: .outlined
                             ) {
                                 LemonadeUi.Badge(text: "3", size: .xSmall)
                             }
@@ -286,7 +293,7 @@ struct TileDisplayView: View {
                                 label: "Inventory",
                                 icon: .package,
                                 onClick: {},
-                                variant: .muted
+                                variant: .outlined
                             )
                         }
 
@@ -295,14 +302,14 @@ struct TileDisplayView: View {
                                 label: "Reports",
                                 icon: .chart,
                                 onClick: {},
-                                variant: .muted
+                                variant: .outlined
                             )
 
                             LemonadeUi.Tile(
                                 label: "Settings",
                                 icon: .gear,
                                 onClick: {},
-                                variant: .muted
+                                variant: .outlined
                             )
                         }
                     }

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -88,6 +88,23 @@ struct TileDisplayView: View {
                     }
                 }
 
+                // MARK: - Leading Slot
+                sectionView(title: "Leading Slot") {
+                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
+                        LemonadeUi.Tile(
+                            label: "Custom",
+                            variant: .filled,
+                            leadingSlot: {
+                                LemonadeUi.Icon(
+                                    icon: .shoppingBag,
+                                    contentDescription: nil,
+                                    size: .medium
+                                )
+                            }
+                        )
+                    }
+                }
+
                 // MARK: - Features
                 sectionView(title: "Interactive") {
                     HStack(spacing: LemonadeTheme.spaces.spacing400) {

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -98,26 +98,6 @@ struct TileDisplayView: View {
                 }
 
                 // MARK: - Features
-                sectionView(title: "With Addon (Badge)") {
-                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
-                        LemonadeUi.Tile(
-                            label: "Messages",
-                            icon: .envelope,
-                            variant: .filled
-                        ) {
-                            LemonadeUi.Badge(text: "5", size: .xSmall)
-                        }
-
-                        LemonadeUi.Tile(
-                            label: "Updates",
-                            icon: .bell,
-                            variant: .filled
-                        ) {
-                            LemonadeUi.Badge(text: "New", size: .xSmall)
-                        }
-                    }
-                }
-
                 sectionView(title: "Interactive") {
                     HStack(spacing: LemonadeTheme.spaces.spacing400) {
                         LemonadeUi.Tile(
@@ -285,9 +265,7 @@ struct TileDisplayView: View {
                                 icon: .shoppingBag,
                                 onClick: {},
                                 variant: .outlined
-                            ) {
-                                LemonadeUi.Badge(text: "3", size: .xSmall)
-                            }
+                            )
 
                             LemonadeUi.Tile(
                                 label: "Inventory",

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -65,15 +65,17 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "Filled",
                             icon: .heart,
-                            supportText: "Support",
+                            supportText: "Long support text example to check how it wraps and looks on smaller screens",
                             variant: .filled
                         )
 
                         LemonadeUi.Tile(
                             label: "Outlined",
                             icon: .star,
-                            supportText: "Support",
-                            variant: .outlined
+//                            supportText: "Support",
+                            supportText: "Long support text example to check how it wraps and looks on smaller screens",
+                            variant: .outlined,
+                            stretched: true
                         )
                     }
                 }

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import Lemonade
 
 struct TileDisplayView: View {
+    @State private var isFilledSelected = true
+    @State private var isOutlinedSelected = true
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing600) {
@@ -12,6 +15,7 @@ struct TileDisplayView: View {
                             LemonadeUi.Tile(
                                 label: "Filled",
                                 icon: .heart,
+                                onClick: {},
                                 variant: .filled
                             )
                             LemonadeUi.Text(
@@ -24,6 +28,7 @@ struct TileDisplayView: View {
                             LemonadeUi.Tile(
                                 label: "Outlined",
                                 icon: .star,
+                                onClick: {},
                                 variant: .outlined
                             )
                             LemonadeUi.Text(
@@ -40,13 +45,15 @@ struct TileDisplayView: View {
                         LemonadeUi.Tile(
                             label: "Filled",
                             icon: .circleCheck,
-                            isSelected: true,
+                            isSelected: isFilledSelected,
+                            onClick: { isFilledSelected.toggle() },
                             variant: .filled
                         )
                         LemonadeUi.Tile(
                             label: "Outlined",
                             icon: .circleCheck,
-                            isSelected: true,
+                            isSelected: isOutlinedSelected,
+                            onClick: { isOutlinedSelected.toggle() },
                             variant: .outlined
                         )
                     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -7,52 +7,38 @@ public enum LemonadeTileVariant {
     case filled
     case outlined
 
-    @available(*, deprecated, renamed: "filled", message: "Use .filled instead")
-    case neutral
-    @available(*, deprecated, renamed: "outlined", message: "Use .outlined instead")
-    case muted
-    @available(*, deprecated, message: "OnColor variant has been removed. Use .filled instead")
-    case onColor
-    @available(*, deprecated, message: "Use .filled with isSelected = true instead")
-    case selected
-
     var backgroundColor: Color {
         switch self {
-        case .filled, .neutral: return LemonadeTheme.colors.background.bgElevated
-        case .outlined, .muted: return LemonadeTheme.colors.background.bgDefault
-        case .onColor: return LemonadeTheme.colors.background.bgBrandElevated
-        case .selected: return LemonadeTheme.colors.background.bgBrandSubtle
+        case .filled: return LemonadeTheme.colors.background.bgElevated
+        case .outlined: return LemonadeTheme.colors.background.bgDefault
         }
     }
 
     var backgroundPressedColor: Color {
         switch self {
-        case .filled, .neutral: return LemonadeTheme.colors.interaction.bgElevatedPressed
-        case .outlined, .muted: return LemonadeTheme.colors.interaction.bgDefaultPressed
-        case .onColor, .selected: return LemonadeTheme.colors.interaction.bgBrandElevatedPressed
+        case .filled: return LemonadeTheme.colors.interaction.bgElevatedPressed
+        case .outlined: return LemonadeTheme.colors.interaction.bgDefaultPressed
         }
     }
 
     var borderColor: Color {
         switch self {
-        case .filled, .neutral, .outlined, .muted: return LemonadeTheme.colors.border.borderNeutralMedium
-        case .onColor: return LemonadeTheme.colors.border.borderNeutralMediumInverse
-        case .selected: return LemonadeTheme.colors.border.borderSelected
+        case .filled: return LemonadeTheme.colors.border.borderNeutralMedium
+        case .outlined: return LemonadeTheme.colors.border.borderNeutralMedium
         }
     }
 
     var borderWidth: CGFloat {
         switch self {
-        case .filled, .neutral, .outlined, .muted, .onColor: return LemonadeTheme.borderWidth.base.border25
-        case .selected: return LemonadeTheme.borderWidth.base.border50
+        case .filled: return LemonadeTheme.borderWidth.base.border25
+        case .outlined: return LemonadeTheme.borderWidth.base.border25
         }
     }
 
     var shadow: LemonadeShadow? {
         switch self {
-        case .filled, .neutral: return nil
-        case .outlined, .muted: return .xsmall
-        case .onColor, .selected: return nil
+        case .filled: return nil
+        case .outlined: return .xsmall
         }
     }
 }
@@ -81,9 +67,6 @@ public extension LemonadeUi {
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
-    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading.
-    ///     **Deprecated**: Tiles now always use leading alignment per the design spec.
-    ///     This parameter will be removed in a future release.
     /// - Returns: A styled Tile view
     @ViewBuilder
     static func Tile(
@@ -94,8 +77,7 @@ public extension LemonadeUi {
         supportText: String? = nil,
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
-        stretched: Bool = false,
-        alignment: HorizontalAlignment = .leading
+        stretched: Bool = false
     ) -> some View {
         LemonadeTileView<EmptyView>(
             label: label,
@@ -106,7 +88,6 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment,
             topAccessory: nil
         )
     }
@@ -135,9 +116,6 @@ public extension LemonadeUi {
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
-    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading.
-    ///     **Deprecated**: Tiles now always use leading alignment per the design spec.
-    ///     This parameter will be removed in a future release.
     ///   - topAccessory: A view rendered at the top-right of the tile
     /// - Returns: A styled Tile view
     @ViewBuilder
@@ -150,7 +128,6 @@ public extension LemonadeUi {
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
-        alignment: HorizontalAlignment = .leading,
         @ViewBuilder topAccessory: @escaping () -> TopAccessory
     ) -> some View {
         LemonadeTileView(
@@ -162,7 +139,6 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment,
             topAccessory: topAccessory
         )
     }
@@ -188,7 +164,6 @@ public extension LemonadeUi {
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
-    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading
     ///   - leadingSlot: A custom view rendered where the icon would normally appear
     /// - Returns: A styled Tile view
     @ViewBuilder
@@ -200,7 +175,6 @@ public extension LemonadeUi {
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
-        alignment: HorizontalAlignment = .leading,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent
     ) -> some View {
         LemonadeTileSlotView<LeadingContent, EmptyView>(
@@ -211,7 +185,6 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment,
             leadingSlot: leadingSlot,
             topAccessory: nil
         )
@@ -241,7 +214,6 @@ public extension LemonadeUi {
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
-    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading
     ///   - leadingSlot: A custom view rendered where the icon would normally appear
     ///   - topAccessory: A view rendered at the top-right of the tile
     /// - Returns: A styled Tile view
@@ -254,7 +226,6 @@ public extension LemonadeUi {
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
-        alignment: HorizontalAlignment = .leading,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
         @ViewBuilder topAccessory: @escaping () -> TopAccessory
     ) -> some View {
@@ -266,7 +237,6 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment,
             leadingSlot: leadingSlot,
             topAccessory: topAccessory
         )
@@ -285,7 +255,6 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let onClick: (() -> Void)?
     let variant: LemonadeTileVariant
     let stretched: Bool
-    let alignment: HorizontalAlignment
     let topAccessory: (() -> TopAccessory)?
 
     private let minWidth: CGFloat = 120
@@ -387,7 +356,6 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let onClick: (() -> Void)?
     let variant: LemonadeTileVariant
     let stretched: Bool
-    let alignment: HorizontalAlignment
     let leadingSlot: () -> LeadingContent
     let topAccessory: (() -> TopAccessory)?
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -4,15 +4,22 @@ import SwiftUI
 
 /// Defines the visual variant for Tile.
 public enum LemonadeTileVariant {
+    case filled
+    case outlined
+
+    @available(*, deprecated, renamed: "filled", message: "Use .filled instead")
     case neutral
+    @available(*, deprecated, renamed: "outlined", message: "Use .outlined instead")
     case muted
+    @available(*, deprecated, message: "OnColor variant has been removed. Use .filled instead")
     case onColor
+    @available(*, deprecated, message: "Use .filled with isSelected = true instead")
     case selected
 
     var backgroundColor: Color {
         switch self {
-        case .neutral: return LemonadeTheme.colors.background.bgElevated
-        case .muted: return LemonadeTheme.colors.background.bgDefault
+        case .filled, .neutral: return LemonadeTheme.colors.background.bgElevated
+        case .outlined, .muted: return LemonadeTheme.colors.background.bgDefault
         case .onColor: return LemonadeTheme.colors.background.bgBrandElevated
         case .selected: return LemonadeTheme.colors.background.bgBrandSubtle
         }
@@ -20,15 +27,15 @@ public enum LemonadeTileVariant {
 
     var backgroundPressedColor: Color {
         switch self {
-        case .neutral: return LemonadeTheme.colors.interaction.bgElevatedPressed
-        case .muted: return LemonadeTheme.colors.interaction.bgDefaultPressed
+        case .filled, .neutral: return LemonadeTheme.colors.interaction.bgElevatedPressed
+        case .outlined, .muted: return LemonadeTheme.colors.interaction.bgDefaultPressed
         case .onColor, .selected: return LemonadeTheme.colors.interaction.bgBrandElevatedPressed
         }
     }
 
     var borderColor: Color {
         switch self {
-        case .neutral, .muted: return LemonadeTheme.colors.border.borderNeutralMedium
+        case .filled, .neutral, .outlined, .muted: return LemonadeTheme.colors.border.borderNeutralMedium
         case .onColor: return LemonadeTheme.colors.border.borderNeutralMediumInverse
         case .selected: return LemonadeTheme.colors.border.borderSelected
         }
@@ -36,15 +43,15 @@ public enum LemonadeTileVariant {
 
     var borderWidth: CGFloat {
         switch self {
-        case .neutral, .muted, .onColor: return LemonadeTheme.borderWidth.base.border25
+        case .filled, .neutral, .outlined, .muted, .onColor: return LemonadeTheme.borderWidth.base.border25
         case .selected: return LemonadeTheme.borderWidth.base.border50
         }
     }
 
     var shadow: LemonadeShadow? {
         switch self {
-        case .neutral: return nil
-        case .muted: return .xsmall
+        case .filled, .neutral: return nil
+        case .outlined, .muted: return .xsmall
         case .onColor, .selected: return nil
         }
     }
@@ -60,7 +67,7 @@ public extension LemonadeUi {
     /// LemonadeUi.Tile(
     ///     label: "Label",
     ///     icon: .heart,
-    ///     variant: .neutral,
+    ///     variant: .filled,
     ///     onClick: { /* action */ }
     /// )
     /// ```
@@ -69,8 +76,10 @@ public extension LemonadeUi {
     ///   - label: The text to be displayed in the tile
     ///   - icon: LemonadeIcon to be displayed above the label
     ///   - enabled: Flag to define if component is enabled. Defaults to true
+    ///   - isSelected: Whether the tile is in a selected state. Defaults to false
+    ///   - supportText: Optional secondary text displayed below the label
     ///   - onClick: Callback called when component is tapped
-    ///   - variant: LemonadeTileVariant to define visual style. Defaults to .neutral
+    ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     ///   - alignment: Horizontal alignment of the tile content. Defaults to .center
     ///   - addon: Optional content to be displayed as a badge overlay
@@ -80,8 +89,10 @@ public extension LemonadeUi {
         label: String,
         icon: LemonadeIcon,
         enabled: Bool = true,
+        isSelected: Bool = false,
+        supportText: String? = nil,
         onClick: (() -> Void)? = nil,
-        variant: LemonadeTileVariant = .neutral,
+        variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
         alignment: HorizontalAlignment = .center,
         @ViewBuilder addon: @escaping () -> AddonContent
@@ -90,6 +101,8 @@ public extension LemonadeUi {
             label: label,
             icon: icon,
             enabled: enabled,
+            isSelected: isSelected,
+            supportText: supportText,
             onClick: onClick,
             variant: variant,
             stretched: stretched,
@@ -104,8 +117,10 @@ public extension LemonadeUi {
         label: String,
         icon: LemonadeIcon,
         enabled: Bool = true,
+        isSelected: Bool = false,
+        supportText: String? = nil,
         onClick: (() -> Void)? = nil,
-        variant: LemonadeTileVariant = .neutral,
+        variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
         alignment: HorizontalAlignment = .center
     ) -> some View {
@@ -113,6 +128,8 @@ public extension LemonadeUi {
             label: label,
             icon: icon,
             enabled: enabled,
+            isSelected: isSelected,
+            supportText: supportText,
             onClick: onClick,
             variant: variant,
             stretched: stretched,
@@ -128,6 +145,8 @@ private struct LemonadeTileView<AddonContent: View>: View {
     let label: String
     let icon: LemonadeIcon
     let enabled: Bool
+    let isSelected: Bool
+    let supportText: String?
     let onClick: (() -> Void)?
     let variant: LemonadeTileVariant
     let stretched: Bool
@@ -135,29 +154,52 @@ private struct LemonadeTileView<AddonContent: View>: View {
     let addon: (() -> AddonContent)?
 
     private let minWidth: CGFloat = 120
+    private let minHeight: CGFloat = 88
 
-    private var backgroundColor: Color {
-        variant.backgroundColor
+    private var effectiveBackgroundColor: Color {
+        isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
+    }
+
+    private var effectiveBorderColor: Color {
+        isSelected ? LemonadeTheme.colors.border.borderSelected : variant.borderColor
+    }
+
+    private var effectiveBorderWidth: CGFloat {
+        isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
     }
 
     private var tileContent: some View {
-        VStack(alignment: alignment, spacing: LemonadeTheme.spaces.spacing400) {
+        VStack(alignment: alignment, spacing: LemonadeTheme.spaces.spacing300) {
             LemonadeUi.Icon(
                 icon: icon,
                 contentDescription: nil,
                 size: .medium
             )
 
-            LemonadeUi.Text(
-                label,
-                textStyle: LemonadeTypography.shared.bodySmallSemiBold,
-                color: LemonadeTheme.colors.content.contentPrimary,
-                overflow: .tail,
-                maxLines: 1
-            )
+            Spacer()
+
+            VStack(alignment: alignment, spacing: 0) {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodySmallMedium,
+                    color: LemonadeTheme.colors.content.contentPrimary,
+                    overflow: .tail,
+                    maxLines: 1
+                )
+
+                if let supportText {
+                    LemonadeUi.Text(
+                        supportText,
+                        textStyle: LemonadeTypography.shared.bodySmallRegular,
+                        color: LemonadeTheme.colors.content.contentSecondary,
+                        overflow: .tail,
+                        maxLines: 1
+                    )
+                }
+            }
         }
         .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
-        .padding(LemonadeTheme.spaces.spacing400)
+        .padding(LemonadeTheme.spaces.spacing300)
     }
 
     var body: some View {
@@ -173,12 +215,13 @@ private struct LemonadeTileView<AddonContent: View>: View {
                         .frame(minWidth: minWidth)
                 }
             }
+            .frame(minHeight: minHeight)
             .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
-            .background(backgroundColor)
+            .background(effectiveBackgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
             .overlay(
                 RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                    .stroke(variant.borderColor, lineWidth: variant.borderWidth)
+                    .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
             )
             .applyIf(variant.shadow != nil) { view in
                 view.lemonadeShadow(variant.shadow!)
@@ -209,56 +252,65 @@ private struct LemonadeTileView<AddonContent: View>: View {
 struct LemonadeTile_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 24) {
-            // All variants
+            // New variants
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
-                    label: "Neutral",
+                    label: "Filled",
                     icon: .heart,
-                    variant: .neutral
+                    variant: .filled
                 )
 
                 LemonadeUi.Tile(
-                    label: "Muted",
+                    label: "Outlined",
                     icon: .star,
-                    variant: .muted
+                    variant: .outlined
                 )
 
                 LemonadeUi.Tile(
                     label: "Selected",
                     icon: .circleCheck,
-                    variant: .selected
+                    isSelected: true,
+                    variant: .filled
                 )
             }
 
-            // OnColor variant (needs brand background)
-            LemonadeUi.Tile(
-                label: "OnColor",
-                icon: .check,
-                variant: .onColor
-            )
-            .padding()
-            .background(LemonadeTheme.colors.background.bgBrand)
+            // With support text
+            HStack(spacing: 16) {
+                LemonadeUi.Tile(
+                    label: "Filled",
+                    icon: .heart,
+                    supportText: "Support",
+                    variant: .filled
+                )
+
+                LemonadeUi.Tile(
+                    label: "Outlined",
+                    icon: .star,
+                    supportText: "Support",
+                    variant: .outlined
+                )
+            }
 
             // Alignment
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
                     label: "Leading",
                     icon: .arrowLeft,
-                    variant: .neutral,
+                    variant: .filled,
                     alignment: .leading
                 )
 
                 LemonadeUi.Tile(
                     label: "Center",
                     icon: .arrowLeftRight,
-                    variant: .neutral,
+                    variant: .filled,
                     alignment: .center
                 )
 
                 LemonadeUi.Tile(
                     label: "Trailing",
                     icon: .arrowRight,
-                    variant: .neutral,
+                    variant: .filled,
                     alignment: .trailing
                 )
             }
@@ -267,7 +319,7 @@ struct LemonadeTile_Previews: PreviewProvider {
             LemonadeUi.Tile(
                 label: "With Addon",
                 icon: .heart,
-                variant: .neutral
+                variant: .filled
             ) {
                 LemonadeUi.Badge(text: "New", size: .xSmall)
             }
@@ -278,11 +330,11 @@ struct LemonadeTile_Previews: PreviewProvider {
                     label: "Disabled",
                     icon: .heart,
                     enabled: false,
-                    variant: .neutral
+                    variant: .filled
                 )
             }
 
-            // Tight container — tiles shrink below 120pt instead of overflowing
+            // Tight container -- tiles shrink below 120pt instead of overflowing
             // Only demonstrates correctly on iOS 16+ where DefaultMinSize is used
             if #available(iOS 16, macOS 13, *) {
                 VStack(alignment: .leading, spacing: 4) {
@@ -290,9 +342,9 @@ struct LemonadeTile_Previews: PreviewProvider {
                         .font(.caption)
                         .foregroundColor(.secondary)
                     HStack(spacing: 8) {
-                        LemonadeUi.Tile(label: "One", icon: .heart, variant: .neutral)
-                        LemonadeUi.Tile(label: "Two", icon: .star, variant: .neutral)
-                        LemonadeUi.Tile(label: "Three", icon: .check, variant: .neutral)
+                        LemonadeUi.Tile(label: "One", icon: .heart, variant: .filled)
+                        LemonadeUi.Tile(label: "Two", icon: .star, variant: .filled)
+                        LemonadeUi.Tile(label: "Three", icon: .check, variant: .filled)
                     }
                     .frame(width: 200)
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -81,7 +81,9 @@ public extension LemonadeUi {
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
-    ///   - alignment: Horizontal alignment of the tile content. Defaults to .center
+    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading.
+    ///     **Deprecated**: Tiles now always use leading alignment per the design spec.
+    ///     This parameter will be removed in a future release.
     /// - Returns: A styled Tile view
     @ViewBuilder
     static func Tile(
@@ -93,7 +95,63 @@ public extension LemonadeUi {
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
         stretched: Bool = false,
-        alignment: HorizontalAlignment = .center
+        alignment: HorizontalAlignment = .leading
+    ) -> some View {
+        LemonadeTileView<EmptyView>(
+            label: label,
+            icon: icon,
+            enabled: enabled,
+            isSelected: isSelected,
+            supportText: supportText,
+            onClick: onClick,
+            variant: variant,
+            stretched: stretched,
+            alignment: alignment,
+            topAccessory: nil
+        )
+    }
+
+    /// A tile component with icon, label, and a top-right accessory view.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.Tile(
+    ///     label: "Label",
+    ///     icon: .heart,
+    ///     variant: .filled,
+    ///     onClick: { /* action */ }
+    /// ) {
+    ///     // top-right accessory content
+    ///     Image(systemName: "info.circle")
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - label: The text to be displayed in the tile
+    ///   - icon: LemonadeIcon to be displayed above the label
+    ///   - enabled: Flag to define if component is enabled. Defaults to true
+    ///   - isSelected: Whether the tile is in a selected state. Defaults to false
+    ///   - supportText: Optional secondary text displayed below the label
+    ///   - onClick: Callback called when component is tapped
+    ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
+    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading.
+    ///     **Deprecated**: Tiles now always use leading alignment per the design spec.
+    ///     This parameter will be removed in a future release.
+    ///   - topAccessory: A view rendered at the top-right of the tile
+    /// - Returns: A styled Tile view
+    @ViewBuilder
+    static func Tile<TopAccessory: View>(
+        label: String,
+        icon: LemonadeIcon,
+        enabled: Bool = true,
+        isSelected: Bool = false,
+        supportText: String? = nil,
+        onClick: (() -> Void)? = nil,
+        variant: LemonadeTileVariant = .filled,
+        stretched: Bool = false,
+        alignment: HorizontalAlignment = .leading,
+        @ViewBuilder topAccessory: @escaping () -> TopAccessory
     ) -> some View {
         LemonadeTileView(
             label: label,
@@ -104,14 +162,16 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment
+            alignment: alignment,
+            topAccessory: topAccessory
         )
     }
+
 }
 
 // MARK: - Internal Tile View
 
-private struct LemonadeTileView: View {
+private struct LemonadeTileView<TopAccessory: View>: View {
     let label: String
     let icon: LemonadeIcon
     let enabled: Bool
@@ -121,6 +181,7 @@ private struct LemonadeTileView: View {
     let variant: LemonadeTileVariant
     let stretched: Bool
     let alignment: HorizontalAlignment
+    let topAccessory: (() -> TopAccessory)?
 
     private let minWidth: CGFloat = 120
     private let minHeight: CGFloat = 88
@@ -141,13 +202,27 @@ private struct LemonadeTileView: View {
         isSelected ? nil : variant.shadow
     }
 
+    private var effectiveContentColor: Color {
+        isSelected ? LemonadeTheme.colors.content.contentOnBrandHigh : LemonadeTheme.colors.content.contentPrimary
+    }
+
     private var tileContent: some View {
         VStack(alignment: alignment, spacing: LemonadeTheme.spaces.spacing300) {
-            LemonadeUi.Icon(
-                icon: icon,
-                contentDescription: nil,
-                size: .medium
-            )
+            // Top row: icon + topAccessory
+            HStack {
+                LemonadeUi.Icon(
+                    icon: icon,
+                    contentDescription: nil,
+                    size: .medium,
+                    tint: effectiveContentColor
+                )
+
+                Spacer()
+
+                if let topAccessory {
+                    topAccessory()
+                }
+            }
 
             Spacer()
 
@@ -155,7 +230,7 @@ private struct LemonadeTileView: View {
                 LemonadeUi.Text(
                     label,
                     textStyle: LemonadeTypography.shared.bodySmallMedium,
-                    color: LemonadeTheme.colors.content.contentPrimary,
+                    color: effectiveContentColor,
                     overflow: .tail,
                     maxLines: 1
                 )
@@ -252,27 +327,33 @@ struct LemonadeTile_Previews: PreviewProvider {
                 )
             }
 
-            // Alignment
+            // With top accessory
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
-                    label: "Leading",
-                    icon: .arrowLeft,
+                    label: "With Accessory",
+                    icon: .heart,
                     variant: .filled,
-                    alignment: .leading
+                    topAccessory: {
+                        LemonadeUi.Icon(
+                            icon: .circleInfo,
+                            contentDescription: nil,
+                            size: .small
+                        )
+                    }
                 )
 
                 LemonadeUi.Tile(
-                    label: "Center",
-                    icon: .arrowLeftRight,
+                    label: "Selected",
+                    icon: .star,
+                    isSelected: true,
                     variant: .filled,
-                    alignment: .center
-                )
-
-                LemonadeUi.Tile(
-                    label: "Trailing",
-                    icon: .arrowRight,
-                    variant: .filled,
-                    alignment: .trailing
+                    topAccessory: {
+                        LemonadeUi.Icon(
+                            icon: .circleInfo,
+                            contentDescription: nil,
+                            size: .small
+                        )
+                    }
                 )
             }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -60,7 +60,7 @@ public enum LemonadeTileVariant {
 // MARK: - Tile Component
 
 public extension LemonadeUi {
-    /// A tile component with icon, label, and optional addon.
+    /// A tile component with icon and label.
     ///
     /// ## Usage
     /// ```swift
@@ -82,36 +82,7 @@ public extension LemonadeUi {
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     ///   - alignment: Horizontal alignment of the tile content. Defaults to .center
-    ///   - addon: Optional content to be displayed as a badge overlay
     /// - Returns: A styled Tile view
-    @ViewBuilder
-    static func Tile<AddonContent: View>(
-        label: String,
-        icon: LemonadeIcon,
-        enabled: Bool = true,
-        isSelected: Bool = false,
-        supportText: String? = nil,
-        onClick: (() -> Void)? = nil,
-        variant: LemonadeTileVariant = .filled,
-        stretched: Bool = false,
-        alignment: HorizontalAlignment = .center,
-        @ViewBuilder addon: @escaping () -> AddonContent
-    ) -> some View {
-        LemonadeTileView(
-            label: label,
-            icon: icon,
-            enabled: enabled,
-            isSelected: isSelected,
-            supportText: supportText,
-            onClick: onClick,
-            variant: variant,
-            stretched: stretched,
-            alignment: alignment,
-            addon: addon
-        )
-    }
-
-    /// A tile component without addon.
     @ViewBuilder
     static func Tile(
         label: String,
@@ -124,7 +95,7 @@ public extension LemonadeUi {
         stretched: Bool = false,
         alignment: HorizontalAlignment = .center
     ) -> some View {
-        LemonadeTileView<EmptyView>(
+        LemonadeTileView(
             label: label,
             icon: icon,
             enabled: enabled,
@@ -133,15 +104,14 @@ public extension LemonadeUi {
             onClick: onClick,
             variant: variant,
             stretched: stretched,
-            alignment: alignment,
-            addon: nil
+            alignment: alignment
         )
     }
 }
 
 // MARK: - Internal Tile View
 
-private struct LemonadeTileView<AddonContent: View>: View {
+private struct LemonadeTileView: View {
     let label: String
     let icon: LemonadeIcon
     let enabled: Bool
@@ -151,7 +121,6 @@ private struct LemonadeTileView<AddonContent: View>: View {
     let variant: LemonadeTileVariant
     let stretched: Bool
     let alignment: HorizontalAlignment
-    let addon: (() -> AddonContent)?
 
     private let minWidth: CGFloat = 120
     private let minHeight: CGFloat = 88
@@ -203,44 +172,32 @@ private struct LemonadeTileView<AddonContent: View>: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            // Main tile content
-            Group {
-                if #available(iOS 16, macOS 13, *) {
-                    DefaultMinSize(minWidth: minWidth) {
-                        tileContent
-                    }
-                } else {
+        Group {
+            if #available(iOS 16, macOS 13, *) {
+                DefaultMinSize(minWidth: minWidth) {
                     tileContent
-                        .frame(minWidth: minWidth)
                 }
+            } else {
+                tileContent
+                    .frame(minWidth: minWidth)
             }
-            .frame(minHeight: minHeight)
-            .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
-            .background(effectiveBackgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-            .overlay(
-                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
-                    .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
-            )
-            .applyIf(variant.shadow != nil) { view in
-                view.lemonadeShadow(variant.shadow!)
-            }
-            .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
-            .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-            .onTapGesture {
-                if let onClick = onClick, enabled {
-                    onClick()
-                }
-            }
-
-            // Addon badge
-            if let addon = addon {
-                addon()
-                    .offset(
-                        x: LemonadeTheme.spaces.spacing200,
-                        y: -LemonadeTheme.spaces.spacing200
-                    )
+        }
+        .frame(minHeight: minHeight)
+        .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
+        .background(effectiveBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .overlay(
+            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
+        )
+        .applyIf(variant.shadow != nil) { view in
+            view.lemonadeShadow(variant.shadow!)
+        }
+        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+        .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .onTapGesture {
+            if let onClick = onClick, enabled {
+                onClick()
             }
         }
     }
@@ -313,15 +270,6 @@ struct LemonadeTile_Previews: PreviewProvider {
                     variant: .filled,
                     alignment: .trailing
                 )
-            }
-
-            // With addon
-            LemonadeUi.Tile(
-                label: "With Addon",
-                icon: .heart,
-                variant: .filled
-            ) {
-                LemonadeUi.Badge(text: "New", size: .xSmall)
             }
 
             // Disabled

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -246,7 +246,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
+        .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .top))
         .padding(LemonadeTheme.spaces.spacing300)
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -252,6 +252,17 @@ fileprivate func triggerTouchHaptic() {}
 fileprivate func triggerSelectionHaptic() {}
 #endif
 
+// MARK: - Tile Button Style
+
+private struct LemonadeTileButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? .opacity.opacityPressed : .opacity.opacity100)
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
 // MARK: - Internal Tile View
 
 private struct LemonadeTileView<TopAccessory: View>: View {
@@ -264,8 +275,6 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let variant: LemonadeTileVariant
     let stretched: Bool
     let topAccessory: (() -> TopAccessory)?
-
-    @State private var isPressed = false
 
     private let minWidth: CGFloat = 120
 
@@ -347,11 +356,8 @@ private struct LemonadeTileView<TopAccessory: View>: View {
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
         )
-        .opacity(enabled
-            ? (isPressed ? .opacity.opacityPressed : .opacity.opacity100)
-            : LemonadeTheme.opacity.state.opacityDisabled)
+        .opacity(enabled ? .opacity.opacity100 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-        .animation(.easeInOut(duration: 0.1), value: isPressed)
         .onChange(of: isSelected) { newValue in
             if newValue { triggerSelectionHaptic() }
         }
@@ -360,7 +366,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     var body: some View {
         if let onClick {
             Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
-                .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+                .buttonStyle(LemonadeTileButtonStyle())
                 .disabled(!enabled)
         } else {
             tileShape
@@ -380,8 +386,6 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let stretched: Bool
     let leadingSlot: () -> LeadingContent
     let topAccessory: (() -> TopAccessory)?
-
-    @State private var isPressed = false
 
     private let minWidth: CGFloat = 120
 
@@ -458,11 +462,8 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
         )
-        .opacity(enabled
-            ? (isPressed ? .opacity.opacityPressed : .opacity.opacity100)
-            : LemonadeTheme.opacity.state.opacityDisabled)
+        .opacity(enabled ? .opacity.opacity100 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-        .animation(.easeInOut(duration: 0.1), value: isPressed)
         .onChange(of: isSelected) { newValue in
             if newValue { triggerSelectionHaptic() }
         }
@@ -471,7 +472,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     var body: some View {
         if let onClick {
             Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
-                .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+                .buttonStyle(LemonadeTileButtonStyle())
                 .disabled(!enabled)
         } else {
             tileShape
@@ -520,7 +521,7 @@ struct LemonadeTile_Previews: PreviewProvider {
                 LemonadeUi.Tile(
                     label: "Outlined",
                     icon: .star,
-                    supportText: "Support",
+                    supportText: "Long support text example to check how it wraps and looks on smaller screens",
                     variant: .outlined
                 )
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -30,15 +30,8 @@ public enum LemonadeTileVariant {
 
     var borderWidth: CGFloat {
         switch self {
-        case .filled: return LemonadeTheme.borderWidth.base.border25
-        case .outlined: return LemonadeTheme.borderWidth.base.border25
-        }
-    }
-
-    var shadow: LemonadeShadow? {
-        switch self {
-        case .filled: return nil
-        case .outlined: return .xsmall
+        case .filled: return 0
+        case .outlined: return LemonadeTheme.borderWidth.base.border40
         }
     }
 }
@@ -244,6 +237,21 @@ public extension LemonadeUi {
 
 }
 
+// MARK: - Haptic Helpers
+
+#if os(iOS)
+fileprivate func triggerTouchHaptic() {
+    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+}
+
+fileprivate func triggerSelectionHaptic() {
+    UISelectionFeedbackGenerator().selectionChanged()
+}
+#else
+fileprivate func triggerTouchHaptic() {}
+fileprivate func triggerSelectionHaptic() {}
+#endif
+
 // MARK: - Internal Tile View
 
 private struct LemonadeTileView<TopAccessory: View>: View {
@@ -257,6 +265,8 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let stretched: Bool
     let topAccessory: (() -> TopAccessory)?
 
+    @State private var isPressed = false
+
     private let minWidth: CGFloat = 120
 
     private var effectiveBackgroundColor: Color {
@@ -269,10 +279,6 @@ private struct LemonadeTileView<TopAccessory: View>: View {
 
     private var effectiveBorderWidth: CGFloat {
         isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
-    }
-
-    private var effectiveShadow: LemonadeShadow? {
-        isSelected ? nil : variant.shadow
     }
 
     private var effectiveContentColor: Color {
@@ -323,7 +329,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
-    var body: some View {
+    private var tileShape: some View {
         Group {
             if #available(iOS 16, macOS 13, *) {
                 DefaultMinSize(minWidth: minWidth) {
@@ -341,15 +347,23 @@ private struct LemonadeTileView<TopAccessory: View>: View {
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
         )
-        .applyIf(effectiveShadow != nil) { view in
-            view.lemonadeShadow(self.effectiveShadow!)
-        }
-        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+        .opacity(enabled
+            ? (isPressed ? .opacity.opacityPressed : .opacity.opacity100)
+            : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-        .onTapGesture {
-            if let onClick = onClick, enabled {
-                onClick()
-            }
+        .animation(.easeInOut(duration: 0.1), value: isPressed)
+        .onChange(of: isSelected) { newValue in
+            if newValue { triggerSelectionHaptic() }
+        }
+    }
+
+    var body: some View {
+        if let onClick {
+            Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
+                .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+                .disabled(!enabled)
+        } else {
+            tileShape
         }
     }
 }
@@ -367,6 +381,8 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let leadingSlot: () -> LeadingContent
     let topAccessory: (() -> TopAccessory)?
 
+    @State private var isPressed = false
+
     private let minWidth: CGFloat = 120
 
     private var effectiveBackgroundColor: Color {
@@ -379,10 +395,6 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
 
     private var effectiveBorderWidth: CGFloat {
         isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
-    }
-
-    private var effectiveShadow: LemonadeShadow? {
-        isSelected ? nil : variant.shadow
     }
 
     private var effectiveContentColor: Color {
@@ -428,7 +440,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
-    var body: some View {
+    private var tileShape: some View {
         Group {
             if #available(iOS 16, macOS 13, *) {
                 DefaultMinSize(minWidth: minWidth) {
@@ -446,15 +458,23 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
         )
-        .applyIf(effectiveShadow != nil) { view in
-            view.lemonadeShadow(self.effectiveShadow!)
-        }
-        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+        .opacity(enabled
+            ? (isPressed ? .opacity.opacityPressed : .opacity.opacity100)
+            : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
-        .onTapGesture {
-            if let onClick = onClick, enabled {
-                onClick()
-            }
+        .animation(.easeInOut(duration: 0.1), value: isPressed)
+        .onChange(of: isSelected) { newValue in
+            if newValue { triggerSelectionHaptic() }
+        }
+    }
+
+    var body: some View {
+        if let onClick {
+            Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
+                .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+                .disabled(!enabled)
+        } else {
+            tileShape
         }
     }
 }
@@ -470,6 +490,7 @@ struct LemonadeTile_Previews: PreviewProvider {
                 LemonadeUi.Tile(
                     label: "Filled",
                     icon: .heart,
+                    onClick: {},
                     variant: .filled
                 )
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -207,7 +207,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     }
 
     private var tileContent: some View {
-        VStack(alignment: alignment, spacing: LemonadeTheme.spaces.spacing300) {
+        VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing300) {
             // Top row: icon + topAccessory
             HStack {
                 LemonadeUi.Icon(
@@ -217,16 +217,16 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                     tint: effectiveContentColor
                 )
 
-                Spacer()
+                Spacer(minLength: 0)
 
                 if let topAccessory {
                     topAccessory()
                 }
             }
 
-            Spacer()
+            Spacer(minLength: 0)
 
-            VStack(alignment: alignment, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
                 LemonadeUi.Text(
                     label,
                     textStyle: LemonadeTypography.shared.bodySmallMedium,
@@ -246,22 +246,12 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .top))
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
     var body: some View {
-        Group {
-            if #available(iOS 16, macOS 13, *) {
-                DefaultMinSize(minWidth: minWidth) {
-                    tileContent
-                }
-            } else {
-                tileContent
-                    .frame(minWidth: minWidth)
-            }
-        }
-        .frame(minHeight: minHeight)
+        tileContent
+        .frame(minWidth: minWidth, minHeight: minHeight)
         .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
         .background(effectiveBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -167,6 +167,111 @@ public extension LemonadeUi {
         )
     }
 
+    /// A tile component with a custom leading slot view instead of an icon.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.Tile(
+    ///     label: "Custom",
+    ///     variant: .filled,
+    ///     leadingSlot: {
+    ///         LemonadeUi.Icon(icon: .shoppingBag, contentDescription: nil, size: .medium)
+    ///     }
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - label: The text to be displayed in the tile
+    ///   - enabled: Flag to define if component is enabled. Defaults to true
+    ///   - isSelected: Whether the tile is in a selected state. Defaults to false
+    ///   - supportText: Optional secondary text displayed below the label
+    ///   - onClick: Callback called when component is tapped
+    ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
+    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading
+    ///   - leadingSlot: A custom view rendered where the icon would normally appear
+    /// - Returns: A styled Tile view
+    @ViewBuilder
+    static func Tile<LeadingContent: View>(
+        label: String,
+        enabled: Bool = true,
+        isSelected: Bool = false,
+        supportText: String? = nil,
+        onClick: (() -> Void)? = nil,
+        variant: LemonadeTileVariant = .filled,
+        stretched: Bool = false,
+        alignment: HorizontalAlignment = .leading,
+        @ViewBuilder leadingSlot: @escaping () -> LeadingContent
+    ) -> some View {
+        LemonadeTileSlotView<LeadingContent, EmptyView>(
+            label: label,
+            enabled: enabled,
+            isSelected: isSelected,
+            supportText: supportText,
+            onClick: onClick,
+            variant: variant,
+            stretched: stretched,
+            alignment: alignment,
+            leadingSlot: leadingSlot,
+            topAccessory: nil
+        )
+    }
+
+    /// A tile component with a custom leading slot view and a top-right accessory.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.Tile(
+    ///     label: "Custom",
+    ///     variant: .filled,
+    ///     leadingSlot: {
+    ///         LemonadeUi.Icon(icon: .shoppingBag, contentDescription: nil, size: .medium)
+    ///     },
+    ///     topAccessory: {
+    ///         LemonadeUi.Icon(icon: .circleInfo, contentDescription: nil, size: .small)
+    ///     }
+    /// )
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - label: The text to be displayed in the tile
+    ///   - enabled: Flag to define if component is enabled. Defaults to true
+    ///   - isSelected: Whether the tile is in a selected state. Defaults to false
+    ///   - supportText: Optional secondary text displayed below the label
+    ///   - onClick: Callback called when component is tapped
+    ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
+    ///   - alignment: Horizontal alignment of the tile content. Defaults to .leading
+    ///   - leadingSlot: A custom view rendered where the icon would normally appear
+    ///   - topAccessory: A view rendered at the top-right of the tile
+    /// - Returns: A styled Tile view
+    @ViewBuilder
+    static func Tile<LeadingContent: View, TopAccessory: View>(
+        label: String,
+        enabled: Bool = true,
+        isSelected: Bool = false,
+        supportText: String? = nil,
+        onClick: (() -> Void)? = nil,
+        variant: LemonadeTileVariant = .filled,
+        stretched: Bool = false,
+        alignment: HorizontalAlignment = .leading,
+        @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
+        @ViewBuilder topAccessory: @escaping () -> TopAccessory
+    ) -> some View {
+        LemonadeTileSlotView(
+            label: label,
+            enabled: enabled,
+            isSelected: isSelected,
+            supportText: supportText,
+            onClick: onClick,
+            variant: variant,
+            stretched: stretched,
+            alignment: alignment,
+            leadingSlot: leadingSlot,
+            topAccessory: topAccessory
+        )
+    }
+
 }
 
 // MARK: - Internal Tile View
@@ -216,6 +321,104 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                     size: .medium,
                     tint: effectiveContentColor
                 )
+
+                Spacer(minLength: 0)
+
+                if let topAccessory {
+                    topAccessory()
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            VStack(alignment: .leading, spacing: 0) {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodySmallMedium,
+                    color: effectiveContentColor,
+                    overflow: .tail,
+                    maxLines: 1
+                )
+
+                if let supportText {
+                    LemonadeUi.Text(
+                        supportText,
+                        textStyle: LemonadeTypography.shared.bodySmallRegular,
+                        color: LemonadeTheme.colors.content.contentSecondary,
+                        overflow: .tail,
+                        maxLines: 1
+                    )
+                }
+            }
+        }
+        .padding(LemonadeTheme.spaces.spacing300)
+    }
+
+    var body: some View {
+        tileContent
+        .frame(minWidth: minWidth, minHeight: minHeight)
+        .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
+        .background(effectiveBackgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .overlay(
+            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
+        )
+        .applyIf(effectiveShadow != nil) { view in
+            view.lemonadeShadow(self.effectiveShadow!)
+        }
+        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+        .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .onTapGesture {
+            if let onClick = onClick, enabled {
+                onClick()
+            }
+        }
+    }
+}
+
+// MARK: - Internal Tile Slot View
+
+private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: View {
+    let label: String
+    let enabled: Bool
+    let isSelected: Bool
+    let supportText: String?
+    let onClick: (() -> Void)?
+    let variant: LemonadeTileVariant
+    let stretched: Bool
+    let alignment: HorizontalAlignment
+    let leadingSlot: () -> LeadingContent
+    let topAccessory: (() -> TopAccessory)?
+
+    private let minWidth: CGFloat = 120
+    private let minHeight: CGFloat = 88
+
+    private var effectiveBackgroundColor: Color {
+        isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
+    }
+
+    private var effectiveBorderColor: Color {
+        isSelected ? LemonadeTheme.colors.border.borderSelected : variant.borderColor
+    }
+
+    private var effectiveBorderWidth: CGFloat {
+        isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
+    }
+
+    private var effectiveShadow: LemonadeShadow? {
+        isSelected ? nil : variant.shadow
+    }
+
+    private var effectiveContentColor: Color {
+        isSelected ? LemonadeTheme.colors.content.contentOnBrandHigh : LemonadeTheme.colors.content.contentPrimary
+    }
+
+    private var tileContent: some View {
+        VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing300) {
+            // Top row: leadingSlot + topAccessory
+            HStack {
+                leadingSlot()
 
                 Spacer(minLength: 0)
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -137,6 +137,10 @@ private struct LemonadeTileView: View {
         isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
     }
 
+    private var effectiveShadow: LemonadeShadow? {
+        isSelected ? nil : variant.shadow
+    }
+
     private var tileContent: some View {
         VStack(alignment: alignment, spacing: LemonadeTheme.spaces.spacing300) {
             LemonadeUi.Icon(
@@ -190,8 +194,8 @@ private struct LemonadeTileView: View {
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(effectiveBorderColor, lineWidth: effectiveBorderWidth)
         )
-        .applyIf(variant.shadow != nil) { view in
-            view.lemonadeShadow(variant.shadow!)
+        .applyIf(effectiveShadow != nil) { view in
+            view.lemonadeShadow(self.effectiveShadow!)
         }
         .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
         .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -258,7 +258,6 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let topAccessory: (() -> TopAccessory)?
 
     private let minWidth: CGFloat = 120
-    private let minHeight: CGFloat = 88
 
     private var effectiveBackgroundColor: Color {
         isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
@@ -320,12 +319,21 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
     var body: some View {
-        tileContent
-        .frame(minWidth: minWidth, minHeight: minHeight)
+        Group {
+            if #available(iOS 16, macOS 13, *) {
+                DefaultMinSize(minWidth: minWidth) {
+                    tileContent
+                }
+            } else {
+                tileContent
+                    .frame(minWidth: minWidth)
+            }
+        }
         .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
         .background(effectiveBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
@@ -360,7 +368,6 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let topAccessory: (() -> TopAccessory)?
 
     private let minWidth: CGFloat = 120
-    private let minHeight: CGFloat = 88
 
     private var effectiveBackgroundColor: Color {
         isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
@@ -417,12 +424,21 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
     var body: some View {
-        tileContent
-        .frame(minWidth: minWidth, minHeight: minHeight)
+        Group {
+            if #available(iOS 16, macOS 13, *) {
+                DefaultMinSize(minWidth: minWidth) {
+                    tileContent
+                }
+            } else {
+                tileContent
+                    .frame(minWidth: minWidth)
+            }
+        }
         .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
         .background(effectiveBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -6,28 +6,28 @@ import SwiftUI
 public enum LemonadeTileVariant {
     case filled
     case outlined
-
+    
     var backgroundColor: Color {
         switch self {
         case .filled: return LemonadeTheme.colors.background.bgElevated
         case .outlined: return LemonadeTheme.colors.background.bgDefault
         }
     }
-
+    
     var backgroundPressedColor: Color {
         switch self {
         case .filled: return LemonadeTheme.colors.interaction.bgElevatedPressed
         case .outlined: return LemonadeTheme.colors.interaction.bgDefaultPressed
         }
     }
-
+    
     var borderColor: Color {
         switch self {
         case .filled: return LemonadeTheme.colors.border.borderNeutralMedium
         case .outlined: return LemonadeTheme.colors.border.borderNeutralMedium
         }
     }
-
+    
     var borderWidth: CGFloat {
         switch self {
         case .filled: return 0
@@ -84,7 +84,7 @@ public extension LemonadeUi {
             topAccessory: nil
         )
     }
-
+    
     /// A tile component with icon, label, and a top-right accessory view.
     ///
     /// ## Usage
@@ -135,7 +135,7 @@ public extension LemonadeUi {
             topAccessory: topAccessory
         )
     }
-
+    
     /// A tile component with a custom leading slot view instead of an icon.
     ///
     /// ## Usage
@@ -182,7 +182,7 @@ public extension LemonadeUi {
             topAccessory: nil
         )
     }
-
+    
     /// A tile component with a custom leading slot view and a top-right accessory.
     ///
     /// ## Usage
@@ -234,7 +234,7 @@ public extension LemonadeUi {
             topAccessory: topAccessory
         )
     }
-
+    
 }
 
 // MARK: - Haptic Helpers
@@ -275,25 +275,25 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let variant: LemonadeTileVariant
     let stretched: Bool
     let topAccessory: (() -> TopAccessory)?
-
+    
     private let minWidth: CGFloat = 120
-
+    
     private var effectiveBackgroundColor: Color {
         isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
     }
-
+    
     private var effectiveBorderColor: Color {
         isSelected ? LemonadeTheme.colors.border.borderSelected : variant.borderColor
     }
-
+    
     private var effectiveBorderWidth: CGFloat {
         isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
     }
-
+    
     private var effectiveContentColor: Color {
         isSelected ? LemonadeTheme.colors.content.contentOnBrandHigh : LemonadeTheme.colors.content.contentPrimary
     }
-
+    
     private var tileContent: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing300) {
             // Top row: icon + topAccessory
@@ -304,16 +304,16 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                     size: .medium,
                     tint: effectiveContentColor
                 )
-
+                
                 Spacer(minLength: 0)
-
+                
                 if let topAccessory {
                     topAccessory()
                 }
             }
-
+            
             Spacer(minLength: 0)
-
+            
             VStack(alignment: .leading, spacing: 0) {
                 LemonadeUi.Text(
                     label,
@@ -322,22 +322,23 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                     overflow: .tail,
                     maxLines: 1
                 )
-
+                
                 if let supportText {
                     LemonadeUi.Text(
                         supportText,
                         textStyle: LemonadeTypography.shared.bodySmallRegular,
                         color: LemonadeTheme.colors.content.contentSecondary,
                         overflow: .tail,
-                        maxLines: 1
+                        maxLines: 1,
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(LemonadeTheme.spaces.spacing300)
     }
-
+    
     private var tileShape: some View {
         Group {
             if #available(iOS 16, macOS 13, *) {
@@ -349,7 +350,9 @@ private struct LemonadeTileView<TopAccessory: View>: View {
                     .frame(minWidth: minWidth)
             }
         }
-        .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
+        .applyIf(stretched) {
+            $0.frame(maxWidth: .infinity, alignment: .leading)
+        }
         .background(effectiveBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
         .overlay(
@@ -362,7 +365,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
             if newValue { triggerSelectionHaptic() }
         }
     }
-
+    
     var body: some View {
         if let onClick {
             Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
@@ -386,40 +389,40 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let stretched: Bool
     let leadingSlot: () -> LeadingContent
     let topAccessory: (() -> TopAccessory)?
-
+    
     private let minWidth: CGFloat = 120
-
+    
     private var effectiveBackgroundColor: Color {
         isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
     }
-
+    
     private var effectiveBorderColor: Color {
         isSelected ? LemonadeTheme.colors.border.borderSelected : variant.borderColor
     }
-
+    
     private var effectiveBorderWidth: CGFloat {
         isSelected ? LemonadeTheme.borderWidth.base.border50 : variant.borderWidth
     }
-
+    
     private var effectiveContentColor: Color {
         isSelected ? LemonadeTheme.colors.content.contentOnBrandHigh : LemonadeTheme.colors.content.contentPrimary
     }
-
+    
     private var tileContent: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing300) {
             // Top row: leadingSlot + topAccessory
             HStack {
                 leadingSlot()
-
+                
                 Spacer(minLength: 0)
-
+                
                 if let topAccessory {
                     topAccessory()
                 }
             }
-
+            
             Spacer(minLength: 0)
-
+            
             VStack(alignment: .leading, spacing: 0) {
                 LemonadeUi.Text(
                     label,
@@ -428,7 +431,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
                     overflow: .tail,
                     maxLines: 1
                 )
-
+                
                 if let supportText {
                     LemonadeUi.Text(
                         supportText,
@@ -437,10 +440,11 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
                         overflow: .tail,
                         maxLines: 1
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(LemonadeTheme.spaces.spacing300)
     }
 
@@ -455,7 +459,9 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
                     .frame(minWidth: minWidth)
             }
         }
-        .applyIf(stretched) { $0.frame(maxWidth: .infinity) }
+        .applyIf(stretched) {
+            $0.frame(maxWidth: .infinity, alignment: .leading)
+        }
         .background(effectiveBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
         .overlay(
@@ -468,7 +474,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
             if newValue { triggerSelectionHaptic() }
         }
     }
-
+    
     var body: some View {
         if let onClick {
             Button(action: { triggerTouchHaptic(); onClick() }) { tileShape }
@@ -494,13 +500,13 @@ struct LemonadeTile_Previews: PreviewProvider {
                     onClick: {},
                     variant: .filled
                 )
-
+                
                 LemonadeUi.Tile(
                     label: "Outlined",
                     icon: .star,
                     variant: .outlined
                 )
-
+                
                 LemonadeUi.Tile(
                     label: "Selected",
                     icon: .circleCheck,
@@ -508,24 +514,26 @@ struct LemonadeTile_Previews: PreviewProvider {
                     variant: .filled
                 )
             }
-
+            
             // With support text
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
                     label: "Filled",
                     icon: .heart,
                     supportText: "Support",
-                    variant: .filled
+                    variant: .filled,
+                    stretched: true
                 )
-
+                
                 LemonadeUi.Tile(
                     label: "Outlined",
                     icon: .star,
-                    supportText: "Long support text example to check how it wraps and looks on smaller screens",
-                    variant: .outlined
+                    supportText: "Long Support Text to Check Layout",
+                    variant: .outlined,
+                    stretched: true
                 )
             }
-
+            
             // With top accessory
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
@@ -540,7 +548,7 @@ struct LemonadeTile_Previews: PreviewProvider {
                         )
                     }
                 )
-
+                
                 LemonadeUi.Tile(
                     label: "Selected",
                     icon: .star,
@@ -555,17 +563,18 @@ struct LemonadeTile_Previews: PreviewProvider {
                     }
                 )
             }
-
+            
             // Disabled
             HStack(spacing: 16) {
                 LemonadeUi.Tile(
                     label: "Disabled",
                     icon: .heart,
                     enabled: false,
-                    variant: .filled
+                    variant: .filled,
+                    stretched: true
                 )
             }
-
+            
             // Tight container -- tiles shrink below 120pt instead of overflowing
             // Only demonstrates correctly on iOS 16+ where DefaultMinSize is used
             if #available(iOS 16, macOS 13, *) {

--- a/swiftui/Sources/Lemonade/Layouts/DefaultMinSize.swift
+++ b/swiftui/Sources/Lemonade/Layouts/DefaultMinSize.swift
@@ -8,8 +8,13 @@ struct DefaultMinSize: Layout {
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         guard let child = subviews.first else { return .zero }
 
-        let childSize = child.sizeThatFits(proposal)
         let idealSize = child.sizeThatFits(.unspecified)
+
+        // childSize is only needed in the tight-container branch (proposed < minimum).
+        // Avoid the second layout pass in the common case.
+        let inTightContainer = (proposal.width ?? .infinity) < minWidth
+                            || (proposal.height ?? .infinity) < minHeight
+        let childSize = inTightContainer ? child.sizeThatFits(proposal) : .zero
 
         return CGSize(
             width: resolvedDimension(proposed: proposal.width, minimum: minWidth, ideal: idealSize.width, child: childSize.width),
@@ -24,18 +29,16 @@ struct DefaultMinSize: Layout {
 
     /// Resolves a single dimension (width or height) based on the proposed size.
     ///
-    /// - `proposed` is nil, ≤0, or ∞ → return `contentSize` (appear inflexible to HStack probes)
-    /// - `minimum > 0 && proposed > contentSize` → return `proposed` (stretch to fill, e.g. .frame(maxWidth: .infinity))
-    /// - `proposed < contentSize` → return `max(child, proposed)` (graceful shrink in tight containers)
-    /// - Otherwise → return `contentSize` (content-hugging)
+    /// - `proposed` is nil or ∞ → return `contentSize` (appear inflexible to HStack probes)
+    /// - `proposed < minimum` → return `max(child, proposed)` (graceful shrink in tight containers)
+    /// - Otherwise → return `min(contentSize, proposed)` (content-hugging, but never overflow)
     ///
-    /// The ≤0 and ∞ checks make the view report the same size for HStack's min/max probes,
+    /// The nil and ∞ checks make the view report the same size for HStack's min/max probes,
     /// so HStack treats it as inflexible and won't distribute excess space to it.
-    /// The `minimum > 0` guard prevents vertical stretching (minHeight defaults to 0).
     private func resolvedDimension(proposed: CGFloat?, minimum: CGFloat, ideal: CGFloat, child: CGFloat) -> CGFloat {
         let contentSize = max(minimum, ideal)
-        guard let proposed else { return contentSize }
+        guard let proposed, !proposed.isInfinite else { return contentSize }
         if proposed < minimum { return max(child, proposed) }
-        return contentSize
+        return min(contentSize, proposed)
     }
 }


### PR DESCRIPTION
## Summary

- **Variants**: Changed from `Neutral/Muted/OnColor/Selected` to `Filled/Outlined` + `isSelected: Boolean`
- **Old variants deprecated** with migration hints (no breaking removal)
- **New features**: `supportText`, `topAccessory` (internal slot), `leadingSlot` (custom leading content)
- **Selected state**: Uses `contentOnBrandHigh` color for icon/label, `bgBrandSubtle` background, no shadow
- **Layout**: Updated padding (`spacing300`), typography (`bodySmallMedium`), `minHeight: 88`
- **Alignment** deprecated (tiles always use leading/start alignment per design spec)
- **Addon** removed (replaced by `topAccessory` internal slot)

<img width="277" height="600" alt="image" src="https://github.com/user-attachments/assets/0b38b459-f315-4628-8c62-20cdaaf382df" />


<img width="276" height="600" alt="image" src="https://github.com/user-attachments/assets/7088d8d6-1a12-452d-a7f3-295d850a1918" />


## Figma Reference

[Tile Component - Lemonade DS](https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---New-App-Components?node-id=11099-25988)

## Platforms

- [x] Android (KMP / Jetpack Compose)
- [x] iOS (SwiftUI)

## Test plan

- [x] Maestro tests pass on Android (Pixel 7 Pro emulator)
- [x] Maestro tests pass on iOS (iPhone 17 Pro simulator)
- [x] Verified: Variants (Filled, Outlined)
- [x] Verified: Selected state (both variants)
- [x] Verified: Support text
- [x] Verified: Top accessory slot
- [x] Verified: Leading slot
- [x] Verified: Interactive / Disabled states
- [x] Verified: Stretched layout
- [x] Verified: Use cases (Quick Actions, Dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)