### PR TITLE
feat: add error state to Chip component

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
@@ -58,17 +58,6 @@ internal fun ChipDisplay() {
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                     )
                 }
-
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                ) {
-                    LemonadeUi.Chip(label = "Error", selected = false, leadingIcon = null, error = true)
-                    LemonadeUi.Text(
-                        text = "Error",
-                        textStyle = LemonadeTheme.typography.bodySmallRegular,
-                    )
-                }
             }
         }
 
@@ -92,12 +81,6 @@ internal fun ChipDisplay() {
                 ) {
                     LemonadeUi.Chip(label = "Favorites", selected = false, leadingIcon = LemonadeIcons.Heart)
                     LemonadeUi.Chip(label = "Favorites", selected = true, leadingIcon = LemonadeIcons.Heart)
-                    LemonadeUi.Chip(
-                        label = "Favorites",
-                        selected = false,
-                        leadingIcon = LemonadeIcons.Heart,
-                        error = true,
-                    )
                 }
 
                 Row(
@@ -114,13 +97,6 @@ internal fun ChipDisplay() {
                         selected = true,
                         leadingIcon = null,
                         trailingIcon = LemonadeIcons.CircleX,
-                    )
-                    LemonadeUi.Chip(
-                        label = "Remove",
-                        selected = false,
-                        leadingIcon = null,
-                        trailingIcon = LemonadeIcons.CircleX,
-                        error = true,
                     )
                 }
             }
@@ -170,13 +146,68 @@ internal fun ChipDisplay() {
             ) {
                 LemonadeUi.Chip(label = "Disabled", selected = false, leadingIcon = null, enabled = false)
                 LemonadeUi.Chip(label = "Disabled", selected = true, leadingIcon = null, enabled = false)
-                LemonadeUi.Chip(
-                    label = "Disabled",
-                    selected = false,
-                    leadingIcon = null,
-                    enabled = false,
-                    error = true,
-                )
+            }
+        }
+
+        // Error
+        ChipSection(title = "Error") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                    ) {
+                        LemonadeUi.Chip(
+                            label = "Error",
+                            selected = false,
+                            leadingIcon = null,
+                            error = true,
+                        )
+                        LemonadeUi.Text(
+                            text = "Error",
+                            textStyle = LemonadeTheme.typography.bodySmallRegular,
+                        )
+                    }
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                    ) {
+                        LemonadeUi.Chip(
+                            label = "Error",
+                            selected = false,
+                            leadingIcon = null,
+                            enabled = false,
+                            error = true,
+                        )
+                        LemonadeUi.Text(
+                            text = "Error Disabled",
+                            textStyle = LemonadeTheme.typography.bodySmallRegular,
+                        )
+                    }
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    LemonadeUi.Chip(
+                        label = "With Icon",
+                        selected = false,
+                        leadingIcon = LemonadeIcons.CircleAlert,
+                        error = true,
+                    )
+                    LemonadeUi.Chip(
+                        label = "With Trailing",
+                        selected = false,
+                        leadingIcon = null,
+                        trailingIcon = LemonadeIcons.CircleX,
+                        error = true,
+                    )
+                }
             }
         }
     }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
@@ -58,6 +58,17 @@ internal fun ChipDisplay() {
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                     )
                 }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                ) {
+                    LemonadeUi.Chip(label = "Error", selected = false, leadingIcon = null, error = true)
+                    LemonadeUi.Text(
+                        text = "Error",
+                        textStyle = LemonadeTheme.typography.bodySmallRegular,
+                    )
+                }
             }
         }
 
@@ -81,6 +92,12 @@ internal fun ChipDisplay() {
                 ) {
                     LemonadeUi.Chip(label = "Favorites", selected = false, leadingIcon = LemonadeIcons.Heart)
                     LemonadeUi.Chip(label = "Favorites", selected = true, leadingIcon = LemonadeIcons.Heart)
+                    LemonadeUi.Chip(
+                        label = "Favorites",
+                        selected = false,
+                        leadingIcon = LemonadeIcons.Heart,
+                        error = true,
+                    )
                 }
 
                 Row(
@@ -97,6 +114,13 @@ internal fun ChipDisplay() {
                         selected = true,
                         leadingIcon = null,
                         trailingIcon = LemonadeIcons.CircleX,
+                    )
+                    LemonadeUi.Chip(
+                        label = "Remove",
+                        selected = false,
+                        leadingIcon = null,
+                        trailingIcon = LemonadeIcons.CircleX,
+                        error = true,
                     )
                 }
             }
@@ -146,68 +170,13 @@ internal fun ChipDisplay() {
             ) {
                 LemonadeUi.Chip(label = "Disabled", selected = false, leadingIcon = null, enabled = false)
                 LemonadeUi.Chip(label = "Disabled", selected = true, leadingIcon = null, enabled = false)
-            }
-        }
-
-        // Error
-        ChipSection(title = "Error") {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-                ) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                    ) {
-                        LemonadeUi.Chip(
-                            label = "Error",
-                            selected = false,
-                            leadingIcon = null,
-                            error = true,
-                        )
-                        LemonadeUi.Text(
-                            text = "Error",
-                            textStyle = LemonadeTheme.typography.bodySmallRegular,
-                        )
-                    }
-
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
-                    ) {
-                        LemonadeUi.Chip(
-                            label = "Error",
-                            selected = false,
-                            leadingIcon = null,
-                            enabled = false,
-                            error = true,
-                        )
-                        LemonadeUi.Text(
-                            text = "Error Disabled",
-                            textStyle = LemonadeTheme.typography.bodySmallRegular,
-                        )
-                    }
-                }
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
-                ) {
-                    LemonadeUi.Chip(
-                        label = "With Icon",
-                        selected = false,
-                        leadingIcon = LemonadeIcons.CircleAlert,
-                        error = true,
-                    )
-                    LemonadeUi.Chip(
-                        label = "With Trailing",
-                        selected = false,
-                        leadingIcon = null,
-                        trailingIcon = LemonadeIcons.CircleX,
-                        error = true,
-                    )
-                }
+                LemonadeUi.Chip(
+                    label = "Disabled",
+                    selected = false,
+                    leadingIcon = null,
+                    enabled = false,
+                    error = true,
+                )
             }
         }
     }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ChipDisplay.kt
