### PR TITLE
fix(ListItem): vertically center trailing slot + chevron (Android + iOS)

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeBadgeSize
@@ -74,6 +75,47 @@ internal fun ActionListItemDisplay() {
                         contentDescription = null,
                         size = LemonadeAssetSize.Medium,
                     )
+                },
+            )
+        }
+
+        // ActionListItem - Trailing Alignment
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "ActionListItem - Trailing Alignment"),
+        ) {
+            LemonadeUi.ActionListItem(
+                label = "Top aligned",
+                supportText = "trailingVerticalAlignment: Top\nSecond line",
+                showNavigationIndicator = true,
+                showDivider = true,
+                trailingVerticalAlignment = Alignment.Top,
+                onItemClicked = {},
+                trailingSlot = {
+                    LemonadeUi.Tag(label = "Top", voice = TagVoice.Info)
+                },
+            )
+
+            LemonadeUi.ActionListItem(
+                label = "Center aligned",
+                supportText = "trailingVerticalAlignment: CenterVertically\nSecond line",
+                showNavigationIndicator = true,
+                showDivider = true,
+                trailingVerticalAlignment = Alignment.CenterVertically,
+                onItemClicked = {},
+                trailingSlot = {
+                    LemonadeUi.Tag(label = "Center", voice = TagVoice.Positive)
+                },
+            )
+
+            LemonadeUi.ActionListItem(
+                label = "Bottom aligned",
+                supportText = "trailingVerticalAlignment: Bottom\nSecond line",
+                showNavigationIndicator = true,
+                showDivider = false,
+                trailingVerticalAlignment = Alignment.Bottom,
+                onItemClicked = {},
+                trailingSlot = {
+                    LemonadeUi.Tag(label = "Bottom", voice = TagVoice.Warning)
                 },
             )
         }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -123,6 +123,7 @@ public fun LemonadeUi.ResourceListItem(
         modifier = modifier,
         showDivider = showDivider,
         interactionSource = interactionSource,
+        trailingVerticalAlignment = Alignment.Top,
     )
 }
 
