### PR TITLE
feat(tile): allow custom background color override

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TileDisplay.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeTileVariant
@@ -199,6 +200,37 @@ internal fun TileDisplay() {
                     icon = LemonadeIcons.Padlock,
                     enabled = false,
                     variant = LemonadeTileVariant.Outlined,
+                )
+            }
+        }
+
+        // Custom Background
+        TileSection(title = "Custom Background") {
+            val customBg = Color(red = 0.96f, green = 0.97f, blue = 0.65f)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+            ) {
+                LemonadeUi.Tile(
+                    label = "Filled",
+                    icon = LemonadeIcons.Heart,
+                    variant = LemonadeTileVariant.Filled,
+                    backgroundColor = customBg,
+                )
+
+                LemonadeUi.Tile(
+                    label = "Outlined",
+                    icon = LemonadeIcons.Star,
+                    variant = LemonadeTileVariant.Outlined,
+                    backgroundColor = customBg,
+                )
+
+                LemonadeUi.Tile(
+                    label = "Disabled",
+                    icon = LemonadeIcons.Padlock,
+                    enabled = false,
+                    variant = LemonadeTileVariant.Filled,
+                    backgroundColor = customBg,
                 )
             }
         }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tile.kt
@@ -54,6 +54,8 @@ import com.teya.lemonade.core.LemonadeTileVariant
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
  * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
+ * @param backgroundColor - Optional override for the tile background color. When non-null it replaces
+ *   the variant's background in the unselected state.
  */
 @Suppress("LongParameterList")
 @Composable
