### PR TITLE
feat: add labelIsSecondary to ActionListItem (Android + iOS)

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
@@ -79,6 +79,45 @@ internal fun ActionListItemDisplay() {
             )
         }
 
+        // ActionListItem - Label Is Secondary
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "ActionListItem - Label Is Secondary"),
+        ) {
+            LemonadeUi.ActionListItem(
+                label = "Last used",
+                supportText = "170 Oaklands Grove, London,...",
+                labelIsSecondary = true,
+                showNavigationIndicator = true,
+                onItemClicked = {},
+                showDivider = true,
+                leadingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.MapPin,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                        tint = LemonadeTheme.colors.content.contentSecondary,
+                    )
+                },
+            )
+
+            LemonadeUi.ActionListItem(
+                label = "Company address",
+                supportText = "170 Oaklands Grove, London,...",
+                labelIsSecondary = true,
+                showNavigationIndicator = true,
+                onItemClicked = {},
+                showDivider = false,
+                leadingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.MapPin,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                        tint = LemonadeTheme.colors.content.contentSecondary,
+                    )
+                },
+            )
+        }
+
         // ActionListItem - Trailing Alignment
         LemonadeUi.Card(
             header = CardHeaderConfig(title = "ActionListItem - Trailing Alignment"),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -165,6 +165,7 @@ public fun LemonadeUi.ActionListItem(
     label: String,
     modifier: Modifier = Modifier,
     supportText: String? = null,
+    labelIsSecondary: Boolean = false,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     voice: LemonadeListItemVoice = LemonadeListItemVoice.Neutral,
@@ -177,38 +178,68 @@ public fun LemonadeUi.ActionListItem(
     showDivider: Boolean = false,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
-    LemonadeUi.ListItem(
-        label = label,
-        supportText = supportText,
-        isLoading = isLoading,
-        leadingSlot = leadingSlot,
-        trailingSlot = if (trailingSlot != null) {
-            {
-                Row(
-                    modifier = Modifier.then(
-                        other = if (enabled) {
-                            Modifier
-                        } else {
-                            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                        },
-                    ),
-                ) {
-                    trailingSlot()
-                }
+    val resolvedTrailingSlot: (@Composable RowScope.() -> Unit)? = if (trailingSlot != null) {
+        {
+            Row(
+                modifier = Modifier.then(
+                    other = if (enabled) {
+                        Modifier
+                    } else {
+                        Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+                    },
+                ),
+            ) {
+                trailingSlot()
             }
-        } else {
-            null
-        },
-        navigationIndicator = showNavigationIndicator,
-        voice = voice,
-        onListItemClick = onItemClicked,
-        role = role,
-        enabled = enabled,
-        modifier = modifier,
-        showDivider = showDivider,
-        interactionSource = interactionSource,
-        trailingVerticalAlignment = trailingVerticalAlignment,
-    )
+        }
+    } else {
+        null
+    }
+
+    if (labelIsSecondary && supportText != null) {
+        LemonadeUi.ListItem(
+            contentSlot = {
+                LemonadeUi.Text(
+                    text = label,
+                    textStyle = LocalTypographies.current.bodySmallRegular,
+                    color = LocalColors.current.content.contentSecondary,
+                )
+                LemonadeUi.Text(
+                    text = supportText,
+                    textStyle = LocalTypographies.current.bodyMediumMedium,
+                    color = voice.contentColor,
+                )
+            },
+            leadingSlot = leadingSlot,
+            trailingSlot = resolvedTrailingSlot,
+            navigationIndicator = showNavigationIndicator,
+            voice = voice,
+            onListItemClick = onItemClicked,
+            role = role,
+            enabled = enabled,
+            modifier = modifier,
+            showDivider = showDivider,
+            interactionSource = interactionSource,
+            trailingVerticalAlignment = trailingVerticalAlignment,
+        )
+    } else {
+        LemonadeUi.ListItem(
+            label = label,
+            supportText = supportText,
+            isLoading = isLoading,
+            leadingSlot = leadingSlot,
+            trailingSlot = resolvedTrailingSlot,
+            navigationIndicator = showNavigationIndicator,
+            voice = voice,
+            onListItemClick = onItemClicked,
+            role = role,
+            enabled = enabled,
+            modifier = modifier,
+            showDivider = showDivider,
+            interactionSource = interactionSource,
+            trailingVerticalAlignment = trailingVerticalAlignment,
+        )
+    }
 }
 
 /**

--- a/swiftui/SampleApp/ListItemDisplayView.swift
+++ b/swiftui/SampleApp/ListItemDisplayView.swift
@@ -238,6 +238,48 @@ struct ActionListItemPreview: View {
                 )
             }
             
+            // MARK: - ActionListItem - Label Is Secondary
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "ActionListItem - Label Is Secondary"
+                )
+            ) {
+                LemonadeUi.ActionListItem(
+                    label: "Last used",
+                    supportText: "170 Oaklands Grove, London,...",
+                    showNavigationIndicator: true,
+                    showDivider: true,
+                    labelIsSecondary: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .mapPin,
+                            contentDescription: nil,
+                            size: .medium,
+                            tint: .content.contentSecondary
+                        )
+                    }
+                )
+
+                LemonadeUi.ActionListItem(
+                    label: "Company address",
+                    supportText: "170 Oaklands Grove, London,...",
+                    showNavigationIndicator: true,
+                    showDivider: false,
+                    labelIsSecondary: true,
+                    onItemClicked: {},
+                    leadingSlot: {
+                        LemonadeUi.Icon(
+                            icon: .mapPin,
+                            contentDescription: nil,
+                            size: .medium,
+                            tint: .content.contentSecondary
+                        )
+                    }
+                )
+            }
+
             // MARK: - ActionListItem - Design reference (multi-line support text)
             LemonadeUi.Card(
                 contentPadding: .none,

--- a/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
@@ -39,6 +39,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        labelIsSecondary: Bool = false,
         trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
@@ -52,6 +53,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            labelIsSecondary: labelIsSecondary,
             trailingAlignment: trailingAlignment,
             onListItemClick: onItemClicked,
             leadingSlot: leadingSlot,
@@ -72,6 +74,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        labelIsSecondary: Bool = false,
         trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent
@@ -84,6 +87,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            labelIsSecondary: labelIsSecondary,
             trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: leadingSlot,
@@ -101,6 +105,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        labelIsSecondary: Bool = false,
         trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil,
         @ViewBuilder trailingSlot: @escaping () -> TrailingContent
@@ -113,6 +118,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            labelIsSecondary: labelIsSecondary,
             trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: { EmptyView() },
@@ -130,6 +136,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        labelIsSecondary: Bool = false,
         trailingAlignment: VerticalAlignment = .center,
         onItemClicked: (() -> Void)? = nil
     ) -> some View {
@@ -141,6 +148,7 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
+            labelIsSecondary: labelIsSecondary,
             trailingAlignment: trailingAlignment,
             onItemClicked: onItemClicked,
             leadingSlot: { EmptyView() },

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -74,6 +74,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
+        labelIsSecondary: Bool = false,
         trailingAlignment: VerticalAlignment = .center,
         onListItemClick: (() -> Void)? = nil,
         @ViewBuilder leadingSlot: @escaping () -> LeadingContent,
@@ -93,20 +94,33 @@ public extension LemonadeUi {
                 leadingSlot: leadingSlot,
                 trailingSlot: trailingSlot,
                 contentSlot: {
-                    LemonadeUi.Text(
-                        label,
-                        textStyle: LemonadeTypography.shared.bodyMediumMedium,
-                        color: voice.contentColor
-                    )
-                    
-                    if let supportText = supportText {
+                    if labelIsSecondary, let supportText = supportText {
                         LemonadeUi.Text(
-                            supportText,
+                            label,
                             textStyle: LemonadeTypography.shared.bodySmallRegular,
                             color: LemonadeTheme.colors.content.contentSecondary
                         )
+                        LemonadeUi.Text(
+                            supportText,
+                            textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                            color: voice.contentColor
+                        )
+                    } else {
+                        LemonadeUi.Text(
+                            label,
+                            textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                            color: voice.contentColor
+                        )
+
+                        if let supportText = supportText {
+                            LemonadeUi.Text(
+                                supportText,
+                                textStyle: LemonadeTypography.shared.bodySmallRegular,
+                                color: LemonadeTheme.colors.content.contentSecondary
+                            )
+                        }
                     }
-                    
+
                     if SlotContent.self != EmptyView.self {
                         slotContent()
                     }


### PR DESCRIPTION
Adds `labelIsSecondary` to `ActionListItem` on both platforms for the first time.

When `true`, the label renders small/grey (secondary style) and `supportText` renders as the primary text — flipping the visual hierarchy. Useful for patterns like "Last used / address" where the category label is subordinate to the value.

**Changes:**
- **Android (KMP):** new `labelIsSecondary` param on `ActionListItem`; renders label with `bodySmallRegular`/`contentSecondary` and supportText with `bodyMediumMedium`/primary color
- **iOS (SwiftUI):** same `labelIsSecondary` param wired through all `ActionListItem` overloads and `LemonadeListItem`
- **Demo:** new "ActionListItem - Label Is Secondary" card added to both Android and iOS sample apps

| Android | iOS |
|---------|-----|
| <img width="1080" height="2424" alt="action list item - android" src="https://github.com/user-attachments/assets/a7ae1a72-62ba-420f-9b44-47c47d4d94a7" /> | <img width="1206" height="2622" alt="action list item - ios" src="https://github.com/user-attachments/assets/79a0a344-bbfc-4cb7-a4a2-eddc4d5f6284" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)