### PR TITLE
feat: expose ListItem slot API as public (SwiftUI + KMP)

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -226,7 +226,7 @@ public fun LemonadeUi.ActionListItem(
  * @param slotContent - Optional slot content below the label and support text.
  */
 @Composable
-internal fun LemonadeUi.ListItem(
+public fun LemonadeUi.ListItem(
     label: String,
     modifier: Modifier = Modifier,
     supportText: String? = null,
@@ -300,7 +300,7 @@ internal fun LemonadeUi.ListItem(
  * @param interactionSource - [MutableInteractionSource] for interaction events.
  */
 @Composable
-internal fun LemonadeUi.ListItem(
+public fun LemonadeUi.ListItem(
     contentSlot: @Composable ColumnScope.() -> Unit,
     modifier: Modifier = Modifier,
     onListItemClick: (() -> Unit)? = null,

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -46,9 +46,9 @@ public enum LemonadeListItemVoice {
     }
 }
 
-// MARK: - Internal ListItem Helpers
+// MARK: - ListItem
 
-extension LemonadeUi {
+public extension LemonadeUi {
     /// Convenience overload that composes standard label and support-text content from string
     /// parameters and delegates to the content-slot variant of ListItem.
     ///


### PR DESCRIPTION
## Summary
- Makes the two `LemonadeUi.ListItem` overloads public on both platforms: the label + `slotContent` variant and the fully custom `contentSlot` variant.
  - SwiftUI: `swiftui/Sources/Lemonade/Components/LemonadeListItem.swift:51`
  - KMP: `kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt:229` and `:303`
- Until now they were `internal`, only reachable from `ActionListItem` / `ResourceListItem` / `SelectListItem` inside each module. Consumers that need a list item shape outside those presets had no way to compose one without forking.
- Stacked on top of #165 (the chevron top-alignment fix) — merging that first keeps the history clean.

## Notes
- No behaviour change for existing call sites; the underlying core views (`LemonadeCoreListItemView` / `CoreListItem`) are unchanged.
- KMP is in explicit API mode — the `public` modifier is explicit as required.

## Test plan
- [ ] Verify `Lemonade` framework builds for iOS
- [ ] Verify `:ui` module compiles on KMP (`./gradlew :ui:compileKotlinMetadata`)
- [ ] `./gradlew :ui:ktlintCheck` passes
- [ ] In a downstream consumer (or sample app), call `LemonadeUi.ListItem(contentSlot = { ... })` on both platforms — should resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)