### PR TITLE
feat: align ContentListItem with Figma specs (divider + internal padding)

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
-import com.teya.lemonade.core.LemonadeCardPadding
 import com.teya.lemonade.core.LemonadeContentListItemLayout
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.SymbolContainerSize
@@ -32,28 +31,25 @@ internal fun ContentListItemDisplay() {
             .navigationBarsPadding()
             .padding(all = LemonadeTheme.spaces.spacing400),
     ) {
-        // Horizontal simple
+        // Horizontal simple (stacked with dividers)
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Simple"),
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400)) {
-                LemonadeUi.ContentListItem(
-                    label = "Account holder",
-                    value = "John Doe",
-                    layout = LemonadeContentListItemLayout.Horizontal,
-                )
-                LemonadeUi.ContentListItem(
-                    label = "Account number",
-                    value = "123-456-789",
-                    layout = LemonadeContentListItemLayout.Horizontal,
-                )
-            }
+            LemonadeUi.ContentListItem(
+                label = "Account holder",
+                value = "John Doe",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Account number",
+                value = "123-456-789",
+                layout = LemonadeContentListItemLayout.Horizontal,
+            )
         }
 
         // Horizontal with leading SymbolContainer + trailing icon
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Leading & Trailing"),
         ) {
             LemonadeUi.ContentListItem(
@@ -81,7 +77,6 @@ internal fun ContentListItemDisplay() {
 
         // Horizontal with content slot
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Horizontal — Content Slot"),
         ) {
             LemonadeUi.ContentListItem(
@@ -99,7 +94,6 @@ internal fun ContentListItemDisplay() {
 
         // Vertical small (no content slot)
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Small — Simple"),
         ) {
             LemonadeUi.ContentListItem(
@@ -111,7 +105,6 @@ internal fun ContentListItemDisplay() {
 
         // Vertical small with leading + trailing
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Small — Leading & Trailing"),
         ) {
             LemonadeUi.ContentListItem(
@@ -139,7 +132,6 @@ internal fun ContentListItemDisplay() {
 
         // Vertical large (with content slot)
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Large — Content Slot"),
         ) {
             LemonadeUi.ContentListItem(
@@ -157,7 +149,6 @@ internal fun ContentListItemDisplay() {
 
         // Vertical large with leading + trailing + content slot
         LemonadeUi.Card(
-            contentPadding = LemonadeCardPadding.Medium,
             header = CardHeaderConfig(title = "Vertical Large — Full"),
         ) {
             LemonadeUi.ContentListItem(
@@ -180,6 +171,35 @@ internal fun ContentListItemDisplay() {
                         contentDescription = "Edit",
                     )
                 },
+                contentSlot = {
+                    LemonadeUi.Tag(
+                        label = "Available",
+                        voice = TagVoice.Positive,
+                    )
+                },
+            )
+        }
+
+        // Mixed list with dividers
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Mixed List with Dividers"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Label",
+                value = "Value",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Label",
+                value = "Value",
+                layout = LemonadeContentListItemLayout.Vertical,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Label",
+                value = "Value",
+                layout = LemonadeContentListItemLayout.Vertical,
                 contentSlot = {
                     LemonadeUi.Tag(
                         label = "Available",

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +43,7 @@ import com.teya.lemonade.core.SymbolContainerVoice
  * @param value - Value [String] to display.
  * @param layout - [LemonadeContentListItemLayout] horizontal or vertical arrangement.
  * @param modifier - [Modifier] to be applied to the root container.
+ * @param showDivider - Whether to display a bottom divider below the item.
  * @param leadingSlot - Optional slot for a leading element (e.g. SymbolContainer).
  * @param trailingSlot - Optional slot for a trailing element (e.g. icon action).
  * @param contentSlot - Optional slot for additional content. In vertical layout, this also
@@ -53,28 +55,39 @@ public fun LemonadeUi.ContentListItem(
     value: String,
     layout: LemonadeContentListItemLayout = LemonadeContentListItemLayout.Horizontal,
     modifier: Modifier = Modifier,
+    showDivider: Boolean = false,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
-    when (layout) {
-        LemonadeContentListItemLayout.Horizontal -> HorizontalContentListItem(
-            label = label,
-            value = value,
-            modifier = modifier,
-            leadingSlot = leadingSlot,
-            trailingSlot = trailingSlot,
-            contentSlot = contentSlot,
-        )
+    val contentModifier = Modifier.padding(all = LocalSpaces.current.spacing400)
 
-        LemonadeContentListItemLayout.Vertical -> VerticalContentListItem(
-            label = label,
-            value = value,
-            modifier = modifier,
-            leadingSlot = leadingSlot,
-            trailingSlot = trailingSlot,
-            contentSlot = contentSlot,
-        )
+    Column(modifier = modifier) {
+        when (layout) {
+            LemonadeContentListItemLayout.Horizontal -> HorizontalContentListItem(
+                label = label,
+                value = value,
+                modifier = contentModifier,
+                leadingSlot = leadingSlot,
+                trailingSlot = trailingSlot,
+                contentSlot = contentSlot,
+            )
+
+            LemonadeContentListItemLayout.Vertical -> VerticalContentListItem(
+                label = label,
+                value = value,
+                modifier = contentModifier,
+                leadingSlot = leadingSlot,
+                trailingSlot = trailingSlot,
+                contentSlot = contentSlot,
+            )
+        }
+
+        if (showDivider) {
+            LemonadeUi.HorizontalDivider(
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing400),
+            )
+        }
     }
 }
 
@@ -187,6 +200,7 @@ private data class ContentListItemPreviewData(
     val hasLeading: Boolean,
     val hasTrailing: Boolean,
     val hasContentSlot: Boolean,
+    val showDivider: Boolean,
 )
 
 private class ContentListItemPreviewProvider :
@@ -197,14 +211,17 @@ private class ContentListItemPreviewProvider :
                 listOf(true, false).forEach { leading ->
                     listOf(true, false).forEach { trailing ->
                         listOf(true, false).forEach { contentSlot ->
-                            add(
-                                ContentListItemPreviewData(
-                                    layout = layout,
-                                    hasLeading = leading,
-                                    hasTrailing = trailing,
-                                    hasContentSlot = contentSlot,
-                                ),
-                            )
+                            listOf(true, false).forEach { divider ->
+                                add(
+                                    ContentListItemPreviewData(
+                                        layout = layout,
+                                        hasLeading = leading,
+                                        hasTrailing = trailing,
+                                        hasContentSlot = contentSlot,
+                                        showDivider = divider,
+                                    ),
+                                )
+                            }
                         }
                     }
                 }
@@ -222,6 +239,7 @@ private fun ContentListItemPreview(
         label = "Label",
         value = "Value",
         layout = previewData.layout,
+        showDivider = previewData.showDivider,
         leadingSlot = if (previewData.hasLeading) {
             {
                 LemonadeUi.SymbolContainer(

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -5,27 +5,24 @@ struct ContentListItemDisplayView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(spacing: .space.spacing400) {
-                // MARK: - Horizontal Simple
+                // MARK: - Horizontal Simple (stacked with dividers)
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal Simple")
                 ) {
-                    VStack(spacing: .space.spacing400) {
-                        LemonadeUi.ContentListItem(
-                            label: "Account holder",
-                            value: "John Doe"
-                        )
-                        
-                        LemonadeUi.ContentListItem(
-                            label: "Account number",
-                            value: "1234-5678"
-                        )
-                    }
+                    LemonadeUi.ContentListItem(
+                        label: "Account holder",
+                        value: "John Doe",
+                        showDivider: true
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Account number",
+                        value: "1234-5678"
+                    )
                 }
 
                 // MARK: - Horizontal with Leading + Trailing
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal with Leading + Trailing")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -51,7 +48,6 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Horizontal with Content Slot
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Horizontal with Content Slot")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -65,7 +61,6 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Small
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Small")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -77,7 +72,6 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Small with Leading + Trailing
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Small with Leading + Trailing")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -104,7 +98,6 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Large (with Content Slot)
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Large")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -119,7 +112,6 @@ struct ContentListItemDisplayView: View {
 
                 // MARK: - Vertical Large with All Slots
                 LemonadeUi.Card(
-                    contentPadding: .medium,
                     header: CardHeaderConfig(title: "Vertical Large with All Slots")
                 ) {
                     LemonadeUi.ContentListItem(
@@ -141,6 +133,33 @@ struct ContentListItemDisplayView: View {
                                 tint: LemonadeTheme.colors.content.contentBrand
                             )
                         },
+                        contentSlot: {
+                            LemonadeUi.Tag(label: "Available", voice: .positive)
+                        }
+                    )
+                }
+
+                // MARK: - Mixed List with Dividers
+                LemonadeUi.Card(
+                    header: CardHeaderConfig(title: "Mixed List with Dividers")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        showDivider: true
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        layout: .vertical,
+                        showDivider: true
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        layout: .vertical,
                         contentSlot: {
                             LemonadeUi.Tag(label: "Available", voice: .positive)
                         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
@@ -38,6 +38,7 @@ public extension LemonadeUi {
     ///   - label: Label String describing the data field
     ///   - value: Value String to display
     ///   - layout: Horizontal or vertical arrangement
+    ///   - showDivider: Whether to display a bottom divider below the item
     ///   - leadingSlot: Optional leading element (e.g. SymbolContainer)
     ///   - trailingSlot: Optional trailing element (e.g. icon action)
     ///   - contentSlot: Optional additional content. In vertical layout, switches value to larger typography
@@ -46,6 +47,7 @@ public extension LemonadeUi {
         label: String,
         value: String,
         layout: LemonadeContentListItemLayout = .horizontal,
+        showDivider: Bool = false,
         @ViewBuilder leadingSlot: @escaping () -> Leading = { EmptyView() },
         @ViewBuilder trailingSlot: @escaping () -> Trailing = { EmptyView() },
         @ViewBuilder contentSlot: @escaping () -> Content = { EmptyView() }
@@ -54,6 +56,7 @@ public extension LemonadeUi {
             label: label,
             value: value,
             layout: layout,
+            showDivider: showDivider,
             leadingSlot: leadingSlot,
             trailingSlot: trailingSlot,
             contentSlot: contentSlot
@@ -67,6 +70,7 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
     let label: String
     let value: String
     let layout: LemonadeContentListItemLayout
+    let showDivider: Bool
     @ViewBuilder let leadingSlot: () -> Leading
     @ViewBuilder let trailingSlot: () -> Trailing
     @ViewBuilder let contentSlot: () -> Content
@@ -84,11 +88,21 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
     }
 
     var body: some View {
-        switch layout {
-        case .horizontal:
-            horizontalLayout
-        case .vertical:
-            verticalLayout
+        VStack(spacing: 0) {
+            Group {
+                switch layout {
+                case .horizontal:
+                    horizontalLayout
+                case .vertical:
+                    verticalLayout
+                }
+            }
+            .padding(LemonadeTheme.spaces.spacing400)
+
+            if showDivider {
+                LemonadeUi.HorizontalDivider()
+                    .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+            }
         }
     }
 
@@ -229,6 +243,24 @@ struct LemonadeContentListItem_Previews: PreviewProvider {
                         LemonadeUi.Tag(label: "Available", voice: .positive)
                     }
                 )
+
+                // Stacked list with dividers
+                VStack(spacing: 0) {
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        showDivider: true
+                    )
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value",
+                        showDivider: true
+                    )
+                    LemonadeUi.ContentListItem(
+                        label: "Label",
+                        value: "Value"
+                    )
+                }
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- Add `showDivider: Bool = false` to `ContentListItem` in both KMP Compose (`kmp/ui/.../ContentListItem.kt`) and SwiftUI (`swiftui/.../LemonadeContentListItem.swift`).
- Bake 16px (`spacing400`) padding on all sides of the item so it matches the Figma spec for the new Content List Item (node `18130:69377`). The optional divider is inset 16px horizontally, matching `ActionListItem` / `ResourceListItem`.
- Update sample apps: `Card` wrappers drop `contentPadding: .medium` (now redundant), and a new "Mixed List with Dividers" section demonstrates the stacked pattern seen in Figma.

-iOS

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5d6e13e1-264b-4575-a0ab-20e6500accbd" />



- Android

<img width="1440" height="3120" alt="image" src="https://github.com/user-attachments/assets/78aebd49-5358-43c5-87ae-dcf545619e24" />




## Test plan
- [ ] Open the KMP composeApp on Android → Components → ContentListItem and verify items render with 16dp internal padding; stacked samples show dividers inset from the edges.
- [ ] Open the SwiftUI SampleApp on iOS simulator → ContentListItem and verify the same.
- [ ] Compare layouts against Figma node 18130:69377 (simple, with leading/trailing, vertical small/large, with content slot, divider on/off).
- [ ] Confirm existing ActionListItem / ResourceListItem usages are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)