### PR TITLE
fix(swiftui): Tabs (.hug) — scroll selected tab into view on first render and stop trailing fade from overlaying it

### DIFF
--- a/swiftui/SampleApp/TabsDisplayView.swift
+++ b/swiftui/SampleApp/TabsDisplayView.swift
@@ -7,6 +7,7 @@ struct TabsDisplayView: View {
     @State private var manyTabsSelectedIndex = 2
     @State private var iconTabsSelectedIndex = 0
     @State private var disabledTabsSelectedIndex = 0
+    @State private var rightEdgeSelectedIndex = 5
 
     var body: some View {
         ScrollView {
@@ -48,6 +49,21 @@ struct TabsDisplayView: View {
                         ],
                         selectedIndex: manyTabsSelectedIndex,
                         onTabSelected: { manyTabsSelectedIndex = $0 }
+                    )
+                }
+
+                sectionView(title: "Right-edge selected (initial)") {
+                    LemonadeUi.Tabs(
+                        tabs: [
+                            LemonadeTabItem(label: "November"),
+                            LemonadeTabItem(label: "December"),
+                            LemonadeTabItem(label: "January"),
+                            LemonadeTabItem(label: "February"),
+                            LemonadeTabItem(label: "March"),
+                            LemonadeTabItem(label: "April")
+                        ],
+                        selectedIndex: rightEdgeSelectedIndex,
+                        onTabSelected: { rightEdgeSelectedIndex = $0 }
                     )
                 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
@@ -76,8 +76,19 @@ private struct LemonadeTabsView: View {
     @Namespace private var tabNamespace
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
-    @State private var showTrailingFade = false
+    @State private var didInitialScroll = false
     @State private var contentWrapperWidths: [Int: CGFloat] = [:]
+
+    // Mirrors KMP's `canScrollForward` signal: the fade should only paint
+    // when there is content beyond the trailing edge. SwiftUI's ScrollView
+    // doesn't expose a live scroll offset on iOS 15/16 without UIKit interop,
+    // so we use a deterministic substitute — when the last tab is selected,
+    // proxy.scrollTo(_, anchor: .center) clamps to the maximum offset, leaving
+    // the trailing edge of the strip flush with the viewport.
+    private var showTrailingFade: Bool {
+        guard contentWidth > containerWidth, containerWidth > 0 else { return false }
+        return selectedIndex < tabs.count - 1
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -89,37 +100,16 @@ private struct LemonadeTabsView: View {
                             .background(
                                 GeometryReader { geo in
                                     Color.clear
-                                        .preference(
-                                            key: TabsScrollOffsetKey.self,
-                                            value: -geo.frame(in: .named("tabsScroll")).origin.x
-                                        )
-                                        .onAppear {
-                                            contentWidth = geo.size.width
-                                            showTrailingFade = geo.size.width > containerWidth && containerWidth > 0
-                                        }
-                                        .onChange(of: geo.size.width) { newWidth in
-                                            contentWidth = newWidth
-                                            showTrailingFade = newWidth > containerWidth && containerWidth > 0
-                                        }
+                                        .onAppear { contentWidth = geo.size.width }
+                                        .onChange(of: geo.size.width) { contentWidth = $0 }
                                 }
                             )
                     }
-                    .coordinateSpace(name: "tabsScroll")
-                    .onPreferenceChange(TabsScrollOffsetKey.self) { offset in
-                        let scrollThreshold: CGFloat = 1
-                        let newTrailing = contentWidth > containerWidth && offset + containerWidth < contentWidth - scrollThreshold
-                        if newTrailing != showTrailingFade { showTrailingFade = newTrailing }
-                    }
                     .background(
                         GeometryReader { geo in
-                            Color.clear.onAppear {
-                                containerWidth = geo.size.width
-                                showTrailingFade = contentWidth > geo.size.width
-                            }
-                            .onChange(of: geo.size.width) { newWidth in
-                                containerWidth = newWidth
-                                showTrailingFade = contentWidth > newWidth
-                            }
+                            Color.clear
+                                .onAppear { containerWidth = geo.size.width }
+                                .onChange(of: geo.size.width) { containerWidth = $0 }
                         }
                     )
                     .overlay(alignment: .trailing) {
@@ -138,6 +128,12 @@ private struct LemonadeTabsView: View {
                             proxy.scrollTo(newIndex, anchor: .center)
                         }
                     }
+                    .onChange(of: contentWidth) { _ in
+                        performInitialScrollIfNeeded(proxy: proxy)
+                    }
+                    .onChange(of: containerWidth) { _ in
+                        performInitialScrollIfNeeded(proxy: proxy)
+                    }
                 }
             case .stretch:
                 tabRow
@@ -147,6 +143,12 @@ private struct LemonadeTabsView: View {
                 .fill(LemonadeTheme.colors.border.borderNeutralLow)
                 .frame(height: LemonadeTheme.borderWidth.base.border25)
         }
+    }
+
+    private func performInitialScrollIfNeeded(proxy: ScrollViewProxy) {
+        guard !didInitialScroll, contentWidth > 0, containerWidth > 0 else { return }
+        didInitialScroll = true
+        proxy.scrollTo(selectedIndex, anchor: .center)
     }
 
     private var tabRow: some View {
@@ -317,15 +319,6 @@ private struct TabPressButtonStyle: ButtonStyle {
                     isPressed = newValue
                 }
             }
-    }
-}
-
-// MARK: - Scroll Offset Preference Key
-
-private struct TabsScrollOffsetKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 // MARK: - Tab Item Model
 
