### PR TITLE
Fixes selection background not showing in swift ui date picker

### DIFF
--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/CalendarDayCell.kt
@@ -55,7 +55,7 @@ internal fun CalendarDayCell(
     selectionContentColor: Color? = null,
     trailingContent: (@Composable () -> Unit)? = null,
 ) {
-    val selectionShape = LocalShapes.current.radius300
+    val selectionShape = LocalShapes.current.radius200
     val resolvedSelectionBgColor = selectionBackgroundColor
         ?: LocalColors.current.interaction.bgBrandInteractive
     val weekdayLabelColor = resolveWeekdayLabelColor(

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -54,7 +54,8 @@ struct HomeView: View {
                     DemoItem(title: "Checkbox", destination: AnyView(CheckboxDisplayView())),
                     DemoItem(title: "RadioButton", destination: AnyView(RadioButtonDisplayView())),
                     DemoItem(title: "Switch", destination: AnyView(SwitchDisplayView())),
-                    DemoItem(title: "DatePicker", destination: AnyView(DatePickerDisplayView()))
+                    DemoItem(title: "DatePicker", destination: AnyView(DatePickerDisplayView())),
+                    DemoItem(title: "InlineCalendar", destination: AnyView(InlineCalendarDisplayView()))
                 ]
             ),
             DemoSection(

--- a/swiftui/SampleApp/InlineCalendarDisplayView.swift
+++ b/swiftui/SampleApp/InlineCalendarDisplayView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import Lemonade
+
+struct InlineCalendarDisplayView: View {
+    @StateObject private var defaultState = LemonadeInlineCalendarState(initialDate: Date())
+    @StateObject private var trailingDotsState = LemonadeInlineCalendarState(initialDate: Date())
+    @StateObject private var shortLabelsState = LemonadeInlineCalendarState(initialDate: Date())
+    @StateObject private var constrainedState: LemonadeInlineCalendarState
+    @StateObject private var compactSelectionState = LemonadeInlineCalendarState(initialDate: Date())
+    @StateObject private var compactDotsState = LemonadeInlineCalendarState(initialDate: Date())
+    @StateObject private var customColorsState = LemonadeInlineCalendarState(initialDate: Date())
+
+    private let constrainedMinDate: Date
+    private let constrainedMaxDate: Date
+
+    private var dateFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }
+
+    init() {
+        let today = Calendar.current.startOfDay(for: Date())
+        let minDate = Calendar.current.date(byAdding: .day, value: -7, to: today)!
+        let maxDate = Calendar.current.date(byAdding: .day, value: 30, to: today)!
+        self.constrainedMinDate = minDate
+        self.constrainedMaxDate = maxDate
+        _constrainedState = StateObject(
+            wrappedValue: LemonadeInlineCalendarState(
+                initialDate: today,
+                minDate: minDate,
+                maxDate: maxDate
+            )
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 32) {
+                sectionView(title: "Default (today selected)") {
+                    LemonadeUi.InlineCalendar(state: defaultState)
+                    selectedDateLabel(for: defaultState)
+                }
+
+                sectionView(title: "With trailing content (dot on every 3rd day)") {
+                    LemonadeUi.InlineCalendar(
+                        state: trailingDotsState,
+                        enabledDates: { isEveryThirdDay($0) }
+                    ) { date, isSelected in
+                        if isEveryThirdDay(date) {
+                            eventDot(isSelected: isSelected)
+                        }
+                    }
+                    selectedDateLabel(for: trailingDotsState)
+                }
+
+                sectionView(title: "Short day labels (Mon, Tue, Wed...)") {
+                    LemonadeUi.InlineCalendar(
+                        state: shortLabelsState,
+                        dayLabelFormat: .short
+                    )
+                    selectedDateLabel(for: shortLabelsState)
+                }
+
+                sectionView(title: "Constrained range (7 days before to 30 days after)") {
+                    LemonadeUi.InlineCalendar(state: constrainedState)
+
+                    LemonadeUi.Text(
+                        "Range: \(dateFormatter.string(from: constrainedMinDate)) - \(dateFormatter.string(from: constrainedMaxDate))",
+                        textStyle: LemonadeTypography.shared.bodySmallRegular,
+                        color: LemonadeTheme.colors.content.contentSecondary
+                    )
+
+                    selectedDateLabel(for: constrainedState)
+                }
+
+                sectionView(title: "Compact selection (day number only)") {
+                    LemonadeUi.InlineCalendar(
+                        state: compactSelectionState,
+                        expandSelectionToLabel: false
+                    )
+                    selectedDateLabel(for: compactSelectionState)
+                }
+
+                sectionView(title: "Compact selection with trailing dots") {
+                    LemonadeUi.InlineCalendar(
+                        state: compactDotsState,
+                        expandSelectionToLabel: false,
+                        enabledDates: { isEveryThirdDay($0) }
+                    ) { date, isSelected in
+                        if isEveryThirdDay(date) {
+                            eventDot(isSelected: isSelected)
+                        }
+                    }
+                    selectedDateLabel(for: compactDotsState)
+                }
+
+                sectionView(title: "Custom selection colors") {
+                    LemonadeUi.InlineCalendar(
+                        state: customColorsState,
+                        selectionBackgroundColor: LemonadeTheme.colors.interaction.bgInfoInteractive,
+                        selectionContentColor: LemonadeTheme.colors.content.contentAlwaysLight
+                    )
+                    selectedDateLabel(for: customColorsState)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("InlineCalendar")
+    }
+
+    private func isEveryThirdDay(_ date: Date) -> Bool {
+        Calendar.current.component(.day, from: date) % 3 == 0
+    }
+
+    @ViewBuilder
+    private func eventDot(isSelected: Bool) -> some View {
+        Circle()
+            .fill(isSelected
+                ? LemonadeTheme.colors.content.contentOnBrandHigh
+                : LemonadeTheme.colors.content.contentBrand)
+            .frame(width: 6, height: 6)
+    }
+
+    @ViewBuilder
+    private func selectedDateLabel(for state: LemonadeInlineCalendarState) -> some View {
+        LemonadeUi.Text(
+            "Selected: \(state.selectedDate.map { dateFormatter.string(from: $0) } ?? "none")",
+            textStyle: LemonadeTypography.shared.bodySmallRegular,
+            color: LemonadeTheme.colors.content.contentSecondary
+        )
+    }
+
+    private func sectionView<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.content.contentSecondary)
+
+            content()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        InlineCalendarDisplayView()
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarDayCell.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarDayCell.swift
@@ -46,6 +46,7 @@ struct CalendarDayCell<TrailingContent: View>: View {
     /// circle draws the brand background (DatePicker style), and the weekday label
     /// retains its default color.
     let expandSelectionToLabel: Bool
+    let showTodayIndicator: Bool
     let selectionBackgroundColor: Color?
     let selectionContentColor: Color?
     let onClick: () -> Void
@@ -62,6 +63,7 @@ struct CalendarDayCell<TrailingContent: View>: View {
         showWeekdayLabel: Bool = true,
         weekdayLabel: String? = nil,
         expandSelectionToLabel: Bool = true,
+        showTodayIndicator: Bool = false,
         selectionBackgroundColor: Color? = nil,
         selectionContentColor: Color? = nil,
         onClick: @escaping () -> Void,
@@ -77,6 +79,7 @@ struct CalendarDayCell<TrailingContent: View>: View {
         self.showWeekdayLabel = showWeekdayLabel
         self.weekdayLabel = weekdayLabel
         self.expandSelectionToLabel = expandSelectionToLabel
+        self.showTodayIndicator = showTodayIndicator
         self.selectionBackgroundColor = selectionBackgroundColor
         self.selectionContentColor = selectionContentColor
         self.onClick = onClick
@@ -107,6 +110,17 @@ struct CalendarDayCell<TrailingContent: View>: View {
         return LemonadeTheme.colors.content.contentPrimary
     }
 
+    /// Renders the selected-state brand background when `active` is true.
+    @ViewBuilder
+    private func selectionBackground(active: Bool, inset: CGFloat = 0) -> some View {
+        if active {
+            RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius200)
+                .fill(selectionBackgroundColor ?? LemonadeTheme.colors.interaction.bgBrandInteractive)
+                .padding(.horizontal, inset)
+                .padding(.vertical, inset)
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if showWeekdayLabel, let label = weekdayLabel {
@@ -131,7 +145,7 @@ struct CalendarDayCell<TrailingContent: View>: View {
                     isOutsideVisibleRange: isOutsideVisibleRange,
                     isInsideSelectedRange: isInsideSelectedRange,
                     showSelectionBackground: false,
-                    showTodayIndicator: false,
+                    showTodayIndicator: showTodayIndicator,
                     selectionContentColor: selectionContentColor,
                     onClick: onClick
                 )
@@ -140,28 +154,15 @@ struct CalendarDayCell<TrailingContent: View>: View {
             }
             .padding(.vertical, !expandSelectionToLabel ? LemonadeTheme.spaces.spacing100 : 0)
             .background(
-                Group {
-                    if !expandSelectionToLabel && isSelected {
-                        // Negative horizontal padding extends the background into the
-                        // outer VStack's padding area so the compact selection matches
-                        // the expanded selection width.
-                        RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius400)
-                            .fill(selectionBackgroundColor ?? LemonadeTheme.colors.interaction.bgBrandInteractive)
-                            .padding(.horizontal, -LemonadeTheme.spaces.spacing100)
-                            .padding(.vertical, -LemonadeTheme.spaces.spacing100)
-                    }
-                }
+                selectionBackground(
+                    active: !expandSelectionToLabel && isSelected,
+                    inset: -LemonadeTheme.spaces.spacing100
+                )
             )
         }
-        .padding(.horizontal, LemonadeTheme.spaces.spacing100)
-        .padding(.vertical, LemonadeTheme.spaces.spacing100)
+        .padding(showWeekdayLabel ? LemonadeTheme.spaces.spacing100 : 0)
         .background(
-            Group {
-                if showWeekdayLabel && expandSelectionToLabel && isSelected {
-                    RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius400)
-                        .fill(selectionBackgroundColor ?? LemonadeTheme.colors.interaction.bgBrandInteractive)
-                }
-            }
+            selectionBackground(active: expandSelectionToLabel && isSelected)
         )
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -378,6 +378,7 @@ private struct MonthGridView: View {
                             isOutsideVisibleRange: isOutsideMonth,
                             isInsideSelectedRange: isInRange,
                             showWeekdayLabel: false,
+                            showTodayIndicator: true,
                             onClick: { onDateSelected(normalized) }
                         )
                         .padding(.horizontal, LemonadeTheme.spaces.spacing200)
@@ -407,6 +408,7 @@ private struct MonthGridView: View {
                 )
             }
         }
+        .frame(maxHeight: .infinity, alignment: .top)
     }
 }
 


### PR DESCRIPTION
# Summary
<!--Please provide a short summary, describing the changes made by the PR if necessary. -->
Fixes selection background and today dot not showing in swift ui date picker
Also adds inline calendar section to ios sample app which was missing

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->
<img width="300" alt="Screenshot 2026-04-20 at 11 30 26" src="https://github.com/user-attachments/assets/f4244d77-dbe3-4641-9500-e05ff3c3c7ad" />
