### PR TITLE
feat(swiftui): add .fullShape() modifier for LemonadeUi.Button

### DIFF
--- a/swiftui/SampleApp/ButtonDisplayView.swift
+++ b/swiftui/SampleApp/ButtonDisplayView.swift
@@ -103,22 +103,22 @@ struct ButtonDisplayView: View {
                     }
                 }
 
-                // Rounded Corner
-                sectionView(title: "Rounded Corner (.full)") {
+                // Full Shape (pill)
+                sectionView(title: "Full Shape (.fullShape())") {
                     VStack(spacing: 16) {
                         HStack(spacing: 12) {
                             LemonadeUi.Button(label: "XSmall", onClick: {}, size: .xSmall)
-                                .roundedCorner(.full)
+                                .fullShape()
                             LemonadeUi.Button(label: "Small", onClick: {}, size: .small)
-                                .roundedCorner(.full)
+                                .fullShape()
                             LemonadeUi.Button(label: "Medium", onClick: {}, size: .medium)
-                                .roundedCorner(.full)
+                                .fullShape()
                             LemonadeUi.Button(label: "Large", onClick: {}, size: .large)
-                                .roundedCorner(.full)
+                                .fullShape()
                         }
 
                         LemonadeUi.Button(label: "Pill with icon", onClick: {}, leadingIcon: .heart, variant: .secondary)
-                            .roundedCorner(.full)
+                            .fullShape()
                     }
                 }
             }

--- a/swiftui/SampleApp/ButtonDisplayView.swift
+++ b/swiftui/SampleApp/ButtonDisplayView.swift
@@ -102,6 +102,25 @@ struct ButtonDisplayView: View {
                         LemonadeUi.Button(label: "Loading", onClick: {}, variant: .critical, type: .solid, size: .medium, loading: true)
                     }
                 }