@@ -156,6 +157,8 @@ public fun LemonadeUi.ResourceListItem(
  * @param role - [Role] interaction semantics.
  * @param interactionSource - [MutableInteractionSource] to be had within the component.
  * @param showDivider - [Boolean] flag to show a divider below the list item.
+ * @param trailingVerticalAlignment - Vertical alignment of the trailing slot and navigation
+ *  indicator against the label/supportText column. Defaults to [Alignment.CenterVertically].
  */
 @Composable
 public fun LemonadeUi.ActionListItem(
@@ -172,6 +175,7 @@ public fun LemonadeUi.ActionListItem(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     showNavigationIndicator: Boolean = false,
     showDivider: Boolean = false,
+    trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
     LemonadeUi.ListItem(
         label = label,
@@ -203,6 +207,7 @@ public fun LemonadeUi.ActionListItem(
         modifier = modifier,
         showDivider = showDivider,
         interactionSource = interactionSource,
+        trailingVerticalAlignment = trailingVerticalAlignment,
     )
 }
 
@@ -224,6 +229,8 @@ public fun LemonadeUi.ActionListItem(
  * @param showDivider - Flag to show a divider below the list item.
  * @param interactionSource - [MutableInteractionSource] for interaction events.
  * @param slotContent - Optional slot content below the label and support text.
+ * @param trailingVerticalAlignment - Vertical alignment of the trailing slot and navigation
+ *  indicator against the label/supportText column. Defaults to [Alignment.CenterVertically].
  */
 @Composable
 public fun LemonadeUi.ListItem(
@@ -241,6 +248,7 @@ public fun LemonadeUi.ListItem(
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     slotContent: (@Composable ColumnScope.() -> Unit)? = null,
+    trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
     if (isLoading) {
         ListItemSkeleton(
@@ -259,6 +267,7 @@ public fun LemonadeUi.ListItem(
             modifier = modifier,
             showDivider = showDivider,
             interactionSource = interactionSource,
+            trailingVerticalAlignment = trailingVerticalAlignment,
             contentSlot = {
                 LemonadeUi.Text(
                     text = label,
@@ -298,6 +307,8 @@ public fun LemonadeUi.ListItem(
  * @param modifier - [Modifier] to be applied to the base container of the component.
  * @param showDivider - Flag to show a divider below the list item.
  * @param interactionSource - [MutableInteractionSource] for interaction events.
+ * @param trailingVerticalAlignment - Vertical alignment of the trailing slot and navigation
+ *  indicator against the content slot. Defaults to [Alignment.CenterVertically].
  */
 @Composable
 public fun LemonadeUi.ListItem(
@@ -312,6 +323,7 @@ public fun LemonadeUi.ListItem(
     showDivider: Boolean = false,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
+    trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
     CoreListItem(
         contentSlot = contentSlot,
@@ -325,6 +337,7 @@ public fun LemonadeUi.ListItem(
         modifier = modifier,
         showDivider = showDivider,
         interactionSource = interactionSource,
+        trailingVerticalAlignment = trailingVerticalAlignment,
     )
 }
 
@@ -341,6 +354,7 @@ private fun CoreListItem(
     modifier: Modifier = Modifier,
     showDivider: Boolean,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
     val isPressed by interactionSource.collectIsPressedAsState()
     val isHovering by interactionSource.collectIsHoveredAsState()
@@ -398,7 +412,7 @@ private fun CoreListItem(
 
             Row(
                 modifier = Modifier.weight(weight = 1f),
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = trailingVerticalAlignment,
             ) {
                 Column(
                     content = contentSlot,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -398,6 +398,7 @@ private fun CoreListItem(
 
             Row(
                 modifier = Modifier.weight(weight = 1f),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(
                     content = contentSlot,
@@ -426,11 +427,11 @@ private fun CoreListItem(
                             size = LemonadeAssetSize.Medium,
                             contentDescription = null,
                             modifier = Modifier
-                                .alpha(
-                                    alpha = if (enabled) {
-                                        0.5f
+                                .then(
+                                    other = if (!enabled) {
+                                        Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
                                     } else {
-                                        0.5f * LocalOpacities.current.state.opacityDisabled
+                                        Modifier
                                     },
                                 ).padding(start = LocalSpaces.current.spacing100),
                         )

--- a/swiftui/SampleApp/ListItemDisplayView.swift
+++ b/swiftui/SampleApp/ListItemDisplayView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Lemonade
+import SwiftUI
 
 private struct OutlinedOption: Identifiable {
     let id = UUID()
@@ -15,285 +15,698 @@ private struct TrailingPreset {
 private let trailingPresets: [TrailingPreset] = [
     TrailingPreset(label: "New", voice: .info),
     TrailingPreset(label: "Recommended", voice: .positive),
-    TrailingPreset(label: "Popular", voice: .neutral)
+    TrailingPreset(label: "Popular", voice: .neutral),
 ]
 
-struct ListItemDisplayView: View {
+struct ResourceListItemPreview: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: .space.spacing400) {
+            LemonadeUi.Text("ResourceListItem", font: .headingXSmall)
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(title: "ResourceListItem")
+            ) {
+                LemonadeUi.ResourceListItem(
+                    label: "Credit •••• 8931",
+                    value: "$1,234.56",
+                    supportText: "Today 12:54 • Onion Garden",
+                    showDivider: true,
+                    onItemClicked: {},
+                    addonSlot: {
+                        LemonadeUi.Tag(
+                            label: "Approved",
+                            icon: .circleCheck,
+                            voice: .positive
+                        )
+                    },
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            shape: .rounded,
+                            content: {
+                                LemonadeUi.BrandLogo(
+                                    logo: .mastercard,
+                                    size: .medium
+                                )
+                            }
+                        )
+                    }
+                )
+                
+                LemonadeUi.ResourceListItem(
+                    label: "14 Apr sales",
+                    value: "$5,000.00",
+                    supportText: "Paid on 22 Apr • Onion Garden",
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            icon: .coins,
+                            contentDescription: nil,
+                            voice: .positive,
+                            size: .large,
+                            shape: .rounded
+                        )
+                    }
+                )
+            }
+            
+            // MARK: - ResourceListItem with Addon
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ResourceListItem with Addon"
+                )
+            ) {
+                LemonadeUi.ResourceListItem(
+                    label: "Last Transaction",
+                    value: "-$50.00",
+                    supportText: "Yesterday",
+                    showDivider: false,
+                    addonSlot: {
+                        LemonadeUi.Tag(label: "Pending", voice: .warning)
+                    },
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            icon: .arrowUpRight,
+                            contentDescription: nil,
+                            voice: .critical,
+                            size: .large,
+                            shape: .rounded
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+struct ActionListItemPreview: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: .space.spacing400) {
+            LemonadeUi.Text("ActionListItem", font: .headingXSmall)
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(title: "ActionListItem")
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Settings",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .gear,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "Notifications",
+                    supportText: "Manage your notifications",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .bell,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "Privacy",
+                    showNavigationIndicator: true,
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .padlock,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    }
+                )
+            }
+            
+            // MARK: - ActionListItem - Trailing Alignment
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ActionListItem - Trailing Alignment"
+                )
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Top aligned",
+                    supportText: "trailingAlignment: .top\nSecond line",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    trailingAlignment: .top,
+                    onItemClicked: {},
+                    trailingSlot: {
+                        LemonadeUi.Tag(label: "Top", voice: .info)
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "Center aligned",
+                    supportText: "trailingAlignment: .center\nSecond line",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    trailingAlignment: .center,
+                    onItemClicked: {},
+                    trailingSlot: {
+                        LemonadeUi.Tag(label: "Center", voice: .positive)
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "Bottom aligned",
+                    supportText: "trailingAlignment: .bottom\nSecond line",
+                    showNavigationIndicator: true,
+                    showDivider: false,
+                    trailingAlignment: .bottom,
+                    onItemClicked: {},
+                    trailingSlot: {
+                        LemonadeUi.Tag(label: "Bottom", voice: .warning)
+                    }
+                )
+            }
+            
+            // MARK: - ActionListItem with Trailing
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ActionListItem with Trailing"
+                )
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Updates Available",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .download,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    },
+                    trailingSlot: {
+                        LemonadeUi.Badge(text: "3", size: .small)
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "New Features",
+                    showNavigationIndicator: true,
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .sparkles,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    },
+                    trailingSlot: {
+                        LemonadeUi.Tag(label: "New", voice: .positive)
+                    }
+                )
+            }
+            
+            // MARK: - ActionListItem - Design reference (multi-line support text)
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ActionListItem - Figma reference"
+                )
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Account ***4236",
+                    supportText: "PT50 0002 0123 1234…\n1 store linked",
+                    showNavigationIndicator: true,
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            icon: .bank,
+                            contentDescription: nil,
+                            voice: .neutral,
+                            size: .large,
+                            shape: .rounded
+                        )
+                    },
+                    trailingSlot: {
+                        LemonadeUi.Tag(
+                            label: "Settlements",
+                            voice: .positive
+                        )
+                    }
+                )
+            }
+            
+            // MARK: - ActionListItem - Critical Voice
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ActionListItem - Critical Voice"
+                )
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Delete Account",
+                    voice: .critical,
+                    showDivider: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .trash,
+                            contentDescription: nil,
+                            size: .medium,
+                            tint: .content.contentCritical
+                        )
+                    }
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "Log Out",
+                    supportText: "You will need to sign in again",
+                    voice: .critical,
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .logOut,
+                            contentDescription: nil,
+                            size: .medium,
+                            tint: .content.contentCritical
+                        )
+                    }
+                )
+            }
+            
+            // MARK: - Disabled States (Action)
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(title: "Disabled States")
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Disabled Action",
+                    enabled: false,
+                    showDivider: false,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .gear,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    }
+                )
+            }
+            
+            // MARK: - Loading State
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(title: "Loading State")
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "",
+                    isLoading: true,
+                    showDivider: true
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "",
+                    isLoading: true,
+                    showDivider: true
+                )
+                
+                LemonadeUi.ActionListItem(
+                    label: "",
+                    isLoading: true,
+                    showDivider: false
+                )
+            }
+        }
+    }
+}
+
+struct SelectListItemPreview: View {
     @State private var singleSelection = 0
     @State private var multipleSelections: Set<Int> = [0]
     @State private var toggleStates: [Bool] = [true, false, true]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: .space.spacing400) {
+            LemonadeUi.Text("SelectListItem", font: .headingXSmall)
+            // MARK: - SelectListItem - Single
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "SelectListItem - Single"
+                )
+            ) {
+                ForEach(0..<3, id: \.self) { index in
+                    LemonadeUi.SelectListItem(
+                        label: "Option \(index + 1)",
+                        type: .single,
+                        checked: singleSelection == index,
+                        onItemClicked: { singleSelection = index },
+                        showDivider: index < 2,
+                        supportText: index == 0
+                        ? "With support text" : nil
+                    )
+                }
+            }
+            
+            // MARK: - SelectListItem - Multiple
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "SelectListItem - Multiple"
+                )
+            ) {
+                ForEach(0..<3, id: \.self) { index in
+                    LemonadeUi.SelectListItem(
+                        label: "Item \(index + 1)",
+                        type: .multiple,
+                        checked: multipleSelections.contains(index),
+                        onItemClicked: {
+                            if multipleSelections.contains(index) {
+                                multipleSelections.remove(index)
+                            } else {
+                                multipleSelections.insert(index)
+                            }
+                        },
+                        showDivider: index < 2
+                    )
+                }
+            }
+            
+            // MARK: - SelectListItem - Toggle
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "SelectListItem - Toggle"
+                )
+            ) {
+                ForEach(0..<3, id: \.self) { index in
+                    LemonadeUi.SelectListItem(
+                        label: "Setting \(index + 1)",
+                        type: .toggle,
+                        checked: toggleStates[index],
+                        onItemClicked: { toggleStates[index].toggle() },
+                        showDivider: index < 2,
+                        supportText: index == 0
+                        ? "With support text" : nil
+                    )
+                }
+            }
+            
+            // MARK: - SelectListItem with Leading
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "SelectListItem with Leading"
+                )
+            ) {
+                LemonadeUi.SelectListItem(
+                    label: "With Icon",
+                    type: .single,
+                    checked: true,
+                    onItemClicked: {},
+                    supportText: "Leading icon example",
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .star,
+                            contentDescription: nil,
+                            size: .medium
+                        )
+                    }
+                )
+                LemonadeUi.SelectListItem(
+                    label: "With Leading",
+                    type: .single,
+                    checked: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.SymbolContainer(
+                            text: "LM",
+                            size: .medium,
+                            shape: .rounded
+                        )
+                    }
+                )
+            }
+            // MARK: - Disabled States (Select)
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(title: "Disabled States")
+            ) {
+                LemonadeUi.SelectListItem(
+                    label: "Disabled Option",
+                    type: .single,
+                    checked: false,
+                    onItemClicked: {},
+                    enabled: false
+                )
+            }
+        }
+    }
+}
+
+struct OutlinedSelectListItemPreview: View {
     @State private var outlinedWithLeading = 0
     @State private var outlinedWithTrailing = 1
     @State private var outlinedLabelOnly = 0
     @State private var outlinedWithSupport = 0
     @State private var outlinedMultiple: Set<Int> = [0]
-
+    
     private let outlinedOptions: [OutlinedOption] = [
         OutlinedOption(label: "Option A", icon: .heart),
         OutlinedOption(label: "Option B", icon: .star),
         OutlinedOption(label: "Option C", icon: .sparkles),
-        OutlinedOption(label: "Option D", icon: .gift)
+        OutlinedOption(label: "Option D", icon: .gift),
     ]
-
+    
     var body: some View {
-        ScrollView(.vertical) {
-            VStack(spacing: .space.spacing400) {
-                // MARK: - SelectListItem - Single
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "SelectListItem - Single")
-                ) {
+        VStack(alignment: .leading, spacing: .space.spacing400) {
+            LemonadeUi.Text("SelectListItem", font: .headingXSmall)
+
+            // MARK: - Outlined — Leading icon only
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(
+                    title: "Outlined — Leading icon only"
+                )
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
+                    ForEach(
+                        Array(outlinedOptions.enumerated()),
+                        id: \.element.id
+                    ) { index, option in
+                        let isChecked = outlinedWithLeading == index
+                        LemonadeUi.SelectListItem(
+                            label: option.label,
+                            type: .single,
+                            checked: isChecked,
+                            onItemClicked: { outlinedWithLeading = index },
+                            variant: .outlined,
+                            leadingSlot: {
+                                LemonadeUi.SymbolContainer(
+                                    icon: option.icon,
+                                    contentDescription: nil,
+                                    voice: isChecked ? .positive : .neutral,
+                                    size: .large,
+                                    shape: .rounded
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+            
+            // MARK: - Outlined — Leading + trailing tag
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(
+                    title: "Outlined — Leading + trailing tag"
+                )
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
+                    ForEach(
+                        Array(outlinedOptions.prefix(3).enumerated()),
+                        id: \.element.id
+                    ) { index, option in
+                        let isChecked = outlinedWithTrailing == index
+                        let preset = trailingPresets[index]
+                        LemonadeUi.SelectListItem(
+                            label: option.label,
+                            type: .single,
+                            checked: isChecked,
+                            onItemClicked: { outlinedWithTrailing = index },
+                            variant: .outlined,
+                            leadingSlot: {
+                                LemonadeUi.SymbolContainer(
+                                    icon: option.icon,
+                                    contentDescription: nil,
+                                    voice: isChecked ? .positive : .neutral,
+                                    size: .large,
+                                    shape: .rounded
+                                )
+                            },
+                            trailingSlot: {
+                                LemonadeUi.Tag(
+                                    label: preset.label,
+                                    voice: preset.voice
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+            
+            // MARK: - Outlined — Label only
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(
+                    title: "Outlined — Label only (no leading, no trailing)"
+                )
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
                     ForEach(0..<3, id: \.self) { index in
                         LemonadeUi.SelectListItem(
                             label: "Option \(index + 1)",
                             type: .single,
-                            checked: singleSelection == index,
-                            onItemClicked: { singleSelection = index },
-                            showDivider: index < 2,
-                            supportText: index == 0 ? "With support text" : nil
+                            checked: outlinedLabelOnly == index,
+                            onItemClicked: { outlinedLabelOnly = index },
+                            variant: .outlined
                         )
                     }
                 }
-
-                // MARK: - SelectListItem - Multiple
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "SelectListItem - Multiple")
-                ) {
-                    ForEach(0..<3, id: \.self) { index in
+            }
+            
+            // MARK: - Outlined — With support text
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(
+                    title: "Outlined — With support text"
+                )
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
+                    ForEach(
+                        Array(outlinedOptions.prefix(3).enumerated()),
+                        id: \.element.id
+                    ) { index, option in
                         LemonadeUi.SelectListItem(
-                            label: "Item \(index + 1)",
+                            label: option.label,
+                            type: .single,
+                            checked: outlinedWithSupport == index,
+                            onItemClicked: { outlinedWithSupport = index },
+                            variant: .outlined,
+                            supportText:
+                                "Short description for \(option.label.lowercased())",
+                            leadingSlot: {
+                                LemonadeUi.SymbolContainer(
+                                    icon: option.icon,
+                                    contentDescription: nil,
+                                    voice: .neutral,
+                                    size: .large,
+                                    shape: .rounded
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+            
+            // MARK: - Outlined — Multiple
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(title: "Outlined — Multiple")
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
+                    ForEach(
+                        Array(outlinedOptions.enumerated()),
+                        id: \.element.id
+                    ) { index, option in
+                        let isChecked = outlinedMultiple.contains(index)
+                        LemonadeUi.SelectListItem(
+                            label: option.label,
                             type: .multiple,
-                            checked: multipleSelections.contains(index),
+                            checked: isChecked,
                             onItemClicked: {
-                                if multipleSelections.contains(index) {
-                                    multipleSelections.remove(index)
+                                if isChecked {
+                                    outlinedMultiple.remove(index)
                                 } else {
-                                    multipleSelections.insert(index)
+                                    outlinedMultiple.insert(index)
                                 }
                             },
-                            showDivider: index < 2
+                            variant: .outlined,
+                            supportText: index == 0 ? "Tap to toggle" : nil,
+                            leadingSlot: {
+                                LemonadeUi.SymbolContainer(
+                                    icon: option.icon,
+                                    contentDescription: nil,
+                                    voice: isChecked ? .positive : .neutral,
+                                    size: .large,
+                                    shape: .rounded
+                                )
+                            }
                         )
                     }
                 }
-
-                // MARK: - SelectListItem - Toggle
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "SelectListItem - Toggle")
-                ) {
-                    ForEach(0..<3, id: \.self) { index in
-                        LemonadeUi.SelectListItem(
-                            label: "Setting \(index + 1)",
-                            type: .toggle,
-                            checked: toggleStates[index],
-                            onItemClicked: { toggleStates[index].toggle() },
-                            showDivider: index < 2,
-                            supportText: index == 0 ? "With support text" : nil
-                        )
-                    }
-                }
-
-                // MARK: - SelectListItem with Leading
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "SelectListItem with Leading")
-                ) {
+            }
+            
+            // MARK: - Outlined — Disabled states
+            LemonadeUi.Card(
+                contentPadding: .xSmall,
+                header: CardHeaderConfig(
+                    title: "Outlined — Disabled states"
+                )
+            ) {
+                VStack(spacing: LemonadeTheme.spaces.spacing100) {
                     LemonadeUi.SelectListItem(
-                        label: "With Icon",
-                        type: .single,
-                        checked: true,
-                        onItemClicked: {},
-                        supportText: "Leading icon example",
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .star,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        }
-                    )
-                }
-
-                // MARK: - Disabled States (Select)
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "Disabled States")
-                ) {
-                    LemonadeUi.SelectListItem(
-                        label: "Disabled Option",
+                        label: "Disabled, no leading",
                         type: .single,
                         checked: false,
                         onItemClicked: {},
+                        variant: .outlined,
                         enabled: false
                     )
-                }
-
-                // MARK: - ResourceListItem
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ResourceListItem")
-                ) {
-                    LemonadeUi.ResourceListItem(
-                        label: "Account Balance",
-                        value: "$1,234.56",
-                        supportText: "Updated today",
-                        showDivider: true,
+                    
+                    LemonadeUi.SelectListItem(
+                        label: "Disabled, with leading",
+                        type: .single,
+                        checked: false,
+                        onItemClicked: {},
+                        variant: .outlined,
+                        enabled: false,
                         leadingSlot: {
                             LemonadeUi.SymbolContainer(
-                                icon: .money,
-                                contentDescription: nil,
-                                voice: .info,
-                                size: .large,
-                                shape: .rounded
-                            )
-                        }
-                    )
-
-                    LemonadeUi.ResourceListItem(
-                        label: "Savings",
-                        value: "$5,000.00",
-                        showDivider: false,
-                        leadingSlot: {
-                            LemonadeUi.SymbolContainer(
-                                icon: .coins,
-                                contentDescription: nil,
-                                voice: .positive,
-                                size: .large,
-                                shape: .rounded
-                            )
-                        }
-                    )
-                }
-
-                // MARK: - ResourceListItem with Addon
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ResourceListItem with Addon")
-                ) {
-                    LemonadeUi.ResourceListItem(
-                        label: "Last Transaction",
-                        value: "-$50.00",
-                        supportText: "Yesterday",
-                        showDivider: false,
-                        addonSlot: {
-                            LemonadeUi.Tag(label: "Pending", voice: .warning)
-                        },
-                        leadingSlot: {
-                            LemonadeUi.SymbolContainer(
-                                icon: .arrowUpRight,
-                                contentDescription: nil,
-                                voice: .critical,
-                                size: .large,
-                                shape: .rounded
-                            )
-                        }
-                    )
-                }
-
-                // MARK: - ActionListItem
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ActionListItem")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "Settings",
-                        showNavigationIndicator: true,
-                        showDivider: true,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .gear,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        }
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "Notifications",
-                        supportText: "Manage your notifications",
-                        showNavigationIndicator: true,
-                        showDivider: true,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .bell,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        }
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "Privacy",
-                        showNavigationIndicator: true,
-                        showDivider: false,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
                                 icon: .padlock,
                                 contentDescription: nil,
-                                size: .medium
+                                voice: .neutral,
+                                size: .large,
+                                shape: .rounded
                             )
                         }
                     )
-                }
-
-                // MARK: - ActionListItem with Trailing
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ActionListItem with Trailing")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "Updates Available",
-                        showNavigationIndicator: true,
-                        showDivider: true,
+                    
+                    LemonadeUi.SelectListItem(
+                        label: "Disabled, with trailing tag",
+                        type: .single,
+                        checked: false,
                         onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .download,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        },
-                        trailingSlot: {
-                            LemonadeUi.Badge(text: "3", size: .small)
-                        }
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "New Features",
-                        showNavigationIndicator: true,
-                        showDivider: false,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .sparkles,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        },
-                        trailingSlot: {
-                            LemonadeUi.Tag(label: "New", voice: .positive)
-                        }
-                    )
-                }
-
-                // MARK: - ActionListItem - Figma reference (multi-line support text)
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ActionListItem - Figma reference")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "Account ***4236",
-                        supportText: "PT50 0002 0123 1234…\n1 store linked",
-                        showNavigationIndicator: true,
-                        showDivider: false,
-                        onItemClicked: {},
+                        variant: .outlined,
+                        enabled: false,
                         leadingSlot: {
                             LemonadeUi.SymbolContainer(
-                                icon: .bank,
+                                icon: .bell,
                                 contentDescription: nil,
                                 voice: .neutral,
                                 size: .large,
@@ -301,288 +714,23 @@ struct ListItemDisplayView: View {
                             )
                         },
                         trailingSlot: {
-                            LemonadeUi.Tag(label: "Settlements", voice: .positive)
+                            LemonadeUi.Tag(label: "Coming Soon")
                         }
                     )
                 }