@@ -68,6 +70,7 @@ public fun LemonadeUi.Tile(
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
+    backgroundColor: Color? = null,
 ) {
     val contentColor = if (isSelected) {
         LocalColors.current.content.contentOnBrandHigh
@@ -78,6 +81,7 @@ public fun LemonadeUi.Tile(
     CoreTile(
         modifier = modifier,
         variant = variant,
+        backgroundColor = backgroundColor,
         onClick = onClick,
         enabled = enabled,
         isSelected = isSelected,
@@ -157,6 +161,8 @@ public fun LemonadeUi.Tile(
  * @param onClick - Callback to be invoked when the Tile is clicked.
  * @param interactionSource - [MutableInteractionSource] to be applied to the Tile.
  * @param variant - [LemonadeTileVariant] to style the Tile accordingly.
+ * @param backgroundColor - Optional override for the tile background color. When non-null it replaces
+ *   the variant's background in the unselected state.
  */
 @Suppress("LongParameterList")
 @Composable
@@ -170,6 +176,7 @@ public fun LemonadeUi.Tile(
     onClick: (() -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     variant: LemonadeTileVariant = LemonadeTileVariant.Filled,
+    backgroundColor: Color? = null,
     leadingSlot: @Composable () -> Unit,
 ) {
     val contentColor = if (isSelected) {
@@ -181,6 +188,7 @@ public fun LemonadeUi.Tile(
     CoreTile(
         modifier = modifier,
         variant = variant,
+        backgroundColor = backgroundColor,
         onClick = onClick,
         enabled = enabled,
         isSelected = isSelected,
@@ -244,19 +252,20 @@ private fun CoreTile(
     onClick: (() -> Unit)?,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
+    backgroundColor: Color? = null,
 ) {
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     val tileShape = LocalShapes.current.radius500
     val baseTileData = variant.data
-    val tileData = if (isSelected) {
-        baseTileData.copy(
+    val tileData = when {
+        isSelected -> baseTileData.copy(
             backgroundColor = LocalColors.current.background.bgBrandSubtle,
             borderColor = LocalColors.current.border.borderSelected,
             borderWidth = LocalBorderWidths.current.base.border50,
         )
-    } else {
-        baseTileData
+        backgroundColor != null -> baseTileData.copy(backgroundColor = backgroundColor)
+        else -> baseTileData
     }
     val animatedBackgroundColor by animateColorAsState(
         targetValue = tileData.backgroundColor,

--- a/swiftui/SampleApp/TileDisplayView.swift
+++ b/swiftui/SampleApp/TileDisplayView.swift
@@ -155,6 +155,33 @@ struct TileDisplayView: View {
                     }
                 }
 
+                // MARK: - Custom Background
+                sectionView(title: "Custom Background") {
+                    HStack(spacing: LemonadeTheme.spaces.spacing400) {
+                        LemonadeUi.Tile(
+                            label: "Filled",
+                            icon: .heart,
+                            variant: .filled,
+                            backgroundColor: Color(red: 0.96, green: 0.97, blue: 0.65)
+                        )
+
+                        LemonadeUi.Tile(
+                            label: "Outlined",
+                            icon: .star,
+                            variant: .outlined,
+                            backgroundColor: Color(red: 0.96, green: 0.97, blue: 0.65)
+                        )
+
+                        LemonadeUi.Tile(
+                            label: "Disabled",
+                            icon: .padlock,
+                            enabled: false,
+                            variant: .filled,
+                            backgroundColor: Color(red: 0.96, green: 0.97, blue: 0.65)
+                        )
+                    }
+                }
+
                 // MARK: - Layout Behavior
                 sectionView(title: "Default Size (min 120pt)") {
                     LemonadeUi.Tile(

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -59,6 +59,8 @@ public extension LemonadeUi {
     ///   - supportText: Optional secondary text displayed below the label
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - backgroundColor: Optional override for the tile background color. When non-nil it replaces
+    ///     the variant's background in the unselected state. Defaults to nil.
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     /// - Returns: A styled Tile view
     @ViewBuilder
@@ -70,6 +72,7 @@ public extension LemonadeUi {
         supportText: String? = nil,
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
+        backgroundColor: Color? = nil,
         stretched: Bool = false
     ) -> some View {
         LemonadeTileView<EmptyView>(
@@ -80,6 +83,7 @@ public extension LemonadeUi {
             supportText: supportText,
             onClick: onClick,
             variant: variant,
+            backgroundColor: backgroundColor,
             stretched: stretched,
             topAccessory: nil
         )
@@ -108,6 +112,8 @@ public extension LemonadeUi {
     ///   - supportText: Optional secondary text displayed below the label
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - backgroundColor: Optional override for the tile background color. When non-nil it replaces
+    ///     the variant's background in the unselected state. Defaults to nil.
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     ///   - topAccessory: A view rendered at the top-right of the tile
     /// - Returns: A styled Tile view
@@ -120,6 +126,7 @@ public extension LemonadeUi {
         supportText: String? = nil,
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
+        backgroundColor: Color? = nil,
         stretched: Bool = false,
         @ViewBuilder topAccessory: @escaping () -> TopAccessory
     ) -> some View {
@@ -131,6 +138,7 @@ public extension LemonadeUi {
             supportText: supportText,
             onClick: onClick,
             variant: variant,
+            backgroundColor: backgroundColor,
             stretched: stretched,
             topAccessory: topAccessory
         )
@@ -156,6 +164,8 @@ public extension LemonadeUi {
     ///   - supportText: Optional secondary text displayed below the label
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - backgroundColor: Optional override for the tile background color. When non-nil it replaces
+    ///     the variant's background in the unselected state. Defaults to nil.
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     ///   - leadingSlot: A custom view rendered where the icon would normally appear
     /// - Returns: A styled Tile view
@@ -167,6 +177,7 @@ public extension LemonadeUi {
         supportText: String? = nil,
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
+        backgroundColor: Color? = nil,
         stretched: Bool = false,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent
     ) -> some View {
@@ -177,6 +188,7 @@ public extension LemonadeUi {
             supportText: supportText,
             onClick: onClick,
             variant: variant,
+            backgroundColor: backgroundColor,
             stretched: stretched,
             leadingSlot: leadingSlot,
             topAccessory: nil
@@ -206,6 +218,8 @@ public extension LemonadeUi {
     ///   - supportText: Optional secondary text displayed below the label
     ///   - onClick: Callback called when component is tapped
     ///   - variant: LemonadeTileVariant to define visual style. Defaults to .filled
+    ///   - backgroundColor: Optional override for the tile background color. When non-nil it replaces
+    ///     the variant's background in the unselected state. Defaults to nil.
     ///   - stretched: Whether the tile should stretch to fill available width. Defaults to false
     ///   - leadingSlot: A custom view rendered where the icon would normally appear
     ///   - topAccessory: A view rendered at the top-right of the tile
@@ -218,6 +232,7 @@ public extension LemonadeUi {
         supportText: String? = nil,
         onClick: (() -> Void)? = nil,
         variant: LemonadeTileVariant = .filled,
+        backgroundColor: Color? = nil,
         stretched: Bool = false,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
         @ViewBuilder topAccessory: @escaping () -> TopAccessory
@@ -229,6 +244,7 @@ public extension LemonadeUi {
             supportText: supportText,
             onClick: onClick,
             variant: variant,
+            backgroundColor: backgroundColor,
             stretched: stretched,
             leadingSlot: leadingSlot,
             topAccessory: topAccessory
@@ -273,13 +289,15 @@ private struct LemonadeTileView<TopAccessory: View>: View {
     let supportText: String?
     let onClick: (() -> Void)?
     let variant: LemonadeTileVariant
+    let backgroundColor: Color?
     let stretched: Bool
     let topAccessory: (() -> TopAccessory)?
-    
+
     private let minWidth: CGFloat = 120
-    
+
     private var effectiveBackgroundColor: Color {
-        isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
+        if isSelected { return LemonadeTheme.colors.background.bgBrandSubtle }
+        return backgroundColor ?? variant.backgroundColor
     }
     
     private var effectiveBorderColor: Color {
@@ -386,14 +404,16 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
     let supportText: String?
     let onClick: (() -> Void)?
     let variant: LemonadeTileVariant
+    let backgroundColor: Color?
     let stretched: Bool
     let leadingSlot: () -> LeadingContent
     let topAccessory: (() -> TopAccessory)?
-    
+
     private let minWidth: CGFloat = 120
-    
+
     private var effectiveBackgroundColor: Color {
-        isSelected ? LemonadeTheme.colors.background.bgBrandSubtle : variant.backgroundColor
+        if isSelected { return LemonadeTheme.colors.background.bgBrandSubtle }
+        return backgroundColor ?? variant.backgroundColor
     }
     
     private var effectiveBorderColor: Color {


### PR DESCRIPTION
# Summary

Adds an optional `backgroundColor` parameter to `LemonadeUi.Tile` on both **SwiftUI** and **KMP**. When non-`nil`, it overrides the variant's background in the unselected state; selected and disabled behavior are unchanged (selected still wins; disabled still applies the disabled opacity).

This unlocks the yellow-background row from the new Tile design (e.g. Teya app's promotional or accented quick actions) without forcing all consumers to adopt a new variant or color bundle.

## Figma component

- Tile (Lemonade DS): https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---New-App-Components?node-id=11099-25988&m=dev
- Use case (Teya App 2026): https://www.figma.com/design/skjFZ42nUMrFEFTvUZW6wT/Teya-App-2026?node-id=9361-73162&m=dev
- Disabled state (Teya App 2026): https://www.figma.com/design/skjFZ42nUMrFEFTvUZW6wT/Teya-App-2026?node-id=15818-10561&m=dev

## API

```swift
// SwiftUI
LemonadeUi.Tile(
    label: "Filled",
    icon: .heart,
    variant: .filled,
    backgroundColor: Color(red: 0.96, green: 0.97, blue: 0.65)
)
```

```kotlin
// KMP
LemonadeUi.Tile(
    label = "Filled",
    icon = LemonadeIcons.Heart,
    variant = LemonadeTileVariant.Filled,
    backgroundColor = Color(red = 0.96f, green = 0.97f, blue = 0.65f),
)
```

`backgroundColor` defaults to `nil`/`null`, so all existing call sites are unaffected.

## Screenshots

### iOS — Tile screen (SwiftUI sample)

<img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/assets/tile-custom-bg-screenshots/screenshots/ios-after-1.png" alt="iOS Tile - top of screen" width="280" />
<img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/assets/tile-custom-bg-screenshots/screenshots/ios-after-2.png" alt="iOS Tile - middle (incl. start of Custom Background)" width="280" />
<img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/assets/tile-custom-bg-screenshots/screenshots/ios-after-3-custom-bg.png" alt="iOS Tile - Custom Background section (filled / outlined / disabled)" width="280" />

### Android — Tile screen (KMP composeApp)

<img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/assets/tile-custom-bg-screenshots/screenshots/android-after-1.png" alt="Android Tile - top of screen" width="280" />
<img src="https://raw.githubusercontent.com/saltpay/lemonade-design-system/assets/tile-custom-bg-screenshots/screenshots/android-after-2-custom-bg.png" alt="Android Tile - Custom Background section (filled / outlined / disabled)" width="280" />

## Test plan

- [ ] iOS sample app: open **Tile** screen, scroll to the new **Custom Background** section, confirm filled/outlined/disabled tiles render with yellow bg and disabled tile is dimmed.
- [ ] Android sample app: same as above on the KMP composeApp.
- [ ] Existing call sites still compile (no signature changes — only an optional defaulted parameter added).
- [ ] Selected state still uses `bgBrandSubtle` (i.e. selected wins over `backgroundColor`).

## Notes

- Screenshots are hosted on the [`assets/tile-custom-bg-screenshots`](https://github.com/saltpay/lemonade-design-system/tree/assets/tile-custom-bg-screenshots) branch (not part of this PR's diff).
- Flutter is intentionally out of scope for this PR — that target uses a different variant model (`neutral` / `muted` / `onBrand`); a follow-up can extend the same idea there if needed.