@@ -148,6 +148,68 @@ internal fun ChipDisplay() {
                 LemonadeUi.Chip(label = "Disabled", selected = true, leadingIcon = null, enabled = false)
             }
         }
+
+        // Error
+        ChipSection(title = "Error") {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                    ) {
+                        LemonadeUi.Chip(
+                            label = "Error",
+                            selected = false,
+                            leadingIcon = null,
+                            error = true,
+                        )
+                        LemonadeUi.Text(
+                            text = "Error",
+                            textStyle = LemonadeTheme.typography.bodySmallRegular,
+                        )
+                    }
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing200),
+                    ) {
+                        LemonadeUi.Chip(
+                            label = "Error",
+                            selected = false,
+                            leadingIcon = null,
+                            enabled = false,
+                            error = true,
+                        )
+                        LemonadeUi.Text(
+                            text = "Error Disabled",
+                            textStyle = LemonadeTheme.typography.bodySmallRegular,
+                        )
+                    }
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing300),
+                ) {
+                    LemonadeUi.Chip(
+                        label = "With Icon",
+                        selected = false,
+                        leadingIcon = LemonadeIcons.CircleAlert,
+                        error = true,
+                    )
+                    LemonadeUi.Chip(
+                        label = "With Trailing",
+                        selected = false,
+                        leadingIcon = null,
+                        trailingIcon = LemonadeIcons.CircleX,
+                        error = true,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -65,6 +65,8 @@ import com.teya.lemonade.core.LemonadeTextStyle
  * @param enabled: Optional - controls the enabled state of the chip.
  *  When `false`, interaction is disabled and it is visually styled
  *  as such. Defaults to true.
+ * @param error: Optional - set to `true` to display the chip in an error state with a
+ *  critical border and background. Cannot be combined with [selected]. Defaults to false.
  * @param onChipClicked: Optional - sets the callback for when
  *  the chip is clicked. If null the clickable interactions will be
  *  automatically disabled.
@@ -84,6 +86,7 @@ public fun LemonadeUi.Chip(
     trailingIcon: LemonadeIcons? = null,
     counter: Int? = null,
     enabled: Boolean = true,
+    error: Boolean = false,
     onChipClicked: (() -> Unit)? = null,
     onTrailingIconClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -92,6 +95,7 @@ public fun LemonadeUi.Chip(
         label = label,
         selected = selected,
         enabled = enabled,
+        error = error,
         counter = counter,
         leadingSlot = if (leadingPainter != null) {
             {
@@ -156,6 +160,8 @@ public fun LemonadeUi.Chip(
  * @param enabled: Optional - controls the enabled state of the chip.
  *  When `false`, interaction is disabled and it is visually styled
  *  as such. Defaults to true.
+ * @param error: Optional - set to `true` to display the chip in an error state with a
+ *  critical border and background. Cannot be combined with [selected]. Defaults to false.
  * @param onChipClicked: Optional - sets the callback for when
  *  the chip is clicked. If null the clickable interactions will be
  *  automatically disabled.
@@ -175,6 +181,7 @@ public fun LemonadeUi.Chip(
     trailingIcon: LemonadeIcons? = null,
     counter: Int? = null,
     enabled: Boolean = true,
+    error: Boolean = false,
     onChipClicked: (() -> Unit)? = null,
     onTrailingIconClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -183,12 +190,13 @@ public fun LemonadeUi.Chip(
         label = label,
         selected = selected,
         enabled = enabled,
+        error = error,
         counter = counter,
         leadingSlot = if (leadingIcon != null) {
             {
                 LemonadeUi.Icon(
                     icon = leadingIcon,
-                    tint = LocalChipContentColor.current.invoke(),
+                    tint = LocalChipLeadingIconColor.current.invoke(),
                     size = LemonadeAssetSize.Small,
                     contentDescription = null,
                 )
@@ -221,6 +229,7 @@ internal fun CoreChip(
     label: String,
     selected: Boolean,
     enabled: Boolean,
+    error: Boolean,
     counter: Int?,
     leadingSlot: (@Composable BoxScope.() -> Unit)?,
     trailingSlot: (@Composable BoxScope.() -> Unit)?,
@@ -230,12 +239,14 @@ internal fun CoreChip(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     val platformDimensions = defaultChipDimensions()
-    val props = getChipProps(selected = selected)
+    val props = getChipProps(selected = selected, error = error)
 
     val isHover by interactionSource.collectIsHoveredAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
 
     val animatedContentColor by animateColorAsState(targetValue = props.contentColor)
+    val animatedLeadingIconColor by animateColorAsState(targetValue = props.leadingIconColor)
+    val animatedBorderColor by animateColorAsState(targetValue = props.borderColor)
     val animatedBackgroundColor by animateColorAsState(
         targetValue = if (isHover || isPressed) {
             props.pressedBackgroundColor
@@ -243,7 +254,10 @@ internal fun CoreChip(
             props.backgroundColor
         },
     )
-    CompositionLocalProvider(LocalChipContentColor provides { animatedContentColor }) {
+    CompositionLocalProvider(
+        LocalChipContentColor provides { animatedContentColor },
+        LocalChipLeadingIconColor provides { animatedLeadingIconColor },
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
@@ -266,6 +280,10 @@ internal fun CoreChip(
                     indication = LocalEffects.current.interactionIndication,
                 ).background(
                     color = animatedBackgroundColor,
+                    shape = LocalShapes.current.radiusFull,
+                ).border(
+                    width = LocalBorderWidths.current.base.border40,
+                    color = animatedBorderColor,
                     shape = LocalShapes.current.radiusFull,
                 ).padding(all = LocalSpaces.current.spacing200),
         ) {
@@ -338,6 +356,11 @@ private val LocalChipContentColor: ProvidableCompositionLocal<@Composable () -> 
         { LocalColors.current.content.contentPrimary }
     }
 
+private val LocalChipLeadingIconColor: ProvidableCompositionLocal<@Composable () -> Color> =
+    staticCompositionLocalOf {
+        { LocalColors.current.content.contentPrimary }
+    }
+
 internal data class ChipPlatformDimensions(
     val labelFontStyle: LemonadeTextStyle,
     val counterFontStyle: LemonadeTextStyle,
@@ -361,28 +384,44 @@ private data class ChipProps(
     val backgroundColor: Color,
     val pressedBackgroundColor: Color,
     val contentColor: Color,
+    val leadingIconColor: Color,
+    val borderColor: Color,
 )
 
 @Composable
-private fun getChipProps(selected: Boolean): ChipProps =
-    if (selected) {
+private fun getChipProps(selected: Boolean, error: Boolean): ChipProps {
+    return if (error) {
+        ChipProps(
+            backgroundColor = LocalColors.current.background.bgCriticalSubtle,
+            pressedBackgroundColor = LocalColors.current.interaction.bgCriticalSubtleInteractive,
+            contentColor = LocalColors.current.content.contentPrimary,
+            leadingIconColor = LocalColors.current.content.contentCritical,
+            borderColor = LocalColors.current.border.borderCritical,
+        )
+    } else if (selected) {
         ChipProps(
             backgroundColor = LocalColors.current.background.bgBrandHigh,
             pressedBackgroundColor = LocalColors.current.interaction.bgBrandHighInteractive,
             contentColor = LocalColors.current.content.contentBrandInverse,
+            leadingIconColor = LocalColors.current.content.contentBrandInverse,
+            borderColor = Color.Transparent,
         )
     } else {
         ChipProps(
             backgroundColor = LocalColors.current.background.bgElevated,
             pressedBackgroundColor = LocalColors.current.interaction.bgSubtleInteractive,
             contentColor = LocalColors.current.content.contentPrimary,
+            leadingIconColor = LocalColors.current.content.contentPrimary,
+            borderColor = Color.Transparent,
         )
     }
+}
 
 private data class ChipPreviewData(
     val counter: Int?,
     val isSelected: Boolean,
     val enabled: Boolean,
+    val error: Boolean,
     val leadingIcon: LemonadeIcons?,
     val trailingIcon: LemonadeIcons?,
 )
@@ -401,6 +440,7 @@ private class ChipPreviewProvider : PreviewParameterProvider<ChipPreviewData> {
                                     ChipPreviewData(
                                         isSelected = selected,
                                         enabled = enabled,
+                                        error = false,
                                         counter = 5.takeIf { withCounter },
                                         leadingIcon = LemonadeIcons.Airplane.takeIf { withLeadingIcon },
                                         trailingIcon = LemonadeIcons.Airplane.takeIf { withTrailingIcon },
@@ -424,8 +464,41 @@ private fun ChipPreview(
         label = "Label",
         selected = previewData.isSelected,
         enabled = previewData.enabled,
+        error = previewData.error,
         counter = previewData.counter,
         leadingIcon = previewData.leadingIcon,
         trailingIcon = previewData.trailingIcon,
+    )
+}
+
+@LemonadePreview
+@Composable
+private fun ChipErrorPreview() {
+    LemonadeUi.Chip(
+        label = "Error",
+        selected = false,
+        error = true,
+    )
+}
+
+@LemonadePreview
+@Composable
+private fun ChipErrorWithIconPreview() {
+    LemonadeUi.Chip(
+        label = "Error",
+        selected = false,
+        error = true,
+        leadingIcon = LemonadeIcons.CircleAlert,
+    )
+}
+
+@LemonadePreview
+@Composable
+private fun ChipErrorDisabledPreview() {
+    LemonadeUi.Chip(
+        label = "Error",
+        selected = false,
+        enabled = false,
+        error = true,
     )
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -309,12 +309,12 @@ internal fun CoreChip(
                     modifier = Modifier
                         .padding(horizontal = LocalSpaces.current.spacing100)
                         .defaultMinSize(
-                            minWidth = 18.dp,
-                            minHeight = 16.dp,
+                            minWidth = LocalSizes.current.size450,
+                            minHeight = LocalSizes.current.size400,
                         ).background(
                             color = LocalColors.current.background.bgBrand,
                             shape = LocalShapes.current.radiusFull,
-                        ).padding(horizontal = LocalSpaces.current.spacing100),
+                        ).padding(horizontal = LocalSpaces.current.spacing50),
                 ) {
                     LemonadeUi.Text(
                         text = counter.toString(),
@@ -332,7 +332,6 @@ internal fun CoreChip(
                     contentAlignment = Alignment.Center,
                     content = trailingSlot,
                     modifier = Modifier
-                        .padding(start = LocalSpaces.current.spacing50)
                         .then(
                             other = if (onTrailingIconClick != null) {
                                 Modifier.clickable(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -477,6 +477,7 @@ private fun ChipErrorPreview() {
     LemonadeUi.Chip(
         label = "Error",
         selected = false,
+        leadingIcon = null,
         error = true,
     )
 }
@@ -487,8 +488,8 @@ private fun ChipErrorWithIconPreview() {
     LemonadeUi.Chip(
         label = "Error",
         selected = false,
-        error = true,
         leadingIcon = LemonadeIcons.CircleAlert,
+        error = true,
     )
 }
 
@@ -498,6 +499,7 @@ private fun ChipErrorDisabledPreview() {
     LemonadeUi.Chip(
         label = "Error",
         selected = false,
+        leadingIcon = null,
         enabled = false,
         error = true,
     )

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -66,7 +66,7 @@ import com.teya.lemonade.core.LemonadeTextStyle
  *  When `false`, interaction is disabled and it is visually styled
  *  as such. Defaults to true.
  * @param error: Optional - set to `true` to display the chip in an error state with a
- *  critical border and background. Cannot be combined with [selected]. Defaults to false.
+ *  critical border and background. Takes precedence over [selected] styling when both are true. Defaults to false.
  * @param onChipClicked: Optional - sets the callback for when
  *  the chip is clicked. If null the clickable interactions will be
  *  automatically disabled.
@@ -161,7 +161,7 @@ public fun LemonadeUi.Chip(
  *  When `false`, interaction is disabled and it is visually styled
  *  as such. Defaults to true.
  * @param error: Optional - set to `true` to display the chip in an error state with a
- *  critical border and background. Cannot be combined with [selected]. Defaults to false.
+ *  critical border and background. Takes precedence over [selected] styling when both are true. Defaults to false.
  * @param onChipClicked: Optional - sets the callback for when
  *  the chip is clicked. If null the clickable interactions will be
  *  automatically disabled.

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -388,8 +388,11 @@ private data class ChipProps(
 )
 
 @Composable
-private fun getChipProps(selected: Boolean, error: Boolean): ChipProps {
-    return if (error) {
+private fun getChipProps(
+    selected: Boolean,
+    error: Boolean,
+): ChipProps =
+    if (error) {
         ChipProps(
             backgroundColor = LocalColors.current.background.bgCriticalSubtle,
             pressedBackgroundColor = LocalColors.current.interaction.bgCriticalSubtleInteractive,
@@ -414,7 +417,6 @@ private fun getChipProps(selected: Boolean, error: Boolean): ChipProps {
             borderColor = Color.Transparent,
         )
     }
-}
 
 private data class ChipPreviewData(
     val counter: Int?,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Chip.kt
@@ -392,24 +392,22 @@ private fun getChipProps(
     selected: Boolean,
     error: Boolean,
 ): ChipProps =
-    if (error) {
-        ChipProps(
+    when {
+        error -> ChipProps(
             backgroundColor = LocalColors.current.background.bgCriticalSubtle,
             pressedBackgroundColor = LocalColors.current.interaction.bgCriticalSubtleInteractive,
             contentColor = LocalColors.current.content.contentPrimary,
             leadingIconColor = LocalColors.current.content.contentCritical,
             borderColor = LocalColors.current.border.borderCritical,
         )
-    } else if (selected) {
-        ChipProps(
+        selected -> ChipProps(
             backgroundColor = LocalColors.current.background.bgBrandHigh,
             pressedBackgroundColor = LocalColors.current.interaction.bgBrandHighInteractive,
             contentColor = LocalColors.current.content.contentBrandInverse,
             leadingIconColor = LocalColors.current.content.contentBrandInverse,
             borderColor = Color.Transparent,
         )
-    } else {
-        ChipProps(
+        else -> ChipProps(
             backgroundColor = LocalColors.current.background.bgElevated,
             pressedBackgroundColor = LocalColors.current.interaction.bgSubtleInteractive,
             contentColor = LocalColors.current.content.contentPrimary,

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -1,9 +1,9 @@
-import SwiftUI
 import Lemonade
+import SwiftUI
 
 struct ChipDisplayView: View {
     @State private var selectedChips: Set<String> = ["Option 1"]
-    
+
     var body: some View {
         NavigationStack {
             ScrollView(.vertical) {
@@ -14,6 +14,7 @@ struct ChipDisplayView: View {
                     customLeadingSection
                     interactiveSection
                     disabledSection
+                    errorSection
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding()
@@ -21,7 +22,7 @@ struct ChipDisplayView: View {
             }
         }
     }
-    
+
     private var statesSection: some View {
         sectionView(title: "States") {
             HStack(spacing: 12) {
@@ -30,7 +31,7 @@ struct ChipDisplayView: View {
                     LemonadeUi.Text("Unselected", font: .bodyXSmallRegular)
                         .foregroundStyle(.content.contentSecondary)
                 }
-                
+
                 VStack(spacing: 8) {
                     LemonadeUi.Chip(label: "Selected", selected: true)
                     LemonadeUi.Text("Selected", font: .bodyXSmallRegular)
@@ -39,32 +40,52 @@ struct ChipDisplayView: View {
             }
         }
     }
-    
+
     private var counterSection: some View {
         sectionView(title: "With Counter") {
             HStack(spacing: 12) {
                 LemonadeUi.Chip(label: "Messages", selected: false, counter: 5)
-                LemonadeUi.Chip(label: "Notifications", selected: true, counter: 12)
+                LemonadeUi.Chip(
+                    label: "Notifications",
+                    selected: true,
+                    counter: 12
+                )
             }
         }
     }
-    
+
     private var iconsSection: some View {
         sectionView(title: "With Icons") {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 12) {
-                    LemonadeUi.Chip(label: "Favorites", selected: false, leadingIcon: .heart)
-                    LemonadeUi.Chip(label: "Favorites", selected: true, leadingIcon: .heart)
+                    LemonadeUi.Chip(
+                        label: "Favorites",
+                        selected: false,
+                        leadingIcon: .heart
+                    )
+                    LemonadeUi.Chip(
+                        label: "Favorites",
+                        selected: true,
+                        leadingIcon: .heart
+                    )
                 }
-                
+
                 HStack(spacing: 12) {
-                    LemonadeUi.Chip(label: "Remove", selected: false, trailingIcon: .circleX)
-                    LemonadeUi.Chip(label: "Remove", selected: true, trailingIcon: .circleX)
+                    LemonadeUi.Chip(
+                        label: "Remove",
+                        selected: false,
+                        trailingIcon: .circleX
+                    )
+                    LemonadeUi.Chip(
+                        label: "Remove",
+                        selected: true,
+                        trailingIcon: .circleX
+                    )
                 }
             }
         }
     }
-    
+
     private var customLeadingSection: some View {
         sectionView(title: "With Custom Leading") {
             VStack(alignment: .leading, spacing: 12) {
@@ -72,32 +93,37 @@ struct ChipDisplayView: View {
                     LemonadeUi.Chip(label: "GBP", selected: false) {
                         LemonadeUi.CountryFlag(flag: .gBUnitedKingdom)
                     } trailingContent: {
-                        LemonadeUi.Icon(icon: .chevronDown, contentDescription: nil)
+                        LemonadeUi.Icon(
+                            icon: .chevronDown,
+                            contentDescription: nil
+                        )
                     }
                 }
             }
         }
     }
-    
+
     private var interactiveSection: some View {
         sectionView(title: "Interactive Selection") {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Tap to select/deselect:")
                     .font(.subheadline)
-                
+
                 HStack(spacing: 8) {
                     chipButton(option: "Option 1")
                     chipButton(option: "Option 2")
                     chipButton(option: "Option 3")
                 }
-                
-                Text("Selected: \(selectedChips.sorted().joined(separator: ", "))")
-                    .font(.caption)
-                    .foregroundStyle(.content.contentSecondary)
+
+                Text(
+                    "Selected: \(selectedChips.sorted().joined(separator: ", "))"
+                )
+                .font(.caption)
+                .foregroundStyle(.content.contentSecondary)
             }
         }
     }
-    
+
     private func chipButton(option: String) -> some View {
         LemonadeUi.Chip(
             label: option,
@@ -111,21 +137,82 @@ struct ChipDisplayView: View {
             }
         )
     }
-    
+
     private var disabledSection: some View {
         sectionView(title: "Disabled") {
             HStack(spacing: 12) {
-                LemonadeUi.Chip(label: "Disabled", selected: false, enabled: false)
-                LemonadeUi.Chip(label: "Disabled", selected: true, enabled: false)
+                LemonadeUi.Chip(
+                    label: "Disabled",
+                    selected: false,
+                    enabled: false
+                )
+                LemonadeUi.Chip(
+                    label: "Disabled",
+                    selected: true,
+                    enabled: false
+                )
             }
         }
     }
-    
-    private func sectionView<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+
+    private var errorSection: some View {
+        sectionView(title: "Error") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 12) {
+                    VStack(spacing: 8) {
+                        LemonadeUi.Chip(
+                            label: "Error",
+                            selected: false,
+                            error: true,
+                            onChipClicked: {}
+                        )
+                        LemonadeUi.Text("Error", font: .bodyXSmallRegular)
+                            .foregroundStyle(.content.contentSecondary)
+                    }
+                    VStack(spacing: 8) {
+                        LemonadeUi.Chip(
+                            label: "Error",
+                            selected: false,
+                            enabled: false,
+                            error: true,
+                            onChipClicked: {}
+                        )
+                        LemonadeUi.Text(
+                            "Error Disabled",
+                            font: .bodyXSmallRegular,
+                        )
+                        .foregroundStyle(.content.contentSecondary)
+                    }
+                }
+
+                HStack(spacing: 12) {
+                    LemonadeUi.Chip(
+                        label: "With Icon",
+                        selected: false,
+                        leadingIcon: .circleAlert,
+                        error: true,
+                        onChipClicked: {}
+                    )
+                    LemonadeUi.Chip(
+                        label: "With Trailing",
+                        selected: false,
+                        trailingIcon: .circleX,
+                        error: true,
+                        onChipClicked: {}
+                    )
+                }
+            }
+        }
+    }
+
+    private func sectionView<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             LemonadeUi.Text(title, font: .headingXSmall)
                 .foregroundStyle(.content.contentSecondary)
-            
+
             content()
         }
     }

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -14,6 +14,7 @@ struct ChipDisplayView: View {
                     customLeadingSection
                     interactiveSection
                     disabledSection
+                    errorSection
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding()
@@ -34,12 +35,6 @@ struct ChipDisplayView: View {
                 VStack(spacing: 8) {
                     LemonadeUi.Chip(label: "Selected", selected: true)
                     LemonadeUi.Text("Selected", font: .bodyXSmallRegular)
-                        .foregroundStyle(.content.contentSecondary)
-                }
-
-                VStack(spacing: 8) {
-                    LemonadeUi.Chip(label: "Error", selected: false, error: true)
-                    LemonadeUi.Text("Error", font: .bodyXSmallRegular)
                         .foregroundStyle(.content.contentSecondary)
                 }
             }
@@ -73,12 +68,6 @@ struct ChipDisplayView: View {
                         selected: true,
                         leadingIcon: .heart
                     )
-                    LemonadeUi.Chip(
-                        label: "Favorites",
-                        selected: false,
-                        leadingIcon: .heart,
-                        error: true
-                    )
                 }
 
                 HStack(spacing: 12) {
@@ -91,12 +80,6 @@ struct ChipDisplayView: View {
                         label: "Remove",
                         selected: true,
                         trailingIcon: .circleX
-                    )
-                    LemonadeUi.Chip(
-                        label: "Remove",
-                        selected: false,
-                        trailingIcon: .circleX,
-                        error: true
                     )
                 }
             }
@@ -168,12 +151,56 @@ struct ChipDisplayView: View {
                     selected: true,
                     enabled: false
                 )
-                LemonadeUi.Chip(
-                    label: "Disabled",
-                    selected: false,
-                    enabled: false,
-                    error: true
-                )
+            }
+        }
+    }
+
+    private var errorSection: some View {
+        sectionView(title: "Error") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 12) {
+                    VStack(spacing: 8) {
+                        LemonadeUi.Chip(
+                            label: "Error",
+                            selected: false,
+                            error: true,
+                            onChipClicked: {}
+                        )
+                        LemonadeUi.Text("Error", font: .bodyXSmallRegular)
+                            .foregroundStyle(.content.contentSecondary)
+                    }
+                    VStack(spacing: 8) {
+                        LemonadeUi.Chip(
+                            label: "Error",
+                            selected: false,
+                            enabled: false,
+                            error: true,
+                            onChipClicked: {}
+                        )
+                        LemonadeUi.Text(
+                            "Error Disabled",
+                            font: .bodyXSmallRegular,
+                        )
+                        .foregroundStyle(.content.contentSecondary)
+                    }
+                }
+
+                HStack(spacing: 12) {
+                    LemonadeUi.Chip(
+                        label: "With Icon",
+                        selected: false,
+                        leadingIcon: .circleAlert,
+                        error: true,
+                        onChipClicked: {}
+                    )
+                    LemonadeUi.Chip(
+                        label: "With Trailing",
+                        selected: false,
+                        trailingIcon: .circleX,
+                        error: true,
+                        onChipClicked: {}
+                    )
+                }
             }
         }
     }

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -1,5 +1,5 @@
-import Lemonade
 import SwiftUI
+import Lemonade
 
 struct ChipDisplayView: View {
     @State private var selectedChips: Set<String> = ["Option 1"]
@@ -179,7 +179,7 @@ struct ChipDisplayView: View {
                         )
                         LemonadeUi.Text(
                             "Error Disabled",
-                            font: .bodyXSmallRegular,
+                            font: .bodyXSmallRegular
                         )
                         .foregroundStyle(.content.contentSecondary)
                     }

--- a/swiftui/SampleApp/ChipDisplayView.swift
+++ b/swiftui/SampleApp/ChipDisplayView.swift
@@ -14,7 +14,6 @@ struct ChipDisplayView: View {
                     customLeadingSection
                     interactiveSection
                     disabledSection
-                    errorSection
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding()
@@ -35,6 +34,12 @@ struct ChipDisplayView: View {
                 VStack(spacing: 8) {
                     LemonadeUi.Chip(label: "Selected", selected: true)
                     LemonadeUi.Text("Selected", font: .bodyXSmallRegular)
+                        .foregroundStyle(.content.contentSecondary)
+                }
+
+                VStack(spacing: 8) {
+                    LemonadeUi.Chip(label: "Error", selected: false, error: true)
+                    LemonadeUi.Text("Error", font: .bodyXSmallRegular)
                         .foregroundStyle(.content.contentSecondary)
                 }
             }
@@ -68,6 +73,12 @@ struct ChipDisplayView: View {
                         selected: true,
                         leadingIcon: .heart
                     )
+                    LemonadeUi.Chip(
+                        label: "Favorites",
+                        selected: false,
+                        leadingIcon: .heart,
+                        error: true
+                    )
                 }
 
                 HStack(spacing: 12) {
@@ -80,6 +91,12 @@ struct ChipDisplayView: View {
                         label: "Remove",
                         selected: true,
                         trailingIcon: .circleX
+                    )
+                    LemonadeUi.Chip(
+                        label: "Remove",
+                        selected: false,
+                        trailingIcon: .circleX,
+                        error: true
                     )
                 }
             }
@@ -151,56 +168,12 @@ struct ChipDisplayView: View {
                     selected: true,
                     enabled: false
                 )
-            }
-        }
-    }
-
-    private var errorSection: some View {
-        sectionView(title: "Error") {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(spacing: 12) {
-                    VStack(spacing: 8) {
-                        LemonadeUi.Chip(
-                            label: "Error",
-                            selected: false,
-                            error: true,
-                            onChipClicked: {}
-                        )
-                        LemonadeUi.Text("Error", font: .bodyXSmallRegular)
-                            .foregroundStyle(.content.contentSecondary)
-                    }
-                    VStack(spacing: 8) {
-                        LemonadeUi.Chip(
-                            label: "Error",
-                            selected: false,
-                            enabled: false,
-                            error: true,
-                            onChipClicked: {}
-                        )
-                        LemonadeUi.Text(
-                            "Error Disabled",
-                            font: .bodyXSmallRegular,
-                        )
-                        .foregroundStyle(.content.contentSecondary)
-                    }
-                }
-
-                HStack(spacing: 12) {
-                    LemonadeUi.Chip(
-                        label: "With Icon",
-                        selected: false,
-                        leadingIcon: .circleAlert,
-                        error: true,
-                        onChipClicked: {}
-                    )
-                    LemonadeUi.Chip(
-                        label: "With Trailing",
-                        selected: false,
-                        trailingIcon: .circleX,
-                        error: true,
-                        onChipClicked: {}
-                    )
-                }
+                LemonadeUi.Chip(
+                    label: "Disabled",
+                    selected: false,
+                    enabled: false,
+                    error: true
+                )
             }
         }
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -66,7 +66,9 @@ public extension LemonadeUi {
                         icon: icon,
                         contentDescription: nil,
                         size: .small,
-                        tint: selected
+                        tint: error
+                        ? LemonadeTheme.colors.content.contentPrimary
+                        : selected
                         ? LemonadeTheme.colors.content.contentBrandInverse
                         : LemonadeTheme.colors.content.contentPrimary
                     )
@@ -74,7 +76,7 @@ public extension LemonadeUi {
             }
         )
     }
-    
+
     /// A compact element used to display information with a custom leading image.
     ///
     /// ## Usage

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -33,6 +33,7 @@ public extension LemonadeUi {
         trailingIcon: LemonadeIcon? = nil,
         counter: Int? = nil,
         enabled: Bool = true,
+        error: Bool = false,
         onChipClicked: (() -> Void)? = nil,
         onTrailingIconClick: (() -> Void)? = nil
     ) -> some View {
@@ -41,6 +42,7 @@ public extension LemonadeUi {
             selected: selected,
             counter: counter,
             enabled: enabled,
+            error: error,
             onChipClicked: onChipClicked,
             onTrailingIconClick: onTrailingIconClick,
             leadingContent: {
@@ -49,7 +51,9 @@ public extension LemonadeUi {
                         icon: icon,
                         contentDescription: nil,
                         size: .medium,
-                        tint: selected
+                        tint: error
+                        ? LemonadeTheme.colors.content.contentCritical
+                        : selected
                         ? LemonadeTheme.colors.content.contentBrandInverse
                         : LemonadeTheme.colors.content.contentPrimary
                     )
@@ -99,6 +103,7 @@ public extension LemonadeUi {
         trailingIcon: LemonadeIcon? = nil,
         counter: Int? = nil,
         enabled: Bool = true,
+        error: Bool = false,
         onChipClicked: (() -> Void)? = nil,
         onTrailingIconClick: (() -> Void)? = nil
     ) -> some View {
@@ -107,6 +112,7 @@ public extension LemonadeUi {
             selected: selected,
             counter: counter,
             enabled: enabled,
+            error: error,
             onChipClicked: onChipClicked,
             onTrailingIconClick: onTrailingIconClick,
             leadingContent: {
@@ -168,6 +174,7 @@ public extension LemonadeUi {
         selected: Bool,
         counter: Int? = nil,
         enabled: Bool = true,
+        error: Bool = false,
         onChipClicked: (() -> Void)? = nil,
         onTrailingIconClick: (() -> Void)? = nil,
         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
@@ -178,6 +185,7 @@ public extension LemonadeUi {
             selected: selected,
             counter: counter,
             enabled: enabled,
+            error: error,
             onChipClicked: onChipClicked,
             onTrailingIconClick: onTrailingIconClick,
             leadingContent: leadingContent,
@@ -193,17 +201,23 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     let selected: Bool
     let counter: Int?
     let enabled: Bool
+    let error: Bool
     let onChipClicked: (() -> Void)?
     let onTrailingIconClick: (() -> Void)?
     @ViewBuilder let leadingContent: () -> LeadingContent
     @ViewBuilder let trailingContent: () -> TrailingContent
-    
+
     @State private var isPressed = false
-    
+
     private let minWidth: CGFloat = .size.size1600
     private let minHeight: CGFloat = .size.size800
-    
+
     private var backgroundColor: Color {
+        if error {
+            return isPressed
+                ? LemonadeTheme.colors.interaction.bgCriticalSubtleInteractive
+                : LemonadeTheme.colors.background.bgCriticalSubtle
+        }
         if isPressed {
             return selected
             ? LemonadeTheme.colors.interaction.bgBrandHighInteractive
@@ -213,27 +227,24 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         ? LemonadeTheme.colors.background.bgBrandHigh
         : LemonadeTheme.colors.background.bgElevated
     }
-    
+
     private var contentColor: Color {
         selected
         ? LemonadeTheme.colors.content.contentBrandInverse
         : LemonadeTheme.colors.content.contentPrimary
     }
-    
+
     private var chipContent: some View {
         HStack(spacing: .space.spacing100) {
-            // Leading slot
             leadingContent()
-            
-            // Label
+
             LemonadeUi.Text(
                 label,
                 textStyle: LemonadeTypography.shared.bodySmallMedium,
                 color: contentColor
             )
             .padding(.horizontal, LemonadeTheme.spaces.spacing100)
-            
-            // Counter
+
             if let counter = counter {
                 LemonadeUi.Text("\(counter)", font: .bodyXSmallSemiBold)
                     .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
@@ -243,8 +254,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                     .clipShape(Capsule())
                     .padding(.trailing, .space.spacing100)
             }
-            
-            // Trailing slot
+
             if let onTrailingIconClick = onTrailingIconClick {
                 SwiftUI.Button(action: onTrailingIconClick) {
                     trailingContent()
@@ -260,10 +270,19 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         .frame(minWidth: minWidth, minHeight: minHeight)
         .background(backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: .radius.radiusFull))
+        .overlay {
+            if error {
+                RoundedRectangle(cornerRadius: .radius.radiusFull)
+                    .stroke(
+                        LemonadeTheme.colors.border.borderCritical,
+                        lineWidth: LemonadeTheme.borderWidth.base.border40
+                    )
+                    .transition(.opacity)
+            }
+        }
         .opacity(enabled ? 1.0 : .opacity.opacityDisabled)
         .contentShape(Capsule())
-        .animation(.easeInOut(duration: 0.15), value: selected)
-        .animation(.easeInOut(duration: 0.15), value: isPressed)
+        .animation(.easeInOut(duration: 0.15), value: backgroundColor)
     }
     
     var body: some View {
@@ -323,6 +342,12 @@ struct LemonadeChip_Previews: PreviewProvider {
             HStack(spacing: 8) {
                 LemonadeUi.Chip(label: "Disabled", selected: false, enabled: false)
                 LemonadeUi.Chip(label: "Disabled", selected: true, enabled: false)
+            }
+
+            // Error
+            HStack(spacing: 8) {
+                LemonadeUi.Chip(label: "Error", selected: false, error: true)
+                LemonadeUi.Chip(label: "Error Disabled", selected: false, enabled: false, error: true)
             }
         }
         .padding()

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -235,7 +235,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     }
 
     private var chipContent: some View {
-        HStack(spacing: .space.spacing100) {
+        HStack(spacing: .space.spacing0) {
             leadingContent()
 
             LemonadeUi.Text(
@@ -252,7 +252,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                     .frame(minWidth: .size.size450, minHeight: .size.size400)
                     .background(.bg.bgBrand)
                     .clipShape(Capsule())
-                    .padding(.trailing, .space.spacing100)
+                    .padding(.trailing, .space.spacing50)
             }
 
             if let onTrailingIconClick = onTrailingIconClick {
@@ -261,7 +261,6 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                 }
                 .buttonStyle(PlainButtonStyle())
                 .disabled(!enabled)
-                .padding(.trailing, .space.spacing100)
             } else {
                 trailingContent()
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -22,6 +22,7 @@ public extension LemonadeUi {
     ///   - trailingIcon: Optional LemonadeIcon to be displayed in the trailing position
     ///   - counter: Optional Int number to be displayed in the chip
     ///   - enabled: Controls the enabled state of the chip. Defaults to true
+    ///   - error: Set to true to display the chip in an error state (critical border and background). When true, takes precedence over `selected` styling. Defaults to false
     ///   - onChipClicked: Optional callback for when the chip is clicked
     ///   - onTrailingIconClick: Optional callback when the trailing icon is clicked
     /// - Returns: A styled Chip view
@@ -92,6 +93,7 @@ public extension LemonadeUi {
     ///   - trailingIcon: Optional LemonadeIcon to be displayed in the trailing position
     ///   - counter: Optional Int number to be displayed in the chip
     ///   - enabled: Controls the enabled state of the chip. Defaults to true
+    ///   - error: Set to true to display the chip in an error state (critical border and background). When true, takes precedence over `selected` styling. Defaults to false
     ///   - onChipClicked: Optional callback for when the chip is clicked
     ///   - onTrailingIconClick: Optional callback when the trailing icon is clicked
     /// - Returns: A styled Chip view
@@ -163,6 +165,7 @@ public extension LemonadeUi {
     ///   - selected: Set to true if the chip is in the selected state
     ///   - counter: Optional Int number to be displayed in the chip
     ///   - enabled: Controls the enabled state of the chip. Defaults to true
+    ///   - error: Set to true to display the chip in an error state (critical border and background). When true, takes precedence over `selected` styling. Defaults to false
     ///   - onChipClicked: Optional callback for when the chip is clicked
     ///   - onTrailingIconClick: Optional callback when the trailing icon is clicked
     ///   - leadingContent: Custom leading content
@@ -229,7 +232,9 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
     }
 
     private var contentColor: Color {
-        selected
+        error
+        ? LemonadeTheme.colors.content.contentPrimary
+        : selected
         ? LemonadeTheme.colors.content.contentBrandInverse
         : LemonadeTheme.colors.content.contentPrimary
     }


### PR DESCRIPTION
## Summary
- Adds `error: Bool/Boolean` parameter to the SwiftUI and KMP `Chip` components
- Error state renders a critical red border (`borderCritical`, 1.5px) and subtle red background (`bgCriticalSubtle`), with `contentCritical` tint on the leading icon
- Pressed and disabled variants of the error state are also supported
- Sample app display screens updated with error state examples

## Screenshot
<img width="393" alt="IMG_2175" src="https://github.com/user-attachments/assets/d5548597-4562-415e-ac17-c211d6bda478" />

## Test plan
- [ ] SwiftUI: error chip renders with red border and background
- [ ] SwiftUI: error + disabled chip renders at reduced opacity
- [ ] SwiftUI: error chip with leading icon renders icon in critical red
- [ ] KMP: error chip renders with red border and background
- [ ] KMP: error + disabled chip renders at reduced opacity
- [ ] KMP: error chip with leading icon renders icon in critical red
- [ ] Existing selected/unselected/disabled states are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)