+            }
+        }
+    }
+}
 
-                // MARK: - ActionListItem - Critical Voice
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "ActionListItem - Critical Voice")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "Delete Account",
-                        voice: .critical,
-                        showDivider: true,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .trash,
-                                contentDescription: nil,
-                                size: .medium,
-                                tint: .content.contentCritical
-                            )
-                        }
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "Log Out",
-                        supportText: "You will need to sign in again",
-                        voice: .critical,
-                        showDivider: false,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .logOut,
-                                contentDescription: nil,
-                                size: .medium,
-                                tint: .content.contentCritical
-                            )
-                        }
-                    )
-                }
-
-                // MARK: - Disabled States (Action)
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "Disabled States")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "Disabled Action",
-                        enabled: false,
-                        showDivider: false,
-                        onItemClicked: {},
-                        leadingSlot: {
-                            LemonadeUi.Icon(
-                                icon: .gear,
-                                contentDescription: nil,
-                                size: .medium
-                            )
-                        }
-                    )
-                }
-
-                // MARK: - Loading State
-                LemonadeUi.Card(
-                    contentPadding: .none,
-                    header: CardHeaderConfig(title: "Loading State")
-                ) {
-                    LemonadeUi.ActionListItem(
-                        label: "",
-                        isLoading: true,
-                        showDivider: true
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "",
-                        isLoading: true,
-                        showDivider: true
-                    )
-
-                    LemonadeUi.ActionListItem(
-                        label: "",
-                        isLoading: true,
-                        showDivider: false
-                    )
-                }
-
-                // MARK: - Outlined — Leading icon only
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — Leading icon only")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        ForEach(Array(outlinedOptions.enumerated()), id: \.element.id) { index, option in
-                            let isChecked = outlinedWithLeading == index
-                            LemonadeUi.SelectListItem(
-                                label: option.label,
-                                type: .single,
-                                checked: isChecked,
-                                onItemClicked: { outlinedWithLeading = index },
-                                variant: .outlined,
-                                leadingSlot: {
-                                    LemonadeUi.SymbolContainer(
-                                        icon: option.icon,
-                                        contentDescription: nil,
-                                        voice: isChecked ? .positive : .neutral,
-                                        size: .large,
-                                        shape: .rounded
-                                    )
-                                }
-                            )
-                        }
-                    }
-                }
-
-                // MARK: - Outlined — Leading + trailing tag
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — Leading + trailing tag")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        ForEach(Array(outlinedOptions.prefix(3).enumerated()), id: \.element.id) { index, option in
-                            let isChecked = outlinedWithTrailing == index
-                            let preset = trailingPresets[index]
-                            LemonadeUi.SelectListItem(
-                                label: option.label,
-                                type: .single,
-                                checked: isChecked,
-                                onItemClicked: { outlinedWithTrailing = index },
-                                variant: .outlined,
-                                leadingSlot: {
-                                    LemonadeUi.SymbolContainer(
-                                        icon: option.icon,
-                                        contentDescription: nil,
-                                        voice: isChecked ? .positive : .neutral,
-                                        size: .large,
-                                        shape: .rounded
-                                    )
-                                },
-                                trailingSlot: {
-                                    LemonadeUi.Tag(label: preset.label, voice: preset.voice)
-                                }
-                            )
-                        }
-                    }
-                }
-
-                // MARK: - Outlined — Label only
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — Label only (no leading, no trailing)")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        ForEach(0..<3, id: \.self) { index in
-                            LemonadeUi.SelectListItem(
-                                label: "Option \(index + 1)",
-                                type: .single,
-                                checked: outlinedLabelOnly == index,
-                                onItemClicked: { outlinedLabelOnly = index },
-                                variant: .outlined
-                            )
-                        }
-                    }
-                }
-
-                // MARK: - Outlined — With support text
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — With support text")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        ForEach(Array(outlinedOptions.prefix(3).enumerated()), id: \.element.id) { index, option in
-                            LemonadeUi.SelectListItem(
-                                label: option.label,
-                                type: .single,
-                                checked: outlinedWithSupport == index,
-                                onItemClicked: { outlinedWithSupport = index },
-                                variant: .outlined,
-                                supportText: "Short description for \(option.label.lowercased())",
-                                leadingSlot: {
-                                    LemonadeUi.SymbolContainer(
-                                        icon: option.icon,
-                                        contentDescription: nil,
-                                        voice: .neutral,
-                                        size: .large,
-                                        shape: .rounded
-                                    )
-                                }
-                            )
-                        }
-                    }
-                }
-
-                // MARK: - Outlined — Multiple
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — Multiple")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        ForEach(Array(outlinedOptions.enumerated()), id: \.element.id) { index, option in
-                            let isChecked = outlinedMultiple.contains(index)
-                            LemonadeUi.SelectListItem(
-                                label: option.label,
-                                type: .multiple,
-                                checked: isChecked,
-                                onItemClicked: {
-                                    if isChecked {
-                                        outlinedMultiple.remove(index)
-                                    } else {
-                                        outlinedMultiple.insert(index)
-                                    }
-                                },
-                                variant: .outlined,
-                                supportText: index == 0 ? "Tap to toggle" : nil,
-                                leadingSlot: {
-                                    LemonadeUi.SymbolContainer(
-                                        icon: option.icon,
-                                        contentDescription: nil,
-                                        voice: isChecked ? .positive : .neutral,
-                                        size: .large,
-                                        shape: .rounded
-                                    )
-                                }
-                            )
-                        }
-                    }
-                }
-
-                // MARK: - Outlined — Disabled states
-                LemonadeUi.Card(
-                    contentPadding: .xSmall,
-                    header: CardHeaderConfig(title: "Outlined — Disabled states")
-                ) {
-                    VStack(spacing: LemonadeTheme.spaces.spacing100) {
-                        LemonadeUi.SelectListItem(
-                            label: "Disabled, no leading",
-                            type: .single,
-                            checked: false,
-                            onItemClicked: {},
-                            variant: .outlined,
-                            enabled: false
-                        )
-
-                        LemonadeUi.SelectListItem(
-                            label: "Disabled, with leading",
-                            type: .single,
-                            checked: false,
-                            onItemClicked: {},
-                            variant: .outlined,
-                            enabled: false,
-                            leadingSlot: {
-                                LemonadeUi.SymbolContainer(
-                                    icon: .padlock,
-                                    contentDescription: nil,
-                                    voice: .neutral,
-                                    size: .large,
-                                    shape: .rounded
-                                )
-                            }
-                        )
-
-                        LemonadeUi.SelectListItem(
-                            label: "Disabled, with trailing tag",
-                            type: .single,
-                            checked: false,
-                            onItemClicked: {},
-                            variant: .outlined,
-                            enabled: false,
-                            leadingSlot: {
-                                LemonadeUi.SymbolContainer(
-                                    icon: .bell,
-                                    contentDescription: nil,
-                                    voice: .neutral,
-                                    size: .large,
-                                    shape: .rounded
-                                )
-                            },
-                            trailingSlot: {
-                                LemonadeUi.Tag(label: "Coming Soon")
-                            }
-                        )
-                    }
-                }
+struct ListItemDisplayView: View {
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(spacing: .space.spacing800) {
+                ResourceListItemPreview()
+                SelectListItemPreview()
+                OutlinedSelectListItemPreview()
+                ActionListItemPreview()
             }
             .padding(.space.spacing400)
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
@@ -25,6 +25,7 @@ public extension LemonadeUi {
     ///   - isLoading: Shows a skeleton loading placeholder instead of content
     ///   - enabled: Flag to define if component is enabled. Defaults to true
     ///   - showDivider: Flag to show a divider below the list item. Defaults to false
+    ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
     ///   - onItemClicked: Callback called when component is tapped
     ///   - leadingSlot: Slot content to be placed in leading position
     ///   - trailingSlot: Slot content to be placed in trailing position
@@ -38,6 +39,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
         @ViewBuilder trailingSlot: @escaping () -> TrailingContent
@@ -50,14 +52,12 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: trailingAlignment,
             onListItemClick: onItemClicked,
             leadingSlot: leadingSlot,
             trailingSlot: {
-                HStack {
-                    trailingSlot()
-                        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
-                }
-                .frame(maxHeight: .infinity)
+                trailingSlot()
+                    .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
             }
         )
     }