@@ -76,18 +79,19 @@ private struct LemonadeTabsView: View {
     @Namespace private var tabNamespace
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
+    @State private var scrollOffset: CGFloat = 0
     @State private var didInitialScroll = false
     @State private var contentWrapperWidths: [Int: CGFloat] = [:]
 
-    // Mirrors KMP's `canScrollForward` signal: the fade should only paint
-    // when there is content beyond the trailing edge. SwiftUI's ScrollView
-    // doesn't expose a live scroll offset on iOS 15/16 without UIKit interop,
-    // so we use a deterministic substitute — when the last tab is selected,
-    // proxy.scrollTo(_, anchor: .center) clamps to the maximum offset, leaving
-    // the trailing edge of the strip flush with the viewport.
+    // Mirrors KMP's `scrollState.canScrollForward`: the fade only paints when
+    // the strip is scrollable AND there is still content beyond the trailing
+    // edge. `scrollOffset` is observed live from the underlying UIScrollView
+    // via `ScrollViewOffsetObserver`, since SwiftUI's ScrollView doesn't
+    // expose offset directly on the iOS 15 deployment target.
     private var showTrailingFade: Bool {
+        let scrollThreshold: CGFloat = 1
         guard contentWidth > containerWidth, containerWidth > 0 else { return false }
-        return selectedIndex < tabs.count - 1
+        return scrollOffset + containerWidth < contentWidth - scrollThreshold
     }
 
     var body: some View {
@@ -104,6 +108,12 @@ private struct LemonadeTabsView: View {
                                         .onChange(of: geo.size.width) { contentWidth = $0 }
                                 }
                             )
+                            #if canImport(UIKit)
+                            .background(
+                                ScrollViewOffsetObserver(offset: $scrollOffset)
+                                    .frame(width: 0, height: 0)
+                            )
+                            #endif
                     }
                     .background(
                         GeometryReader { geo in
@@ -124,6 +134,10 @@ private struct LemonadeTabsView: View {
                         }
                     }
                     .onChange(of: selectedIndex) { newIndex in
+                        // Any intentional selection change supersedes the
+                        // initial-scroll path so widths arriving late can't
+                        // cancel the animated scroll with a non-animated one.
+                        didInitialScroll = true
                         withAnimation(.easeInOut(duration: 0.25)) {
                             proxy.scrollTo(newIndex, anchor: .center)
                         }
@@ -321,6 +335,80 @@ private struct TabPressButtonStyle: ButtonStyle {
             }
     }
 }
