### PR TITLE
[LDS] List Item top label

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
@@ -79,6 +79,59 @@ internal fun ActionListItemDisplay() {
             )
         }
 
+        // ActionListItem - Top Label
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "ActionListItem - Top Label"),
+        ) {
+            LemonadeUi.ActionListItem(
+                label = "Notifications",
+                topLabel = "Account",
+                showNavigationIndicator = true,
+                onItemClicked = {},
+                showDivider = true,
+                leadingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.Bell,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                    )
+                },
+            )
+
+            LemonadeUi.ActionListItem(
+                label = "Two-factor auth",
+                topLabel = "Security",
+                supportText = "Recommended",
+                showNavigationIndicator = true,
+                onItemClicked = {},
+                showDivider = true,
+                leadingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.Padlock,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                    )
+                },
+            )
+
+            LemonadeUi.ActionListItem(
+                label = "What's new",
+                topLabel = "Release notes",
+                onItemClicked = {},
+                showDivider = false,
+                leadingSlot = {
+                    LemonadeUi.Icon(
+                        icon = LemonadeIcons.Sparkles,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                    )
+                },
+                trailingSlot = {
+                    LemonadeUi.Tag(label = "New", voice = TagVoice.Positive)
+                },
+            )
+        }
+
         // ActionListItem - Trailing Alignment
         LemonadeUi.Card(
             header = CardHeaderConfig(title = "ActionListItem - Trailing Alignment"),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -181,6 +181,7 @@ public fun LemonadeUi.ActionListItem(
 ) {
     LemonadeUi.ListItem(
         label = label,
+        topLabel = topLabel,
         supportText = supportText,
         isLoading = isLoading,
         leadingSlot = leadingSlot,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -144,6 +144,7 @@ public fun LemonadeUi.ResourceListItem(
  * ```
  * @param label - label [String] to be displayed in the list item.
  * @param modifier - [Modifier] to be applied to the base container of component.
+ * @param topLabel - Optional label [String] displayed above the [label].
  * @param supportText - text [String] to be displayed as Support Text.
  * @param leadingSlot - slot content to be placed in the leading position of the component.
  * @param trailingSlot - slot content to be placed in the trailing position of the component.
@@ -164,6 +165,7 @@ public fun LemonadeUi.ResourceListItem(
 public fun LemonadeUi.ActionListItem(
     label: String,
     modifier: Modifier = Modifier,
+    topLabel: String? = null,
     supportText: String? = null,
     leadingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
@@ -216,6 +218,7 @@ public fun LemonadeUi.ActionListItem(
  * and delegates to the content-slot variant of [ListItem].
  *
  * @param label - Label [String] to be displayed in the list item.
+ * @param topLabel - Optional label [String] displayed above the [label].
  * @param supportText - Optional support text [String] displayed below the [label].
  * @param leadingSlot - A slot to be placed in the leading position of the list item.
  * @param trailingSlot - A slot to be placed in the trailing position of the list item.
@@ -236,6 +239,7 @@ public fun LemonadeUi.ActionListItem(
 public fun LemonadeUi.ListItem(
     label: String,
     modifier: Modifier = Modifier,
+    topLabel: String? = null,
     supportText: String? = null,
     onListItemClick: (() -> Unit)? = null,
     voice: LemonadeListItemVoice = LemonadeListItemVoice.Neutral,
@@ -269,6 +273,14 @@ public fun LemonadeUi.ListItem(
             interactionSource = interactionSource,
             trailingVerticalAlignment = trailingVerticalAlignment,
             contentSlot = {
+                if (topLabel != null) {
+                    LemonadeUi.Text(
+                        text = topLabel,
+                        textStyle = LocalTypographies.current.bodySmallRegular,
+                        color = LocalColors.current.content.contentSecondary,
+                    )
+                }
+
                 LemonadeUi.Text(
                     text = label,
                     textStyle = LocalTypographies.current.bodyMediumMedium,
@@ -611,6 +623,7 @@ private fun ResourceListItemPreview(
 private data class ActionListItemPreviewData(
     val voice: Boolean,
     val enabled: Boolean,
+    val topLabel: Boolean,
     val supportText: Boolean,
     val trailingSlot: Boolean,
     val showNavigationIndicator: Boolean,
@@ -624,18 +637,21 @@ private class ActionListItemPreviewProvider :
         buildList {
             listOf(true, false).forEach { voice ->
                 listOf(true, false).forEach { enabled ->
-                    listOf(true, false).forEach { withSupportText ->
-                        listOf(true, false).forEach { trailingSlot ->
-                            listOf(true, false).forEach { showNavigationIndicator ->
-                                add(
-                                    ActionListItemPreviewData(
-                                        voice = voice,
-                                        enabled = enabled,
-                                        supportText = withSupportText,
-                                        trailingSlot = trailingSlot,
-                                        showNavigationIndicator = showNavigationIndicator,
-                                    ),
-                                )
+                    listOf(true, false).forEach { topLabel ->
+                        listOf(true, false).forEach { withSupportText ->
+                            listOf(true, false).forEach { trailingSlot ->
+                                listOf(true, false).forEach { showNavigationIndicator ->
+                                    add(
+                                        ActionListItemPreviewData(
+                                            voice = voice,
+                                            enabled = enabled,
+                                            topLabel = topLabel,
+                                            supportText = withSupportText,
+                                            trailingSlot = trailingSlot,
+                                            showNavigationIndicator = showNavigationIndicator,
+                                        ),
+                                    )
+                                }
                             }
                         }
                     }
@@ -654,6 +670,7 @@ private fun ActionListItemPreview(
         label = "Label",
         showDivider = true,
         supportText = "Support Text".takeIf { previewData.supportText },
+        topLabel = "Top Label Text".takeIf { previewData.topLabel },
         enabled = previewData.enabled,
         voice = if (previewData.voice) LemonadeListItemVoice.Critical else LemonadeListItemVoice.Neutral,
         showNavigationIndicator = previewData.showNavigationIndicator,

--- a/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
@@ -19,6 +19,7 @@ public extension LemonadeUi {
     ///
     /// - Parameters:
     ///   - label: Label String to be displayed
+    ///   - topLabel: Optional label displayed above the main label
     ///   - supportText: Text to be displayed as supportText below the label
     ///   - voice: LemonadeListItemVoice to define tone of voice. Defaults to .neutral
     ///   - showNavigationIndicator: Indicates navigation visually
@@ -33,6 +34,7 @@ public extension LemonadeUi {
     @ViewBuilder
     static func ActionListItem<LeadingContent: View, TrailingContent: View>(
         label: String,
+        topLabel: String? = nil,
         supportText: String? = nil,
         voice: LemonadeListItemVoice = .neutral,
         showNavigationIndicator: Bool = false,
@@ -46,6 +48,7 @@ public extension LemonadeUi {
     ) -> some View {
         ListItem(
             label: label,
+            topLabel: topLabel,
             supportText: supportText,
             voice: voice,
             navigationIndicator: showNavigationIndicator,
@@ -66,6 +69,7 @@ public extension LemonadeUi {
     @ViewBuilder
     static func ActionListItem<LeadingContent: View>(
         label: String,
+        topLabel: String? = nil,
         supportText: String? = nil,
         voice: LemonadeListItemVoice = .neutral,
         showNavigationIndicator: Bool = false,
@@ -78,6 +82,7 @@ public extension LemonadeUi {
     ) -> some View {
         ActionListItem(
             label: label,
+            topLabel: topLabel,
             supportText: supportText,
             voice: voice,
             showNavigationIndicator: showNavigationIndicator,
@@ -95,6 +100,7 @@ public extension LemonadeUi {
     @ViewBuilder
     static func ActionListItem<TrailingContent: View>(
         label: String,
+        topLabel: String? = nil,
         supportText: String? = nil,
         voice: LemonadeListItemVoice = .neutral,
         showNavigationIndicator: Bool = false,
@@ -107,6 +113,7 @@ public extension LemonadeUi {
     ) -> some View {
         ActionListItem(
             label: label,
+            topLabel: topLabel,
             supportText: supportText,
             voice: voice,
             showNavigationIndicator: showNavigationIndicator,
@@ -124,6 +131,7 @@ public extension LemonadeUi {
     @ViewBuilder
     static func ActionListItem(
         label: String,
+        topLabel: String? = nil,
         supportText: String? = nil,
         voice: LemonadeListItemVoice = .neutral,
         showNavigationIndicator: Bool = false,
@@ -135,6 +143,7 @@ public extension LemonadeUi {
     ) -> some View {
         ActionListItem(
             label: label,
+            topLabel: topLabel,
             supportText: supportText,
             voice: voice,
             showNavigationIndicator: showNavigationIndicator,

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -54,6 +54,7 @@ public extension LemonadeUi {
     ///
     /// - Parameters:
     ///   - label: Label String to be displayed
+    ///   - topLabel: Optional label displayed above the main label
     ///   - supportText: Optional support text displayed below the label
     ///   - voice: LemonadeListItemVoice to define tone of voice
     ///   - navigationIndicator: Shows a chevron-right navigation indicator
@@ -68,6 +69,7 @@ public extension LemonadeUi {
     @ViewBuilder
     static func ListItem<LeadingContent: View, TrailingContent: View, SlotContent: View>(
         label: String,
+        topLabel: String? = nil,
         supportText: String? = nil,
         voice: LemonadeListItemVoice = .neutral,
         navigationIndicator: Bool = false,
@@ -93,6 +95,14 @@ public extension LemonadeUi {
                 leadingSlot: leadingSlot,
                 trailingSlot: trailingSlot,
                 contentSlot: {
+                    if let topLabel = topLabel {
+                        LemonadeUi.Text(
+                            topLabel,
+                            textStyle: LemonadeTypography.shared.bodySmallRegular,
+                            color: LemonadeTheme.colors.content.contentSecondary
+                        )
+                    }
+
                     LemonadeUi.Text(
                         label,
                         textStyle: LemonadeTypography.shared.bodyMediumMedium,


### PR DESCRIPTION
## Summary

Adds an optional `topLabel` parameter to the list-item components on both platforms. The top label renders directly above the main label using the secondary content color and `bodySmallRegular` typography, providing a small caption for grouping or contextual hints (e.g. category, section, status).

## What's exposed

**KMP (Compose)** — `kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt`
- `LemonadeUi.ListItem(label, topLabel = null, supportText = null, ...)`
- `LemonadeUi.ActionListItem(label, topLabel = null, supportText = null, ...)`

**SwiftUI** — `swiftui/Sources/Lemonade/Components/`
- `LemonadeUi.ListItem(label:topLabel:supportText:...)`
- `LemonadeUi.ActionListItem(...)` — all four overloads (with/without leading and trailing slots)

When `topLabel` is `nil` / `null`, the rendered output is unchanged from before.

## Visual treatment

<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/7f39b6fa-fad8-400d-8661-5ba1e3d7a236" />

## Sample app

Adds a new **"ActionListItem - Top Label"** card on the Android \`ActionListItemDisplay\` screen with three variants:
- \`topLabel\` only
- \`topLabel\` + \`supportText\`
- \`topLabel\` + \`trailingSlot\` (Tag)

## Test plan

- [ ] KMP CI green (Detekt previously failed because the \`topLabel\` parameter was declared on \`ActionListItem\` but not forwarded — now fixed)
- [ ] Open Android sample app -> ActionListItem screen -> confirm the new "Top Label" card renders top label above main label with secondary color
- [ ] Verify existing \`ActionListItem\`/\`ListItem\` call sites that don't pass \`topLabel\` are visually unchanged
- [ ] iOS preview in \`LemonadeListItem.swift\` / \`LemonadeActionListItem.swift\` renders top label correctly