### PR TITLE
feat(topbar): add optional subheading to collapsible TopBar variants [SwiftUI]

### DIFF
--- a/swiftui/SampleApp/TopBarDisplayView.swift
+++ b/swiftui/SampleApp/TopBarDisplayView.swift
@@ -16,8 +16,10 @@ struct TopBarDisplayView: View {
         DemoItem(title: "Basic (close button)", destination: AnyView(BasicCloseDemo())),
         DemoItem(title: "Basic with Trailing Slot", destination: AnyView(BasicTrailingSlotDemo())),
         DemoItem(title: "Basic with Bottom Slot", destination: AnyView(BasicBottomSlotDemo())),
+        DemoItem(title: "Basic with Subheading", destination: AnyView(BasicSubheadingDemo())),
         DemoItem(title: "Search", destination: AnyView(SearchTopBarDemo())),
         DemoItem(title: "Search with Expanded Label", destination: AnyView(SearchExpandedLabelDemo())),
+        DemoItem(title: "Search with Subheading", destination: AnyView(SearchSubheadingDemo())),
         DemoItem(title: "Compact Large (pill)", destination: AnyView(CompactLargePillDemo())),
         DemoItem(title: "Compact Large", destination: AnyView(CompactLargeDemo())),
         DemoItem(title: "Compact Large with Subheading", destination: AnyView(CompactLargeSubheadingDemo())),
@@ -162,6 +164,25 @@ private struct BasicBottomSlotDemo: View {
     }
 }
 
+private struct BasicSubheadingDemo: View {
+    var body: some View {
+        ScrollView {
+            SampleListContent()
+        }
+        .lemonadeTopBar(
+            label: "Account",
+            subheading: "Signed in as john@example.com",
+            navigationAction: NavigationAction(action: .back, onAction: {})
+        ) {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {}) {
+                    LemonadeUi.Icon(icon: .bell, contentDescription: "Notifications")
+                }
+            }
+        }
+    }
+}
+
 // MARK: - 2. Search TopBar Demos
 
 private struct SearchTopBarDemo: View {
@@ -230,6 +251,35 @@ private struct SearchExpandedLabelDemo: View {
                 }
             }
         }
+    }
+}
+
+private struct SearchSubheadingDemo: View {
+    @State private var searchQuery = ""
+
+    private let contacts = [
+        "Alice Anderson", "Bob Brown", "Carol Chen", "David Davis",
+        "Eve Edwards", "Frank Foster", "Grace Green", "Henry Harris",
+    ]
+
+    private var filteredContacts: [String] {
+        guard !searchQuery.isEmpty else { return contacts }
+        return contacts.filter { $0.localizedCaseInsensitiveContains(searchQuery) }
+    }
+
+    var body: some View {
+        List {
+            ForEach(filteredContacts, id: \.self) { contact in
+                SwiftUI.Text(contact)
+            }
+        }
+        .lemonadeTopBar(
+            label: "Contacts",
+            subheading: "\(contacts.count) people",
+            searchInput: $searchQuery,
+            searchPrompt: "Search contacts...",
+            navigationAction: NavigationAction(action: .back, onAction: {})
+        )
     }
 }
 

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -49,6 +49,7 @@ private struct LemonadeEmptyToolbarContent: ToolbarContent {
 /// same way as the native `.toolbar` modifier.
 private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>: ViewModifier {
     let label: String
+    let subheading: String?
     let collapsedLabel: String?
     let navigationAction: NavigationAction?
     let toolbarContent: Toolbar
@@ -56,8 +57,7 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
 
     func body(content: Content) -> some View {
         content
-            .navigationTitle(collapsedLabel ?? label)
-            .navigationBarTitleDisplayMode(.large)
+            .lemonadeNavigationTitle(title: collapsedLabel ?? label, subheading: subheading)
             .navigationBarBackButtonHidden(navigationAction?.action == .close)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -72,6 +72,7 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
                 }
                 toolbarContent
             }
+            .lemonadeFallbackPrincipalTitle(label: collapsedLabel ?? label, subheading: subheading)
             .lemonadeTopBarBottomSlot(bottomSlot)
     }
 }
