### PR TITLE
fix(kmp, textfield): clip background to shape, keep cursor when placeholder shown

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -641,12 +641,12 @@ internal fun CoreTextFieldDecorator(
                         Modifier.requiredHeight(height = minHeight)
                     }
                         ?: Modifier,
-                ).clip(shape = size.data.containerShape)
-                .shadowBorder(
+                ).shadowBorder(
                     width = focusShadowBorderWidth,
                     shape = size.data.containerShape,
                     color = LocalColors.current.background.bgElevated,
-                ).border(
+                ).clip(shape = size.data.containerShape)
+                .border(
                     color = animatedBorderColor,
                     width = LocalBorderWidths.current.base.border25,
                     shape = size.data.containerShape,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -743,18 +743,15 @@ internal fun BoxScope.DefaultTextFieldWithSelector(
                     vertical = size.data.verticalPadding,
                 ),
         ) {
-            if (showPlaceholder && placeholderText != null) {
-                LemonadeUi.Text(
-                    text = placeholderText,
-                    textStyle = size.data.contentStyle,
-                    color = LocalColors.current.content.contentSecondary,
-                    modifier = Modifier.weight(weight = 1f),
-                )
-            } else {
-                Box(
-                    content = { innerTextField() },
-                    modifier = Modifier.weight(weight = 1f),
-                )
+            Box(modifier = Modifier.weight(weight = 1f)) {
+                if (showPlaceholder && placeholderText != null) {
+                    LemonadeUi.Text(
+                        text = placeholderText,
+                        textStyle = size.data.contentStyle,
+                        color = LocalColors.current.content.contentSecondary,
+                    )
+                }
+                innerTextField()
             }
 
             if (trailingContent != null) {
@@ -789,18 +786,15 @@ internal fun BoxScope.DefaultTextBox(
             leadingContent()
         }
 
-        if (showPlaceholder && placeholderText != null) {
-            LemonadeUi.Text(
-                text = placeholderText,
-                textStyle = size.data.contentStyle,
-                color = LocalColors.current.content.contentSecondary,
-                modifier = Modifier.weight(weight = 1f),
-            )
-        } else {
-            Box(
-                content = { innerTextField() },
-                modifier = Modifier.weight(weight = 1f),
-            )
+        Box(modifier = Modifier.weight(weight = 1f)) {
+            if (showPlaceholder && placeholderText != null) {
+                LemonadeUi.Text(
+                    text = placeholderText,
+                    textStyle = size.data.contentStyle,
+                    color = LocalColors.current.content.contentSecondary,
+                )
+            }
+            innerTextField()
         }
 
         if (trailingContent != null) {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextRange
@@ -640,7 +641,8 @@ internal fun CoreTextFieldDecorator(
                         Modifier.requiredHeight(height = minHeight)
                     }
                         ?: Modifier,
-                ).shadowBorder(
+                ).clip(shape = size.data.containerShape)
+                .shadowBorder(
                     width = focusShadowBorderWidth,
                     shape = size.data.containerShape,
                     color = LocalColors.current.background.bgElevated,


### PR DESCRIPTION
## Summary

Two independent rendering bugs in the KMP `TextField`:

### 1. Background bleeds past rounded container
The `CoreTextFieldDecorator` `Modifier` chain applied `background` and `border` using `size.data.containerShape`, but never clipped the drawing region to that shape. The backgrounds painted as a square underneath the rounded container, so on rounded sizes the corners bled past the border.

**Fix:** insert `Modifier.clip(shape = size.data.containerShape)` before the shadow/border/background layers.

### 2. Cursor disappears when placeholder is shown
`DefaultTextFieldWithSelector` and `DefaultTextBox` used an exclusive `if/else`: when the input was empty and a `placeholderText` was provided, they replaced the `BasicTextField` decoration slot with the placeholder `Text`. Removing `innerTextField` from the layout tree also removes the `BasicTextField` caret, so users saw no cursor until they typed the first character.

**Fix:** wrap both in a `Box` so the placeholder renders behind a permanently mounted `innerTextField`. The placeholder still hides as soon as the input becomes non-empty, but the caret is always present.

## Test plan
- [ ] Visually verify rounded `TextField` sizes no longer show rectangular background bleed at the corners (default + focused + error states).
- [ ] Confirm shadow + border + background still render as expected on the new clipped surface.
- [ ] Open an empty `TextField` with a placeholder set — verify the blinking caret is visible at the start position alongside the placeholder text.
- [ ] Type a character — placeholder should hide, caret should track input as before.
- [ ] Repeat for both default `TextField` (uses `DefaultTextBox`) and the leading-action selector variant (uses `DefaultTextFieldWithSelector`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)