+
+// MARK: - Scroll Offset Observer
+
+#if canImport(UIKit)
+/// Walks up to the enclosing `UIScrollView` and KVO-observes `contentOffset.x`,
+/// publishing it back into a SwiftUI `@State` via the binding. Needed because
+/// `.onPreferenceChange` over a named coordinate space doesn't fire on every
+/// scroll tick on iOS 18+ in this configuration, and iOS 15 is the deployment
+/// target so `.scrollPosition` / `.onScrollGeometryChange` aren't available.
+private struct ScrollViewOffsetObserver: UIViewRepresentable {
+    @Binding var offset: CGFloat
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: uiView)
+        }
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(offset: $offset)
+    }
+
+    final class Coordinator {
+        @Binding var offset: CGFloat
+        private var observation: NSKeyValueObservation?
+        private weak var observedScrollView: UIScrollView?
+
+        init(offset: Binding<CGFloat>) {
+            self._offset = offset
+        }
+
+        func attachIfNeeded(from view: UIView) {
+            guard let scrollView = enclosingScrollView(of: view),
+                  scrollView !== observedScrollView else { return }
+            observation?.invalidate()
+            observedScrollView = scrollView
+            observation = scrollView.observe(
+                \.contentOffset,
+                options: [.initial, .new]
+            ) { [weak self] sv, _ in
+                let value = sv.contentOffset.x
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self, self.offset != value else { return }
+                    self.offset = value
+                }
+            }
+        }
+
+        func detach() {
+            observation?.invalidate()
+            observation = nil
+        }
+
+        private func enclosingScrollView(of view: UIView) -> UIScrollView? {
+            var current: UIView? = view.superview
+            while let v = current {
+                if let scrollView = v as? UIScrollView { return scrollView }
+                current = v.superview
+            }
+            return nil
+        }
+    }
+}
+#endif
 
 // MARK: - Previews
 


### PR DESCRIPTION
## Summary
- `LemonadeUi.Tabs(itemsSize: .hug)` now scrolls the selected tab into view on the first render — consumers no longer need a `@State + .task` workaround that flashed the wrong tab on the first frame.
- The trailing fade gradient no longer overlays the selected tab when it sits at the right edge of the scrollable strip.
- Aligns the fade signal with KMP's `scrollState.canScrollForward` by observing the underlying `UIScrollView.contentOffset` via KVO. Drops the brittle `.onPreferenceChange(TabsScrollOffsetKey…)` plumbing.

## What was wrong
1. **Initial render didn't scroll the selected tab into view.** `LemonadeTabsView` only called `proxy.scrollTo(_, anchor: .center)` inside `.onChange(of: selectedIndex)`. If the view was constructed with `selectedIndex` already pointing to the last tab (e.g. "current month" in a 6-month past-window picker), no change event fired and the strip opened with that tab off-screen.
2. **Trailing fade stayed on top of the right-edge selected tab.** Two `.onAppear` blocks (on the scrollable content and the container) unconditionally set `showTrailingFade = (contentWidth > containerWidth)`. The `.onPreferenceChange` listener was supposed to clear the fade at the right edge, but the `.onAppear` writes could win the race after the post-`scrollTo` preference update — and even when they didn't, the `GeometryReader`-in-named-coordinate-space approach only fired once on initial layout in this configuration on iOS 18, so the offset never caught up with reality.