@@ -72,6 +72,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent
     ) -> some View {
@@ -83,6 +84,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: leadingSlot,
             trailingSlot: { EmptyView() }
@@ -99,6 +101,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder trailingSlot: @escaping () -> TrailingContent
     ) -> some View {
@@ -110,6 +113,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: { EmptyView() },
             trailingSlot: trailingSlot
@@ -126,6 +130,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil
     ) -> some View {
         ActionListItem(
@@ -136,6 +141,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: { EmptyView() },
             trailingSlot: { EmptyView() }

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -192,7 +192,7 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                     .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
             }
             
-            HStack(alignment: .top, spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
                 VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing0) {
                     contentSlot()
                 }
@@ -213,7 +213,7 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                             size: .medium,
                             tint: LemonadeTheme.colors.content.contentTertiary
                         )
-                        .opacity(enabled ? 0.5 : 0.5 * LemonadeTheme.opacity.state.opacityDisabled)
+                        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
                         .padding(.leading, LemonadeTheme.spaces.spacing100)
                     }
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -60,6 +60,7 @@ public extension LemonadeUi {
     ///   - isLoading: Shows a skeleton loading placeholder instead of content
     ///   - enabled: Flag to define if component is enabled
     ///   - showDivider: Flag to show a divider below the list item
+    ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
     ///   - onListItemClick: Optional callback triggered on click interaction
     ///   - leadingSlot: Slot content to be placed in leading position
     ///   - trailingSlot: Slot content to be placed in trailing position
@@ -73,6 +74,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onListItemClick: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
         @ViewBuilder trailingSlot: @escaping () -> TrailingContent,
@@ -86,6 +88,7 @@ public extension LemonadeUi {
                 navigationIndicator: navigationIndicator,
                 enabled: enabled,
                 showDivider: showDivider,
+                trailingAlignment: trailingAlignment,
                 onListItemClick: onListItemClick,
                 leadingSlot: leadingSlot,
                 trailingSlot: trailingSlot,
@@ -120,6 +123,7 @@ public extension LemonadeUi {
     ///   - navigationIndicator: Shows a chevron-right navigation indicator
     ///   - enabled: Flag to define if component is enabled
     ///   - showDivider: Flag to show a divider below the list item
+    ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
     ///   - onListItemClick: Optional callback triggered on click interaction
     ///   - leadingSlot: Slot content to be placed in leading position
     ///   - trailingSlot: Slot content to be placed in trailing position
@@ -130,6 +134,7 @@ public extension LemonadeUi {
         navigationIndicator: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        trailingAlignment: VerticalAlignment = .center,
         onListItemClick: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
         @ViewBuilder trailingSlot: @escaping () -> TrailingContent,
@@ -141,6 +146,7 @@ public extension LemonadeUi {
             navigationIndicator: navigationIndicator,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: trailingAlignment,
             onListItemClick: onListItemClick,
             leadingSlot: leadingSlot,
             trailingSlot: trailingSlot
@@ -156,6 +162,7 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
     let navigationIndicator: Bool
     let enabled: Bool
     let showDivider: Bool
+    let trailingAlignment: VerticalAlignment
     let onListItemClick: (() -> Void)?
     let leadingSlot: () -> LeadingContent
     let trailingSlot: () -> TrailingContent
@@ -192,11 +199,15 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                     .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
             }
             
-            HStack(alignment: .center, spacing: 0) {
+            HStack(alignment: trailingAlignment, spacing: 0) {
                 VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing0) {
                     contentSlot()
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .leading
+                )
                 .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
                 
                 Spacer()
@@ -329,7 +340,7 @@ struct LemonadeListItem_Previews: PreviewProvider {
             LemonadeUi.ResourceListItem(
                 label: "Resource Label",
                 value: "$100.00",
-                supportText: "Metadata",
+//                supportText: "Metadata",
                 showDivider: true,
                 onItemClicked: {},
             ) {
@@ -340,6 +351,23 @@ struct LemonadeListItem_Previews: PreviewProvider {
                     shape: .rounded
                 )
             }
+            
+            LemonadeUi.ResourceListItem(
+                label: "14 Apr sales",
+                value: "$5,000.00",
+                supportText: "Paid on 22 Apr • Onion Garden",
+                showDivider: true,
+                onItemClicked: {},
+                leadingSlot: {
+                    LemonadeUi.SymbolContainer(
+                        icon: .check,
+                        contentDescription: nil,
+                        voice: .positive,
+                        size: .large,
+                        shape: .rounded
+                    )
+                }
+            )
             
             // ResourceListItem with addon and divider
             LemonadeUi.ResourceListItem(

--- a/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
@@ -47,13 +47,14 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            trailingAlignment: .top,
             onListItemClick: onItemClicked,
             leadingSlot: {
                 leadingSlot()
                     .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
             },
             trailingSlot: {
-                VStack(alignment: .trailing, spacing: LemonadeTheme.spaces.spacing50) {
+                VStack(alignment: .trailing, spacing: .space.spacing0) {
                     LemonadeUi.Text(
                         value,
                         textStyle: LemonadeTypography.shared.bodyMediumMedium
@@ -91,3 +92,54 @@ public extension LemonadeUi {
         )
     }
 }
+
+#if DEBUG
+struct LemonadeResourceListItem_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: .space.spacing0) {
+            LemonadeUi.ResourceListItem(
+                label: "Credit •••• 8931",
+                value: "£1,234.56",
+                supportText: "Today 12:54 • Onion Garden",
+                showDivider: true,
+                onItemClicked: {},
+                addonSlot: {
+                    LemonadeUi.Tag(
+                        label: "Approved",
+                        icon: .circleCheck,
+                        voice: .positive
+                    )
+                },
+                leadingSlot: {
+                    LemonadeUi.SymbolContainer(
+                        shape: .rounded,
+                        content: {
+                            LemonadeUi.BrandLogo(
+                                logo: .mastercard,
+                                size: .medium
+                            )
+                        }
+                    )
+                }
+            )
+            
+            LemonadeUi.ResourceListItem(
+                label: "14 Apr sales",
+                value: "$5,000.00",
+                supportText: "Paid on 22 Apr • Onion Garden",
+                showDivider: false,
+                onItemClicked: {},
+                leadingSlot: {
+                    LemonadeUi.SymbolContainer(
+                        icon: .coins,
+                        contentDescription: nil,
+                        voice: .positive,
+                        size: .large,
+                        shape: .rounded
+                    )
+                }
+            )
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- The middle `Row` (Android) / inner `HStack` (iOS) that wraps the content column plus the trailing slot was defaulting to top alignment. When a `ListItem` had both a `supportText` AND a navigation chevron / trailing slot, the chevron stuck to the title line instead of centering against the full content.
- **Android** (`kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt`): added `verticalAlignment = Alignment.CenterVertically` to the wrapping `Row`.
- **iOS** (`swiftui/Sources/Lemonade/Components/LemonadeListItem.swift`): changed the inner `HStack` alignment from `.top` → `.center`. The outer `HStack` is left on `.top` so leading slots continue to top-align.
- **Fix B (included):** dropped the extra `.alpha(0.5)` / `.opacity(0.5)` layered over the already-semi-transparent `contentTertiary` tint on the enabled-state chevron — net ~20% opacity washed it out vs. Figma. Disabled-state dimming is preserved.
- **Follow-up (Felipe's iOS commit + Android mirror):** exposed `trailingAlignment` (iOS) / `trailingVerticalAlignment` (Android) on `ListItem` and `ActionListItem`, defaulting to `.center` / `Alignment.CenterVertically`. `ResourceListItem` pins it to `.top` internally so its value + addon column keeps top-aligning with the leading symbol. Sample apps on both platforms now include a dedicated `ActionListItem - Trailing Alignment` card.

Discovered while implementing MAC-5422 Card Controls in `teya-business-app` — cancel-card `ActionListItem(label, supportText, showNavigationIndicator = true)` reproduced the bug on both platforms.

## Screenshots

### Bug fix — Notifications row (label + supportText + navigationIndicator)

Before: chevron stuck to title line and washed out. After: chevron vertically centered across label + support text, full tint opacity.

#### Android

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/android-before.png" width="320"> | <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/android-after.png" width="320"> |

#### iOS

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/ios-before.png" width="320"> | <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/ios-after.png" width="320"> |

### New `trailingAlignment` / `trailingVerticalAlignment` showcase

Top / Center / Bottom demonstrated with multi-line `supportText` + `Tag` trailing, matching between platforms.

| Android | iOS |
| --- | --- |
| <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/android-alignment.png" width="320"> | <img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-169-screenshots/pr-169/ios-alignment.png" width="320"> |

## Test plan

- [x] Android: Pixel 9 Pro emulator (API 36) — Notifications row chevron centered and darker; Trailing Alignment card renders Top / Center / Bottom correctly
- [x] iOS: iPhone 17 Pro Max simulator (iOS 26.2) — Notifications row chevron centered and darker; Trailing Alignment card renders .top / .center / .bottom correctly
- [ ] Verify disabled state still dims correctly on both platforms (`Disabled States` card in each showcase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)