### PR TITLE
[KMP] fix: gate clearFocusOnKeyboardDismiss for Android API < 29

### DIFF
--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,0 +1,7 @@
+package com.teya.lemonade
+
+import android.os.Build
+
+internal actual fun supportsImeInsets(): Boolean {
+    return Build.VERSION.SDK_INT >= 30
+}

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
@@ -2,6 +2,4 @@ package com.teya.lemonade
 
 import android.os.Build
 
-internal actual fun supportsImeInsets(): Boolean {
-    return Build.VERSION.SDK_INT >= 29
-}
+internal actual fun supportsImeInsets(): Boolean = Build.VERSION.SDK_INT >= 29

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
@@ -3,5 +3,5 @@ package com.teya.lemonade
 import android.os.Build
 
 internal actual fun supportsImeInsets(): Boolean {
-    return Build.VERSION.SDK_INT >= 30
+    return Build.VERSION.SDK_INT >= 29
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
@@ -29,8 +29,11 @@ internal fun Modifier.modifyIf(
         },
     )
 
-internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier =
-    composed {
+internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier {
+    if (!supportsImeInsets()) {
+        return this
+    }
+    return composed {
         var isFocused by remember { mutableStateOf(false) }
         var keyboardAppearedSinceLastFocused by remember { mutableStateOf(false) }
 
@@ -53,6 +56,7 @@ internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier =
             }
         }
     }
+}
 
 @Composable
 public fun Modifier.clickable(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,0 +1,3 @@
+package com.teya.lemonade
+
+internal expect fun supportsImeInsets(): Boolean

--- a/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,5 +1,3 @@
 package com.teya.lemonade
 
-internal actual fun supportsImeInsets(): Boolean {
-    return true
-}
+internal actual fun supportsImeInsets(): Boolean = true

--- a/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,0 +1,5 @@
+package com.teya.lemonade
+
+internal actual fun supportsImeInsets(): Boolean {
+    return true
+}

--- a/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,5 +1,3 @@
 package com.teya.lemonade
 
-internal actual fun supportsImeInsets(): Boolean {
-    return true
-}
+internal actual fun supportsImeInsets(): Boolean = true

--- a/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Platform.kt
@@ -1,0 +1,5 @@
+package com.teya.lemonade
+
+internal actual fun supportsImeInsets(): Boolean {
+    return true
+}


### PR DESCRIPTION
## Summary
- `clearFocusOnKeyboardDismiss()` relies on `WindowInsets.ime.getBottom()` which doesn't work on Android API < 29, breaking text field focus behavior on older devices
- Adds expect/actual `supportsImeInsets()` to skip the modifier on unsupported API levels — the modifier becomes a no-op, so text fields work normally but won't auto-unfocus on keyboard dismiss
- Platforms: Android (API >= 29 enabled), iOS and Desktop (always enabled)

## Test plan
- [x] Build passes (`./gradlew :ui:assemble`)
- [x] Android API < 29: text fields work without crashes; no auto-unfocus on keyboard dismiss
- [x] Android API >= 29: auto-unfocus on keyboard dismiss works as before
- [x] iOS: no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)