## How it's fixed
- `performInitialScrollIfNeeded(proxy:)` runs once both `contentWidth` and `containerWidth` have been measured, calling `proxy.scrollTo(selectedIndex, anchor: .center)` without animation. Triggered via `.onChange(of: contentWidth/containerWidth)` so it fires exactly once after layout. `.onChange(of: selectedIndex)` also marks `didInitialScroll = true` so a late-arriving width measurement can't cancel an explicit animated scroll with a non-animated one.
- `showTrailingFade` is derived from a live `scrollOffset` published by `ScrollViewOffsetObserver` — a small `UIViewRepresentable` that walks up to the enclosing `UIScrollView` and KVO-observes `contentOffset.x`. This mirrors KMP's `scrollState.canScrollForward` semantics on every iOS version we support, including manual swipes that leave the strip at any position. Gated behind `#if canImport(UIKit)` so the macOS platform target still builds.
- The preference-key plumbing (`TabsScrollOffsetKey`, `coordinateSpace(name:)`, `.onPreferenceChange`) is gone. SwiftUI's `ScrollView` doesn't expose offset directly on the iOS 15 deployment target (`.scrollPosition` / `.onScrollGeometryChange` are iOS 17+/18+).

## KMP parity
| Behavior | KMP | iOS (after this fix) |
|---|---|---|
| Initial scroll to selected tab | ✅ via `LaunchedEffect(selectedIndex)` | ✅ via `performInitialScrollIfNeeded` |
| Fade hides when last tab selected at right edge | ✅ via `canScrollForward` | ✅ via live `scrollOffset` from KVO |
| Fade hides on manual swipe to right edge with non-last tab selected | ✅ via `canScrollForward` | ✅ via live `scrollOffset` from KVO |
| Fade reappears when user scrolls back from the right edge | ✅ via `canScrollForward` | ✅ via live `scrollOffset` from KVO |

## Demo
Added a "Right-edge selected (initial)" section to `TabsDisplayView` (6 months, `selectedIndex = 5`) so the scenario is exercised in the SampleApp.

## Before / After

<table>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
<tr>
<td><b>Bug 1 — initial render with <code>selectedIndex = tabs.count - 1</code></b><br/>The selected tab (April) is off-screen; the user sees Nov–Mar with March faded out.</td>
<td><b>Both bugs fixed on first render</b><br/>April is visible on first render, the trailing fade is correctly hidden, and "Many Tabs" above still fades for non-last selection (Reports centered, content beyond the right edge).</td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-tabs-trailing-fade-assets/pr-tabs-trailing-fade/before-1-initial-render.png" width="280"/></td>
<td><img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-tabs-trailing-fade-assets/pr-tabs-trailing-fade/after.png" width="280"/></td>
</tr>
<tr>
<td><b>Bug 2 — strip scrolled so the selected tab sits at the right edge</b><br/>The trailing fade overlays April, fading out exactly the indicator we want to communicate.</td>
<td><b>Live scroll-offset tracking</b><br/>After the fix, manually swiping the strip back to the right edge correctly hides the fade, and swiping away from it re-paints the fade — matching KMP's <code>canScrollForward</code> on every scroll position.</td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-tabs-trailing-fade-assets/pr-tabs-trailing-fade/before-2-fade-overlay.png" width="280"/></td>
<td><img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/pr-tabs-trailing-fade-assets/pr-tabs-trailing-fade/after-2-manual-swipe.png" width="280"/></td>
</tr>
</table>

## Test plan
- [x] iOS 18 simulator (iPhone 16 Pro): open SampleApp → Tabs → "Right-edge selected (initial)" — April should be visible on first render with no fade overlay.
- [x] Tap a middle tab (e.g. January) — strip animates to center it; trailing fade reappears because content extends to the right.
- [x] Tap April again — strip scrolls back; fade hides.
- [x] Manually swipe the right-edge strip left so April moves off-screen — fade reappears (live `canScrollForward`).
- [x] Swipe back to the right edge — fade hides again.
- [x] Verify "Many Tabs (scrollable)" with `selectedIndex = 2` (Reports) still shows the trailing fade as before.
- [x] Verify `.stretch` mode is unaffected (no scrolling, no fade).
- [ ] Verify no regression in initial-tab-0 strips (Hug default, With Icons, With Disabled Tab).
- [ ] macOS build: confirm the module still compiles for the macOS platform target (`ScrollViewOffsetObserver` is gated behind `#if canImport(UIKit)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)