### PR TITLE
feat(swiftui, kmp): add verticalAlignment to ContentListItem

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -70,7 +70,7 @@ internal fun ContentListItemDisplay() {
                 layout = LemonadeContentListItemLayout.Horizontal,
                 showDivider = true,
                 verticalAlignment = Alignment.Top,
-                valueTextAlign = TextAlign.Left,
+                valueTextAlign = TextAlign.Start,
             )
             LemonadeUi.ContentListItem(
                 label = "Address",

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeContentListItemLayout
 import com.teya.lemonade.core.LemonadeIcons
@@ -70,7 +69,6 @@ internal fun ContentListItemDisplay() {
                 layout = LemonadeContentListItemLayout.Horizontal,
                 showDivider = true,
                 verticalAlignment = Alignment.Top,
-                valueTextAlign = TextAlign.Start,
             )
             LemonadeUi.ContentListItem(
                 label = "Address",

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeContentListItemLayout
 import com.teya.lemonade.core.LemonadeIcons
@@ -45,6 +47,32 @@ internal fun ContentListItemDisplay() {
                 label = "Account number",
                 value = "123-456-789",
                 layout = LemonadeContentListItemLayout.Horizontal,
+            )
+        }
+
+        // Horizontal simple — long text
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal Simple — Long Text"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Terms and conditions agreement for the account holder regarding international transfers and currency exchange policies",
+                value = "This value is intentionally very long to demonstrate how the horizontal simple layout handles multi-line text wrapping across several lines in a constrained width",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Short label",
+                value = "A much longer value that should wrap onto multiple lines to test alignment behavior when only one side is long",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                showDivider = true,
+                verticalAlignment = Alignment.Top,
+                valueTextAlign = TextAlign.Left,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Address",
+                value = "Westminster, London SW1A 2HQ, United Kingdom",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                verticalAlignment = Alignment.Top,
             )
         }
 

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeContentListItemLayout
@@ -55,14 +55,18 @@ internal fun ContentListItemDisplay() {
             header = CardHeaderConfig(title = "Horizontal Simple — Long Text"),
         ) {
             LemonadeUi.ContentListItem(
-                label = "Terms and conditions agreement for the account holder regarding international transfers and currency exchange policies",
-                value = "This value is intentionally very long to demonstrate how the horizontal simple layout handles multi-line text wrapping across several lines in a constrained width",
+                label = "Terms and conditions agreement for the account holder " +
+                    "regarding international transfers and currency exchange policies",
+                value = "This value is intentionally very long to demonstrate how " +
+                    "the horizontal simple layout handles multi-line text wrapping " +
+                    "across several lines in a constrained width",
                 layout = LemonadeContentListItemLayout.Horizontal,
                 showDivider = true,
             )
             LemonadeUi.ContentListItem(
                 label = "Short label",
-                value = "A much longer value that should wrap onto multiple lines to test alignment behavior when only one side is long",
+                value = "A much longer value that should wrap onto multiple lines " +
+                    "to test alignment behavior when only one side is long",
                 layout = LemonadeContentListItemLayout.Horizontal,
                 showDivider = true,
                 verticalAlignment = Alignment.Top,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -49,7 +49,6 @@ import com.teya.lemonade.core.SymbolContainerVoice
  * @param contentSlot - Optional slot for additional content. In vertical layout, this also
  *   switches the value typography to bodyXLargeSemiBold.
  * @param verticalAlignment - Vertical alignment for horizontal layout (default [Alignment.CenterVertically]).
- * @param valueTextAlign - Text alignment for the value in horizontal layout (default [TextAlign.End]).
  */
 @Composable
 public fun LemonadeUi.ContentListItem(
@@ -59,7 +58,6 @@ public fun LemonadeUi.ContentListItem(
     modifier: Modifier = Modifier,
     showDivider: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    valueTextAlign: TextAlign = TextAlign.End,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -73,7 +71,6 @@ public fun LemonadeUi.ContentListItem(
                 value = value,
                 modifier = contentModifier,
                 verticalAlignment = verticalAlignment,
-                valueTextAlign = valueTextAlign,
                 leadingSlot = leadingSlot,
                 trailingSlot = trailingSlot,
                 contentSlot = contentSlot,
@@ -103,7 +100,6 @@ private fun HorizontalContentListItem(
     value: String,
     modifier: Modifier = Modifier,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    valueTextAlign: TextAlign = TextAlign.End,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -140,7 +136,7 @@ private fun HorizontalContentListItem(
                 text = value,
                 textStyle = LocalTypographies.current.bodyMediumMedium,
                 color = LocalColors.current.content.contentPrimary,
-                textAlign = valueTextAlign,
+                textAlign = TextAlign.End,
                 modifier = Modifier.weight(weight = 1f),
             )
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -49,7 +49,7 @@ import com.teya.lemonade.core.SymbolContainerVoice
  * @param contentSlot - Optional slot for additional content. In vertical layout, this also
  *   switches the value typography to bodyXLargeSemiBold.
  * @param verticalAlignment - Vertical alignment for horizontal layout (default [Alignment.CenterVertically]).
- * @param valueTextAlign - Text alignment for the value in horizontal layout (default [TextAlign.Right]).
+ * @param valueTextAlign - Text alignment for the value in horizontal layout (default [TextAlign.End]).
  */
 @Composable
 public fun LemonadeUi.ContentListItem(
@@ -59,7 +59,7 @@ public fun LemonadeUi.ContentListItem(
     modifier: Modifier = Modifier,
     showDivider: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    valueTextAlign: TextAlign = TextAlign.Right,
+    valueTextAlign: TextAlign = TextAlign.End,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -103,7 +103,7 @@ private fun HorizontalContentListItem(
     value: String,
     modifier: Modifier = Modifier,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    valueTextAlign: TextAlign = TextAlign.Right,
+    valueTextAlign: TextAlign = TextAlign.End,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -141,6 +141,7 @@ private fun HorizontalContentListItem(
                 textStyle = LocalTypographies.current.bodyMediumMedium,
                 color = LocalColors.current.content.contentPrimary,
                 textAlign = valueTextAlign,
+                modifier = Modifier.weight(weight = 1f),
             )
 
             if (trailingSlot != null) {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -48,6 +48,8 @@ import com.teya.lemonade.core.SymbolContainerVoice
  * @param trailingSlot - Optional slot for a trailing element (e.g. icon action).
  * @param contentSlot - Optional slot for additional content. In vertical layout, this also
  *   switches the value typography to bodyXLargeSemiBold.
+ * @param verticalAlignment - Vertical alignment for horizontal layout (default [Alignment.CenterVertically]).
+ * @param valueTextAlign - Text alignment for the value in horizontal layout (default [TextAlign.Right]).
  */
 @Composable
 public fun LemonadeUi.ContentListItem(
@@ -56,6 +58,8 @@ public fun LemonadeUi.ContentListItem(
     layout: LemonadeContentListItemLayout = LemonadeContentListItemLayout.Horizontal,
     modifier: Modifier = Modifier,
     showDivider: Boolean = false,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    valueTextAlign: TextAlign = TextAlign.Right,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
@@ -68,6 +72,8 @@ public fun LemonadeUi.ContentListItem(
                 label = label,
                 value = value,
                 modifier = contentModifier,
+                verticalAlignment = verticalAlignment,
+                valueTextAlign = valueTextAlign,
                 leadingSlot = leadingSlot,
                 trailingSlot = trailingSlot,
                 contentSlot = contentSlot,
@@ -96,12 +102,14 @@ private fun HorizontalContentListItem(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    valueTextAlign: TextAlign = TextAlign.Right,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     contentSlot: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = verticalAlignment,
         horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
         modifier = modifier,
     ) {
@@ -126,12 +134,13 @@ private fun HorizontalContentListItem(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
+            modifier = Modifier.weight(weight = 1f),
         ) {
             LemonadeUi.Text(
                 text = value,
                 textStyle = LocalTypographies.current.bodyMediumMedium,
                 color = LocalColors.current.content.contentPrimary,
-                textAlign = TextAlign.Right,
+                textAlign = valueTextAlign,
             )
 
             if (trailingSlot != null) {

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -21,6 +21,31 @@ struct ContentListItemDisplayView: View {
                     )
                 }
 
+                // MARK: - Horizontal Simple (Long Text)
+                LemonadeUi.Card(
+                    header: CardHeaderConfig(title: "Horizontal Simple — Long Text")
+                ) {
+                    LemonadeUi.ContentListItem(
+                        label: "Terms and conditions agreement for the account holder regarding international transfers and currency exchange policies",
+                        value: "This value is intentionally very long to demonstrate how the horizontal simple layout handles multi-line text wrapping across several lines in a constrained width",
+                        showDivider: true
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Short label",
+                        value: "A much longer value that should wrap onto multiple lines to test alignment behavior when only one side is long",
+                        showDivider: true,
+                        verticalAlignment: .top,
+                        valueAlignment: .leading
+                    )
+
+                    LemonadeUi.ContentListItem(
+                        label: "Address",
+                        value: "Westminster, London SW1A 2HQ, United Kingdom",
+                        verticalAlignment: .top
+                    )
+                }
+
                 // MARK: - Horizontal with Leading + Trailing
                 LemonadeUi.Card(
                     header: CardHeaderConfig(title: "Horizontal with Leading + Trailing")

--- a/swiftui/SampleApp/ContentListItemDisplayView.swift
+++ b/swiftui/SampleApp/ContentListItemDisplayView.swift
@@ -35,8 +35,7 @@ struct ContentListItemDisplayView: View {
                         label: "Short label",
                         value: "A much longer value that should wrap onto multiple lines to test alignment behavior when only one side is long",
                         showDivider: true,
-                        verticalAlignment: .top,
-                        valueAlignment: .leading
+                        verticalAlignment: .top
                     )
 
                     LemonadeUi.ContentListItem(

--- a/swiftui/SampleApp/DividerDisplayView.swift
+++ b/swiftui/SampleApp/DividerDisplayView.swift
@@ -60,11 +60,30 @@ struct DividerDisplayView: View {
 
                         VStack(alignment: .leading, spacing: .space.spacing200) {
                             LemonadeUi.Text(
+                                "Label with preposition",
+                                textStyle: LemonadeTypography.shared.bodySmallRegular,
+                                color: .content.contentSecondary
+                            )
+                            LemonadeUi.HorizontalDivider(label: "Or use a saved address")
+                        }
+
+                        VStack(alignment: .leading, spacing: .space.spacing200) {
+                            LemonadeUi.Text(
                                 "Narrow Container",
                                 textStyle: LemonadeTypography.shared.bodySmallRegular,
                                 color: .content.contentSecondary
                             )
                             LemonadeUi.HorizontalDivider(label: "Are you already at a PayPoint?")
+                                .frame(width: 200)
+                        }
+
+                        VStack(alignment: .leading, spacing: .space.spacing200) {
+                            LemonadeUi.Text(
+                                "Label with preposition — narrow container",
+                                textStyle: LemonadeTypography.shared.bodySmallRegular,
+                                color: .content.contentSecondary
+                            )
+                            LemonadeUi.HorizontalDivider(label: "Or use a saved address")
                                 .frame(width: 200)
                         }
                     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
@@ -42,12 +42,16 @@ public extension LemonadeUi {
     ///   - leadingSlot: Optional leading element (e.g. SymbolContainer)
     ///   - trailingSlot: Optional trailing element (e.g. icon action)
     ///   - contentSlot: Optional additional content. In vertical layout, switches value to larger typography
+    ///   - verticalAlignment: Vertical alignment for horizontal layout (default `.center`)
+    ///   - valueAlignment: Text alignment for the value in horizontal layout (default `.trailing`)
     @ViewBuilder
     static func ContentListItem<Leading: View, Trailing: View, Content: View>(
         label: String,
         value: String,
         layout: LemonadeContentListItemLayout = .horizontal,
         showDivider: Bool = false,
+        verticalAlignment: VerticalAlignment = .center,
+        valueAlignment: TextAlignment = .trailing,
         @ViewBuilder leadingSlot: @escaping () -> Leading = { EmptyView() },
         @ViewBuilder trailingSlot: @escaping () -> Trailing = { EmptyView() },
         @ViewBuilder contentSlot: @escaping () -> Content = { EmptyView() }
@@ -57,6 +61,8 @@ public extension LemonadeUi {
             value: value,
             layout: layout,
             showDivider: showDivider,
+            verticalAlignment: verticalAlignment,
+            valueAlignment: valueAlignment,
             leadingSlot: leadingSlot,
             trailingSlot: trailingSlot,
             contentSlot: contentSlot
@@ -71,6 +77,8 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
     let value: String
     let layout: LemonadeContentListItemLayout
     let showDivider: Bool
+    let verticalAlignment: VerticalAlignment
+    let valueAlignment: TextAlignment
     @ViewBuilder let leadingSlot: () -> Leading
     @ViewBuilder let trailingSlot: () -> Trailing
     @ViewBuilder let contentSlot: () -> Content
@@ -107,7 +115,7 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
     }
 
     private var horizontalLayout: some View {
-        HStack(alignment: .center, spacing: LemonadeTheme.spaces.spacing300) {
+        HStack(alignment: verticalAlignment, spacing: LemonadeTheme.spaces.spacing300) {
             if hasLeadingSlot {
                 leadingSlot()
             }
@@ -129,9 +137,9 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
                 LemonadeUi.Text(
                     value,
                     textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                    textAlign: valueAlignment,
                     color: LemonadeTheme.colors.content.contentPrimary
                 )
-                .multilineTextAlignment(.trailing)
 
                 if hasTrailingSlot {
                     trailingSlot()

--- a/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeContentListItem.swift
@@ -43,7 +43,6 @@ public extension LemonadeUi {
     ///   - trailingSlot: Optional trailing element (e.g. icon action)
     ///   - contentSlot: Optional additional content. In vertical layout, switches value to larger typography
     ///   - verticalAlignment: Vertical alignment for horizontal layout (default `.center`)
-    ///   - valueAlignment: Text alignment for the value in horizontal layout (default `.trailing`)
     @ViewBuilder
     static func ContentListItem<Leading: View, Trailing: View, Content: View>(
         label: String,
@@ -51,7 +50,6 @@ public extension LemonadeUi {
         layout: LemonadeContentListItemLayout = .horizontal,
         showDivider: Bool = false,
         verticalAlignment: VerticalAlignment = .center,
-        valueAlignment: TextAlignment = .trailing,
         @ViewBuilder leadingSlot: @escaping () -> Leading = { EmptyView() },
         @ViewBuilder trailingSlot: @escaping () -> Trailing = { EmptyView() },
         @ViewBuilder contentSlot: @escaping () -> Content = { EmptyView() }
@@ -62,7 +60,6 @@ public extension LemonadeUi {
             layout: layout,
             showDivider: showDivider,
             verticalAlignment: verticalAlignment,
-            valueAlignment: valueAlignment,
             leadingSlot: leadingSlot,
             trailingSlot: trailingSlot,
             contentSlot: contentSlot
@@ -78,7 +75,6 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
     let layout: LemonadeContentListItemLayout
     let showDivider: Bool
     let verticalAlignment: VerticalAlignment
-    let valueAlignment: TextAlignment
     @ViewBuilder let leadingSlot: () -> Leading
     @ViewBuilder let trailingSlot: () -> Trailing
     @ViewBuilder let contentSlot: () -> Content
@@ -137,7 +133,7 @@ private struct LemonadeContentListItemView<Leading: View, Trailing: View, Conten
                 LemonadeUi.Text(
                     value,
                     textStyle: LemonadeTypography.shared.bodyMediumMedium,
-                    textAlign: valueAlignment,
+                    textAlign: .trailing,
                     color: LemonadeTheme.colors.content.contentPrimary
                 )
 


### PR DESCRIPTION
## Summary
- Add `verticalAlignment` parameter to `ContentListItem` horizontal layout on **SwiftUI** and **KMP**
- Fix KMP layout bug where long value text crushed the label column to one character wide (added `weight(1f)` to value row)
- Add long text samples to both SwiftUI and KMP sample apps to demonstrate multi-line wrapping behavior

## Screenshots

| Platform | Before | After |
|----------|--------|-------|
| **Android** | <img width="300" alt="android-before-1" src="https://github.com/user-attachments/assets/0eaf707d-ff69-45ca-b63c-795fa19a5520" /> | <img width="300" alt="android-after-1" src="https://github.com/user-attachments/assets/be939645-4331-4a48-8a1e-f2d5f182d27e" /> |
| **iOS** | <img width="300" alt="ios-before-1" src="https://github.com/user-attachments/assets/c02c550e-2866-4b12-8bdc-0a925b3aec4c" /> | <img width="300" alt="ios-after-1" src="https://github.com/user-attachments/assets/5bf41840-da60-4f94-b9f5-6f756212b2bd" /> |

## Test plan
- [ ] Verify short label/value pairs still render correctly (no regression)
- [ ] Verify long text wraps properly with default center alignment
- [ ] Verify `verticalAlignment: .top` / `Alignment.Top` aligns label to top when value wraps
- [ ] Verify value text is always right-aligned in horizontal layout
- [ ] Test on both iOS simulator and Android emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)