### PR TITLE
fix(swiftui): prevent HorizontalDivider label from wrapping

### DIFF
--- a/swiftui/SampleApp/DividerDisplayView.swift
+++ b/swiftui/SampleApp/DividerDisplayView.swift
@@ -57,6 +57,16 @@ struct DividerDisplayView: View {
                             )
                             LemonadeUi.HorizontalDivider(label: "Are you already at a PayPoint?")
                         }
+
+                        VStack(alignment: .leading, spacing: .space.spacing200) {
+                            LemonadeUi.Text(
+                                "Narrow Container",
+                                textStyle: LemonadeTypography.shared.bodySmallRegular,
+                                color: .content.contentSecondary
+                            )
+                            LemonadeUi.HorizontalDivider(label: "Are you already at a PayPoint?")
+                                .frame(width: 200)
+                        }
                     }
                 }
 

--- a/swiftui/SampleApp/DividerDisplayView.swift
+++ b/swiftui/SampleApp/DividerDisplayView.swift
@@ -48,6 +48,15 @@ struct DividerDisplayView: View {
                             )
                             LemonadeUi.HorizontalDivider(label: "OR", variant: .dashed)
                         }
+
+                        VStack(alignment: .leading, spacing: .space.spacing200) {
+                            LemonadeUi.Text(
+                                "Long Label",
+                                textStyle: LemonadeTypography.shared.bodySmallRegular,
+                                color: .content.contentSecondary
+                            )
+                            LemonadeUi.HorizontalDivider(label: "Are you already at a PayPoint?")
+                        }
                     }
                 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
@@ -54,7 +54,7 @@ public extension LemonadeUi {
                     label,
                     textStyle: LemonadeTypography.shared.bodySmallRegular,
                     color: LemonadeTheme.colors.content.contentSecondary,
-                    maxLines: 1
+                    maxLines: 2
                 )
                 .padding(.horizontal, LemonadeTheme.spaces.spacing300)
                 .layoutPriority(1)

--- a/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
@@ -53,9 +53,11 @@ public extension LemonadeUi {
                 LemonadeUi.Text(
                     label,
                     textStyle: LemonadeTypography.shared.bodySmallRegular,
-                    color: LemonadeTheme.colors.content.contentSecondary
+                    color: LemonadeTheme.colors.content.contentSecondary,
+                    maxLines: 1
                 )
                 .padding(.horizontal, LemonadeTheme.spaces.spacing300)
+                .layoutPriority(1)
 
                 CoreHorizontalDivider(
                     color: dividerColor,

--- a/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDivider.swift
@@ -53,6 +53,7 @@ public extension LemonadeUi {
                 LemonadeUi.Text(
                     label,
                     textStyle: LemonadeTypography.shared.bodySmallRegular,
+                    textAlign: .center,
                     color: LemonadeTheme.colors.content.contentSecondary,
                     maxLines: 2
                 )


### PR DESCRIPTION
## Summary
Longer labels in `LemonadeUi.HorizontalDivider(label:)` wrapped to two lines on iOS even when there was plenty of horizontal room, diverging from the Compose version which stays on one line.

Each `CoreHorizontalDivider` uses a `GeometryReader` that greedily fills the HStack, so SwiftUI squeezed the label — which had no line limit or width preference — into multiple lines.

### Fix
Use the DS `LemonadeUi.Text`'s own `maxLines: 2` and give the label `.layoutPriority(1)` so the HStack assigns it its intrinsic one-line width first and the dividers take the remainder. Mirrors Compose's `Modifier.weight(1f)` on the dividers.

- **Normal case (any reasonable container):** label renders on one line, dividers flank it.
- **Extreme-narrow case (tiny container / long localization / large Dynamic Type):** label wraps to two lines instead of truncating or overflowing.

### Approaches considered
| Option | Why not |
| --- | --- |
| `.fixedSize(horizontal: true, vertical: false)` | Forces ideal width — overflows/clips if the label is wider than the container |
| `maxLines: 1` + `.layoutPriority(1)` | Works, but truncates with `…` in narrow cases — preferred wrap-to-two-lines fallback instead |
| **`maxLines: 2` + `.layoutPriority(1)` (this PR)** | Uses the DS Text's own API, matches Compose semantics on normal layouts, wraps gracefully on truly narrow containers |

### Sample app
Added two cases to `DividerDisplayView`:
- `Long Label` — full-width container, demonstrates the fix keeps a long label on one line.
- `Narrow Container` — 200pt-wide container, demonstrates the two-line wrap fallback.

## Before / After
Captured on iPhone 17 simulator (iOS 26.2):

| Before (wraps even when there's room) | After (one line normally, two lines only when narrow) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-175-assets/pr-175/before.png) | ![after](https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-175-assets/pr-175/after.png) |

## Test plan
- [x] Sample app `Divider` screen: long label on full-width container renders on a single line
- [x] Sample app `Divider` screen: same label in a 200pt-wide container wraps to two lines, dividers remain aligned
- [x] Short-label case (`OR`) unchanged — still centered, no layout shift
- [x] Swift package builds (`swift build`)
- [x] Sample app builds + launches on iPhone 17 simulator
- [ ] Downstream check: after DS bump, `teya-business-app` cash deposit tutorial divider renders on one line on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)