@@ -82,6 +83,7 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
 /// Uses `.searchable` with `.navigationBarDrawer` placement for native collapse behavior.
 private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>: ViewModifier {
     let label: String
+    let subheading: String?
     @Binding var searchInput: String
     let searchPrompt: String
     let expandedLabel: String?
@@ -91,8 +93,7 @@ private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View
 
     func body(content: Content) -> some View {
         content
-            .navigationTitle(expandedLabel ?? label)
-            .navigationBarTitleDisplayMode(.large)
+            .lemonadeNavigationTitle(title: expandedLabel ?? label, subheading: subheading)
             .searchable(
                 text: $searchInput,
                 placement: .navigationBarDrawer(displayMode: .always),
@@ -112,6 +113,7 @@ private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View
                 }
                 toolbarContent
             }
+            .lemonadeFallbackPrincipalTitle(label: expandedLabel ?? label, subheading: subheading)
             .lemonadeTopBarBottomSlot(bottomSlot)
     }
 }
@@ -628,6 +630,96 @@ private extension ToolbarContent {
 }
 
 private extension View {
+    /// Applies the navigation title and, on iOS 26, the native `.navigationSubtitle`
+    /// (preserves the large-title morph). On iOS < 26 a non-nil subheading forces
+    /// inline display mode with an empty title so `lemonadeFallbackPrincipalTitle`
+    /// can render a stacked `title` + `subheading` in the principal toolbar slot —
+    /// matching the platform convention (Mail, Messages, Settings) for pre-iOS 26
+    /// two-line nav bars at the cost of losing the large-title morph.
+    @ViewBuilder
+    func lemonadeNavigationTitle(title: String, subheading: String?) -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26, *), let subheading {
+            self
+                .navigationTitle(title)
+                .navigationSubtitle(subheading)
+                .navigationBarTitleDisplayMode(.large)
+        } else if #available(iOS 26, *) {
+            self
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.large)
+        } else if subheading != nil {
+            self
+                .navigationTitle("")
+                .navigationBarTitleDisplayMode(.inline)
+        } else {
+            self
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.large)
+        }
+        #else
+        if subheading != nil {
+            self
+                .navigationTitle("")
+                .navigationBarTitleDisplayMode(.inline)
+        } else {
+            self
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.large)
+        }
+        #endif
+    }
+}
+
+private extension View {
+    /// iOS < 26 fallback: attaches a principal toolbar item that renders
+    /// `label` + `subheading` stacked vertically (matches the Mail / Messages
+    /// pattern used before `.navigationSubtitle` existed). No-op on iOS 26,
+    /// where the native API handles the subheading in both expanded and
+    /// collapsed states.
+    @ViewBuilder
+    func lemonadeFallbackPrincipalTitle(label: String, subheading: String?) -> some View {
+        #if compiler(>=6.2)
+        if #available(iOS 26, *) {
+            self
+        } else if let subheading {
+            self.toolbar {
+                ToolbarItem(placement: .principal) {
+                    VStack(spacing: 2) {
+                        SwiftUI.Text(label)
+                            .font(.headingXSmall)
+                            .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                        SwiftUI.Text(subheading)
+                            .font(.bodySmallRegular)
+                            .foregroundStyle(LemonadeTheme.colors.content.contentSecondary)
+                    }
+                }
+            }
+        } else {
+            self
+        }
+        #else
+        if let subheading {
+            self.toolbar {
+                ToolbarItem(placement: .principal) {
+                    VStack(spacing: 2) {
+                        SwiftUI.Text(label)
+                            .font(.headingXSmall)
+                            .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                        SwiftUI.Text(subheading)
+                            .font(.bodySmallRegular)
+                            .foregroundStyle(LemonadeTheme.colors.content.contentSecondary)
+                    }
+                }
+            }
+        } else {
+            self
+        }
+        #endif
+    }
+}
+
+private extension View {
     /// Renders a bottom slot attached to the nav bar.
     ///
     /// On iOS 26+: uses the native glass toolbar (no divider) and lets the inset ride on top.
@@ -822,6 +914,7 @@ public extension View {
     /// ```
     func lemonadeTopBar<Toolbar: ToolbarContent, BottomContent: View>(
         label: String,
+        subheading: String? = nil,
         collapsedLabel: String? = nil,
         navigationAction: NavigationAction? = nil,
         @ViewBuilder bottomSlot: @escaping () -> BottomContent,
@@ -829,6 +922,7 @@ public extension View {
     ) -> some View {
         modifier(BasicTopBarModifier(
             label: label,
+            subheading: subheading,
             collapsedLabel: collapsedLabel,
             navigationAction: navigationAction,
             toolbarContent: toolbar(),
@@ -839,12 +933,14 @@ public extension View {
     /// Applies a Lemonade-styled navigation bar with toolbar content (no bottom slot).
     func lemonadeTopBar<Toolbar: ToolbarContent>(
         label: String,
+        subheading: String? = nil,
         collapsedLabel: String? = nil,
         navigationAction: NavigationAction? = nil,
         @ToolbarContentBuilder toolbar: () -> Toolbar
     ) -> some View {
         modifier(BasicTopBarModifier(
             label: label,
+            subheading: subheading,
             collapsedLabel: collapsedLabel,
             navigationAction: navigationAction,
             toolbarContent: toolbar(),
@@ -855,11 +951,13 @@ public extension View {
     /// Applies a Lemonade-styled navigation bar with a collapsible large title (no toolbar or bottom slot).
     func lemonadeTopBar(
         label: String,
+        subheading: String? = nil,
         collapsedLabel: String? = nil,
         navigationAction: NavigationAction? = nil
     ) -> some View {
         modifier(BasicTopBarModifier(
             label: label,
+            subheading: subheading,
             collapsedLabel: collapsedLabel,
             navigationAction: navigationAction,
             toolbarContent: LemonadeEmptyToolbarContent(),
@@ -889,6 +987,7 @@ public extension View {
     /// ```
     func lemonadeTopBar<Toolbar: ToolbarContent, BottomContent: View>(
         label: String,
+        subheading: String? = nil,
         searchInput: Binding<String>,
         searchPrompt: String = "Search...",
         expandedLabel: String? = nil,
@@ -898,6 +997,7 @@ public extension View {
     ) -> some View {
         modifier(SearchTopBarModifier(
             label: label,
+            subheading: subheading,
             searchInput: searchInput,
             searchPrompt: searchPrompt,
             expandedLabel: expandedLabel,
@@ -910,6 +1010,7 @@ public extension View {
     /// Applies a Lemonade-styled navigation bar with search + toolbar (no bottom slot).
     func lemonadeTopBar<Toolbar: ToolbarContent>(
         label: String,
+        subheading: String? = nil,
         searchInput: Binding<String>,
         searchPrompt: String = "Search...",
         expandedLabel: String? = nil,
@@ -918,6 +1019,7 @@ public extension View {
     ) -> some View {
         modifier(SearchTopBarModifier(
             label: label,
+            subheading: subheading,
             searchInput: searchInput,
             searchPrompt: searchPrompt,
             expandedLabel: expandedLabel,
@@ -930,6 +1032,7 @@ public extension View {
     /// Applies a Lemonade-styled navigation bar with search (no toolbar or bottom slot).
     func lemonadeTopBar(
         label: String,
+        subheading: String? = nil,
         searchInput: Binding<String>,
         searchPrompt: String = "Search...",
         expandedLabel: String? = nil,
@@ -937,6 +1040,7 @@ public extension View {
     ) -> some View {
         modifier(SearchTopBarModifier(
             label: label,
+            subheading: subheading,
             searchInput: searchInput,
             searchPrompt: searchPrompt,
             expandedLabel: expandedLabel,

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -631,11 +631,12 @@ private extension ToolbarContent {
 
 private extension View {
     /// Applies the navigation title and, on iOS 26, the native `.navigationSubtitle`
-    /// (preserves the large-title morph). On iOS < 26 a non-nil subheading forces
-    /// inline display mode with an empty title so `lemonadeFallbackPrincipalTitle`
-    /// can render a stacked `title` + `subheading` in the principal toolbar slot —
-    /// matching the platform convention (Mail, Messages, Settings) for pre-iOS 26
-    /// two-line nav bars at the cost of losing the large-title morph.
+    /// (preserves the large-title morph). On iOS < 26 a non-nil subheading switches
+    /// to inline display mode so `lemonadeFallbackPrincipalTitle` can render a
+    /// stacked `title` + `subheading` in the principal toolbar slot — matching the
+    /// platform convention (Mail, Messages, Settings) for pre-iOS 26 two-line nav
+    /// bars at the cost of losing the large-title morph. The native `.navigationTitle`
+    /// is kept (not emptied) so pushed screens still inherit a back button label.
     @ViewBuilder
     func lemonadeNavigationTitle(title: String, subheading: String?) -> some View {
         #if compiler(>=6.2)
@@ -650,7 +651,7 @@ private extension View {
                 .navigationBarTitleDisplayMode(.large)
         } else if subheading != nil {
             self
-                .navigationTitle("")
+                .navigationTitle(title)
                 .navigationBarTitleDisplayMode(.inline)
         } else {
             self
@@ -660,7 +661,7 @@ private extension View {
         #else
         if subheading != nil {
             self
-                .navigationTitle("")
+                .navigationTitle(title)
                 .navigationBarTitleDisplayMode(.inline)
         } else {
             self
@@ -685,14 +686,7 @@ private extension View {
         } else if let subheading {
             self.toolbar {
                 ToolbarItem(placement: .principal) {
-                    VStack(spacing: 2) {
-                        SwiftUI.Text(label)
-                            .font(.headingXSmall)
-                            .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
-                        SwiftUI.Text(subheading)
-                            .font(.bodySmallRegular)
-                            .foregroundStyle(LemonadeTheme.colors.content.contentSecondary)
-                    }
+                    LemonadePrincipalTwoLineTitle(label: label, subheading: subheading)
                 }
             }
         } else {
@@ -702,20 +696,36 @@ private extension View {
         if let subheading {
             self.toolbar {
                 ToolbarItem(placement: .principal) {
-                    VStack(spacing: 2) {
-                        SwiftUI.Text(label)
-                            .font(.headingXSmall)
-                            .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
-                        SwiftUI.Text(subheading)
-                            .font(.bodySmallRegular)
-                            .foregroundStyle(LemonadeTheme.colors.content.contentSecondary)
-                    }
+                    LemonadePrincipalTwoLineTitle(label: label, subheading: subheading)
                 }
             }
         } else {
             self
         }
         #endif
+    }
+}
+
+/// Stacked title + subheading used as `.principal` toolbar item on iOS < 26.
+/// Constrained to a single line each with tail truncation so the nav bar
+/// height stays stable regardless of label length.
+private struct LemonadePrincipalTwoLineTitle: View {
+    let label: String
+    let subheading: String
+
+    var body: some View {
+        VStack(spacing: 2) {
+            SwiftUI.Text(label)
+                .font(.headingXSmall)
+                .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            SwiftUI.Text(subheading)
+                .font(.bodySmallRegular)
+                .foregroundStyle(LemonadeTheme.colors.content.contentSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Brings KMP #168 to SwiftUI: Basic and Basic+Search TopBar variants now accept `subheading: String?`, defaulting to `nil` (zero breaking change).

- **iOS 26+:** uses the native `.navigationSubtitle(_:)` — large title morph preserved, subheading visible in both expanded and collapsed states.
- **iOS < 26:** falls back to `.principal` toolbar with a stacked `VStack(title, subheading)` in inline mode. Matches the convention Mail / Messages / Settings adopted before `.navigationSubtitle` existed — trades the large-title morph for a unified two-line nav bar (no "second bar" or bleed-through). This is the same compromise most apps made pre-iOS 26 because UIKit had no native subtitle slot until `UINavigationItem.subtitle` shipped with iOS 26.

All 6 public overloads (Basic × 3 + Basic/Search × 3) gained the new parameter. Compact Large variants already had `subheading` and are untouched.

## Changes

- `Sources/Lemonade/Modifiers/LemonadeTopBar.swift` — new `subheading` field on `BasicTopBarModifier` and `SearchTopBarModifier`; two private helpers (`lemonadeNavigationTitle` and `lemonadeFallbackPrincipalTitle`) that branch on `#available(iOS 26, *)`.
- `SampleApp/TopBarDisplayView.swift` — two new demos: "Basic with Subheading" and "Search with Subheading".

## Test Plan

- [x] Framework builds clean (`xcodebuild build -scheme Lemonade`)
- [x] Sample app builds clean (`xcodebuild build -scheme LemonadeSampleApp`)
- [x] Manually verified on iPhone 17 Pro (iOS 26.0): native `.navigationSubtitle` renders expanded and follows title collapse on scroll
- [x] Manually verified on iPhone 16 Pro (iOS 18.6): fallback renders inline title + subheading stack in nav bar center; native back + trailing toolbar items intact
- [ ] Visual regression: existing Basic / Basic+Search demos (without subheading) unchanged — verify on both simulators

## Follow-ups (not in this PR)

- iOS < 26 fallback accepts the loss of large-title morph. A scroll-driven custom header (Apple Music / App Store pattern) could reach full parity but is significantly more code; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)