### PR TITLE
fix(swiftui): prevent HorizontalDivider label from wrapping

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
@@ -55,6 +55,7 @@ public extension LemonadeUi {
                     textStyle: LemonadeTypography.shared.bodySmallRegular,
                     color: LemonadeTheme.colors.content.contentSecondary
                 )
+                .fixedSize(horizontal: true, vertical: false)
                 .padding(.horizontal, LemonadeTheme.spaces.spacing300)
 
                 CoreHorizontalDivider(


### PR DESCRIPTION
## Summary
- SwiftUI `LemonadeUi.HorizontalDivider(label:)` wraps longer labels onto two lines, diverging from the Compose version which keeps them on a single line.
- Root cause: each `CoreHorizontalDivider` uses `GeometryReader`, so in the HStack SwiftUI distributes width between the dividers and the `Text` — squeezing the label.
- Fix: apply `.fixedSize(horizontal: true, vertical: false)` to the label so it claims its intrinsic one-line width first, letting the side dividers fill the remainder. This mirrors Compose's `Modifier.weight(1f)` on the dividers.

## Test plan
- [ ] Verify `DividerDisplayView` sample renders label on one line across device sizes
- [ ] Regression check on the short-label case (`"OR"`) — still centered, no layout shift
- [ ] Consumer check: teya-business-app cash deposit tutorial no longer shows the "Are you already at a PayPoint?" label wrapped on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)