+
+                // Rounded Corner
+                sectionView(title: "Rounded Corner (.full)") {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            LemonadeUi.Button(label: "XSmall", onClick: {}, size: .xSmall)
+                                .roundedCorner(.full)
+                            LemonadeUi.Button(label: "Small", onClick: {}, size: .small)
+                                .roundedCorner(.full)
+                            LemonadeUi.Button(label: "Medium", onClick: {}, size: .medium)
+                                .roundedCorner(.full)
+                            LemonadeUi.Button(label: "Large", onClick: {}, size: .large)
+                                .roundedCorner(.full)
+                        }
+
+                        LemonadeUi.Button(label: "Pill with icon", onClick: {}, leadingIcon: .heart, variant: .secondary)
+                            .roundedCorner(.full)
+                    }
+                }
             }
             .padding()
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -366,7 +366,7 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
     private var cornerRadius: CGFloat {
         switch cornerRadiusOverride {
         case .full: return LemonadeTheme.radius.radiusFull
-        case .none: return size.contentData.cornerRadius
+        case .default, .none: return size.contentData.cornerRadius
         }
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -360,14 +360,11 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
     let leadingSlot: ((LemonadeButtonColors) -> LeadingSlot)?
     let trailingSlot: ((LemonadeButtonColors) -> TrailingSlot)?
 
-    @Environment(\.lemonadeButtonCornerRadius) private var cornerRadiusOverride
+    @Environment(\.lemonadeButtonFullShape) private var isFullShape
     @State private var isPressed = false
 
     private var cornerRadius: CGFloat {
-        switch cornerRadiusOverride {
-        case .full: return LemonadeTheme.radius.radiusFull
-        case .default, .none: return size.contentData.cornerRadius
-        }
+        isFullShape ? LemonadeTheme.radius.radiusFull : size.contentData.cornerRadius
     }
 
     var body: some View {

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -360,10 +360,19 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
     let leadingSlot: ((LemonadeButtonColors) -> LeadingSlot)?
     let trailingSlot: ((LemonadeButtonColors) -> TrailingSlot)?
 
+    @Environment(\.lemonadeButtonCornerRadius) private var cornerRadiusOverride
     @State private var isPressed = false
+
+    private var cornerRadius: CGFloat {
+        switch cornerRadiusOverride {
+        case .full: return LemonadeTheme.radius.radiusFull
+        case .none: return size.contentData.cornerRadius
+        }
+    }
 
     var body: some View {
         let colors = resolveButtonColors(variant: variant, type: type)
+        let buttonShape = RoundedRectangle(cornerRadius: cornerRadius)
 
         SwiftUI.Button(action: onClick) {
             HStack(spacing: 0) {
@@ -388,11 +397,8 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
             }
             .frame(height: size.contentData.requiredHeight)
             .frame(minWidth: size.contentData.minWidth)
-            .background(
-                RoundedRectangle(cornerRadius: size.contentData.cornerRadius)
-                    .fill(colors.backgroundColor)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: size.contentData.cornerRadius))
+            .background(buttonShape.fill(colors.backgroundColor))
+            .clipShape(buttonShape)
         }
         .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
         .opacity(isPressed ? 1.0 - LemonadeTheme.opacity.state.opacityPressed : LemonadeTheme.opacity.base.opacity100)

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+// MARK: - Button Corner Radius
+
+/// Corner radius style for `LemonadeUi.Button`.
+///
+/// Use with the ``SwiftUICore/View/roundedCorner(_:)`` modifier to override the
+/// per-size corner radius applied by the button. This mirrors the Compose API
+/// `Modifier.clip(Shape.Full)` available on Android.
+public enum LemonadeButtonCornerRadius: Sendable, Hashable {
+    /// Pill shape — corners are clipped to a full half-height radius.
+    case full
+}
+
+// MARK: - Environment
+
+private struct LemonadeButtonCornerRadiusKey: EnvironmentKey {
+    static let defaultValue: LemonadeButtonCornerRadius? = nil
+}
+
+extension EnvironmentValues {
+    var lemonadeButtonCornerRadius: LemonadeButtonCornerRadius? {
+        get { self[LemonadeButtonCornerRadiusKey.self] }
+        set { self[LemonadeButtonCornerRadiusKey.self] = newValue }
+    }
+}
+
+// MARK: - View Modifier
+
+public extension View {
+    /// Overrides the corner radius applied by `LemonadeUi.Button` views in this
+    /// hierarchy. No effect on other views.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.Button(label: "Pill", onClick: { })
+    ///     .roundedCorner(.full)
+    /// ```
+    func roundedCorner(_ radius: LemonadeButtonCornerRadius) -> some View {
+        environment(\.lemonadeButtonCornerRadius, radius)
+    }
+}

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
@@ -1,45 +1,34 @@
 import SwiftUI
 
-// MARK: - Button Corner Radius
-
-/// Corner radius style for `LemonadeUi.Button`.
-///
-/// Use with the `roundedCorner(_:)` modifier to override the per-size corner
-/// radius applied by the button. This mirrors the Compose API
-/// `Modifier.clip(Shape.Full)` available on Android.
-public enum LemonadeButtonCornerRadius: Sendable, Hashable {
-    /// Use the per-size default corner radius.
-    /// Useful for resetting an override applied higher up in the view hierarchy.
-    case `default`
-    /// Pill shape — corners are clipped to a full half-height radius.
-    case full
-}
-
 // MARK: - Environment
 
-private struct LemonadeButtonCornerRadiusKey: EnvironmentKey {
-    static let defaultValue: LemonadeButtonCornerRadius? = nil
+private struct LemonadeButtonFullShapeKey: EnvironmentKey {
+    static let defaultValue: Bool = false
 }
 
 extension EnvironmentValues {
-    var lemonadeButtonCornerRadius: LemonadeButtonCornerRadius? {
-        get { self[LemonadeButtonCornerRadiusKey.self] }
-        set { self[LemonadeButtonCornerRadiusKey.self] = newValue }
+    var lemonadeButtonFullShape: Bool {
+        get { self[LemonadeButtonFullShapeKey.self] }
+        set { self[LemonadeButtonFullShapeKey.self] = newValue }
     }
 }
 
 // MARK: - View Modifier
 
 public extension View {
-    /// Overrides the corner radius applied by `LemonadeUi.Button` views in this
-    /// hierarchy. No effect on other views.
+    /// Renders `LemonadeUi.Button` views in this hierarchy with a pill (full
+    /// corner radius) shape. Has no effect on other views.
+    ///
+    /// Mirrors the Compose API `Modifier.clip(Shape.Full)` available on Android.
+    /// Pass `false` to opt back into the per-size default radius after the
+    /// modifier has been applied higher up the hierarchy.
     ///
     /// ## Usage
     /// ```swift
     /// LemonadeUi.Button(label: "Pill", onClick: { })
-    ///     .roundedCorner(.full)
+    ///     .fullShape()
     /// ```
-    func roundedCorner(_ radius: LemonadeButtonCornerRadius) -> some View {
-        environment(\.lemonadeButtonCornerRadius, radius)
+    func fullShape(_ enabled: Bool = true) -> some View {
+        environment(\.lemonadeButtonFullShape, enabled)
     }
 }

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeButtonShape.swift
@@ -4,10 +4,13 @@ import SwiftUI
 
 /// Corner radius style for `LemonadeUi.Button`.
 ///
-/// Use with the ``SwiftUICore/View/roundedCorner(_:)`` modifier to override the
-/// per-size corner radius applied by the button. This mirrors the Compose API
+/// Use with the `roundedCorner(_:)` modifier to override the per-size corner
+/// radius applied by the button. This mirrors the Compose API
 /// `Modifier.clip(Shape.Full)` available on Android.
 public enum LemonadeButtonCornerRadius: Sendable, Hashable {
+    /// Use the per-size default corner radius.
+    /// Useful for resetting an override applied higher up in the view hierarchy.
+    case `default`
     /// Pill shape — corners are clipped to a full half-height radius.
     case full
 }


### PR DESCRIPTION
## Summary
- Adds an opt-in `.fullShape()` view modifier for `LemonadeUi.Button`, mirroring Compose's `Modifier.clip(Shape.Full)` available on Android.
- Implemented via an `EnvironmentKey` (`lemonadeButtonFullShape`) so it composes like SwiftUI's `.tint` / `.controlSize` — applies to a single button or a whole subtree.
- API follows the SwiftUI `.bold(_:)` / `.italic(_:)` precedent: `func fullShape(_ enabled: Bool = true) -> some View`. Pass `false` to opt back into the per-size default radius after applying it higher in the hierarchy.
- No behavior change when the modifier is **not** used: env value defaults to `false` and `LemonadeCoreButtonView` falls back to the existing per-size default radius.
- The pill radius resolves to `LemonadeTheme.radius.radiusFull` (the existing design token, value `999`).
- Demo section "Full Shape (.fullShape())" added in `ButtonDisplayView` of the SampleApp.

### Usage
```swift
// default (per-size radius — unchanged):
LemonadeUi.Button(label: "Default", onClick: { })

// pill:
LemonadeUi.Button(label: "Pill", onClick: { })
    .fullShape()

// scoped — all buttons in subtree become pills:
VStack {
    LemonadeUi.Button(label: "A", onClick: { })
    LemonadeUi.Button(label: "B", onClick: { })
}
.fullShape()

// opt one button out of an inherited override:
VStack {
    LemonadeUi.Button(label: "Pill", onClick: { })
    LemonadeUi.Button(label: "Default", onClick: { })
        .fullShape(false)
}
.fullShape()
```

## Test plan
- [ ] Build SwiftUI package (`xcodebuild -scheme Lemonade …`) — passes locally with no new warnings.
- [ ] Run `LemonadeSampleApp` on iOS Simulator → Button screen → "Full Shape (.fullShape())" section renders pill-shaped buttons across all sizes.
- [ ] Verify existing button screens (Primary/Secondary/Neutral/Critical/Critical Solid) still render with the original per-size radius (no regression).
- [ ] Apply `.fullShape()` on a parent container and confirm all `LemonadeUi.Button` children inherit the pill shape; non-Button views are unaffected.
- [ ] Pass `.fullShape(false)` on a child of a `.fullShape()` subtree and confirm it reverts to the per-size default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)