### PR TITLE
fix: render selected-tab indicator on iOS <26 SegmentedControl

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -223,6 +223,8 @@ private struct LemonadeSegmentedControlView: View {
                 }
                 .buttonStyle(SegmentPressStyle())
                 .frame(maxWidth: .infinity)
+                .accessibilityLabel(property.label ?? property.icon?.rawValue ?? "")
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
                 .background {
                     if drawSelectionIndicator && isSelected {
                         RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -140,6 +140,8 @@ private struct LemonadeSegmentedControlView: View {
     let size: LemonadeSegmentedControlSize
     let onTabSelected: (Int) -> Void
 
+    @Namespace private var indicatorNamespace
+
     private var clampedSelectedTab: Int {
         min(max(selectedTab, 0), properties.count - 1)
     }
@@ -155,7 +157,7 @@ private struct LemonadeSegmentedControlView: View {
                     onSelectionChanged: onTabSelected
                 )
 
-                labelsOverlay
+                labelsOverlay(drawSelectionIndicator: false)
                     .allowsHitTesting(false)
             }
             .frame(
@@ -164,19 +166,15 @@ private struct LemonadeSegmentedControlView: View {
             )
             .frame(height: size.containerHeight)
         } else {
-            labelsOverlay
-                .frame(
-                    minWidth: size.buttonMinWidth,
-                    minHeight: size.buttonMinHeight
-                )
-                .frame(height: size.containerHeight)
-                .background(
-                    RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
-                        .fill(LemonadeTheme.colors.background.bgElevated)
-                )
+            fallbackControl
         }
         #else
-        labelsOverlay
+        fallbackControl
+        #endif
+    }
+
+    private var fallbackControl: some View {
+        labelsOverlay(drawSelectionIndicator: true)
             .frame(
                 minWidth: size.buttonMinWidth,
                 minHeight: size.buttonMinHeight
@@ -186,14 +184,14 @@ private struct LemonadeSegmentedControlView: View {
                 RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
                     .fill(LemonadeTheme.colors.background.bgElevated)
             )
-        #endif
     }
 
-    private var labelsOverlay: some View {
+    private func labelsOverlay(drawSelectionIndicator: Bool) -> some View {
         HStack(spacing: 0) {
             ForEach(properties.indices, id: \.self) { index in
                 let property = properties[index]
-                let tintColor = index == clampedSelectedTab
+                let isSelected = index == clampedSelectedTab
+                let tintColor = isSelected
                     ? LemonadeTheme.colors.content.contentPrimary
                     : LemonadeTheme.colors.content.contentSecondary
 
@@ -225,6 +223,14 @@ private struct LemonadeSegmentedControlView: View {
                 }
                 .buttonStyle(SegmentPressStyle())
                 .frame(maxWidth: .infinity)
+                .background {
+                    if drawSelectionIndicator && isSelected {
+                        RoundedRectangle(cornerRadius: LemonadeTheme.radius.radiusFull)
+                            .fill(LemonadeTheme.colors.background.bgDefault)
+                            .lemonadeShadow(.xsmall)
+                            .matchedGeometryEffect(id: "indicator", in: indicatorNamespace)
+                    }
+                }
             }
         }
         .padding(size.containerPadding)


### PR DESCRIPTION
## Summary
- The iOS <26 fallback of `LemonadeUi.SegmentedControl` rendered only the outer pill and colored text — the selected tab had no visual indicator. iOS 26+ got the indicator from the native `UISegmentedControl`'s Liquid Glass.
- This PR adds a `bgDefault` pill (with `xsmall` shadow) anchored to the selected tab via `@Namespace` + `matchedGeometryEffect`, matching the KMP design. The iOS 26 path is unchanged.
- Consolidated the iOS <26 and non-UIKit branches into a single `fallbackControl`.

<img width="256" height="325" alt="image" src="https://github.com/user-attachments/assets/07e3b02b-c01f-4e93-955a-23993a7fde1d" />


## Test plan
- [x] Builds on iOS 18.6 simulator
- [x] Builds on iOS 26.0 simulator
- [x] Maestro flow on iOS 18.6: tapping Tab 1/2/3 moves the indicator and updates `Selected:` label across Large / Medium / Small / With Icons variants
- [x] Maestro flow on iOS 26.0: same behavior, indicator visible and animates
- [ ] Visual check in dark mode
- [ ] Visual check for the icon-only variant at small size

🤖 Generated with [Claude Code](https://claude.com/claude-code)