### PR TITLE
fix(swiftui): SegmentedControl hugs content with .fixedSize()

### DIFF
--- a/swiftui/SampleApp/SegmentedControlDisplayView.swift
+++ b/swiftui/SampleApp/SegmentedControlDisplayView.swift
@@ -8,10 +8,47 @@ struct SegmentedControlDisplayView: View {
     @State private var selectedTabMedium = 0
     @State private var selectedTabSmall = 0
     @State private var selectedTabIconOnly = 0
+    @State private var selectedTabHugContent = 0
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
+                // Hug content with .fixedSize() — for inline use alongside other content
+                sectionView(title: "Hug Content (.fixedSize)") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Standalone .fixedSize():")
+                            .font(.caption)
+                        LemonadeUi.SegmentedControl(
+                            properties: [
+                                .label("Week"),
+                                .label("Day"),
+                            ],
+                            selectedTab: selectedTabHugContent,
+                            size: .small,
+                            onTabSelected: { selectedTabHugContent = $0 }
+                        )
+                        .fixedSize()
+                        Text("In HStack with Spacer:")
+                            .font(.caption)
+                        HStack {
+                            Text("Total spent")
+                                .font(.title2)
+                                .bold()
+                            Spacer()
+                            LemonadeUi.SegmentedControl(
+                                properties: [
+                                    .label("Week"),
+                                    .label("Day"),
+                                ],
+                                selectedTab: selectedTabHugContent,
+                                size: .small,
+                                onTabSelected: { selectedTabHugContent = $0 }
+                            )
+                            .fixedSize()
+                        }
+                    }
+                }
+
                 // Large (default)
                 sectionView(title: "Large (Default)") {
                     VStack(spacing: 16) {

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -328,14 +328,15 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
         }
     }
 
-    // Forward intrinsic size so `.fixedSize()` callers hug content. Honor `proposal`
-    // when SwiftUI gives a concrete size so non-fixed-size callers still fill width.
+    // Honor finite proposals (parent VStack width) so non-fixed-size callers fill.
+    // Fall back to intrinsic for nil (`.fixedSize()`) and `.infinity` probes,
+    // so `.fixedSize()` callers hug content instead of collapsing to `buttonMinWidth`.
     @available(iOS 16.0, *)
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
         let intrinsic = uiView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         return CGSize(
-            width: proposal.width ?? intrinsic.width,
-            height: proposal.height ?? intrinsic.height
+            width: proposal.width.flatMap { $0.isFinite ? $0 : nil } ?? intrinsic.width,
+            height: proposal.height.flatMap { $0.isFinite ? $0 : nil } ?? intrinsic.height
         )
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -328,14 +328,14 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
         }
     }
 
-    // Forward UISegmentedControl's intrinsic size so `.fixedSize()` callers hug content.
+    // Forward intrinsic size so `.fixedSize()` callers hug content. Honor `proposal`
+    // when SwiftUI gives a concrete size so non-fixed-size callers still fill width.
     @available(iOS 16.0, *)
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
-        guard let control = context.coordinator.control else { return nil }
-        let intrinsic = control.intrinsicContentSize
+        let intrinsic = uiView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         return CGSize(
-            width: intrinsic.width + containerPadding * 2,
-            height: intrinsic.height + containerPadding * 2
+            width: proposal.width ?? intrinsic.width,
+            height: proposal.height ?? intrinsic.height
         )
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -328,6 +328,17 @@ private struct LemonadeNativeSegmentedControl: UIViewRepresentable {
         }
     }
 
+    // Forward UISegmentedControl's intrinsic size so `.fixedSize()` callers hug content.
+    @available(iOS 16.0, *)
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+        guard let control = context.coordinator.control else { return nil }
+        let intrinsic = control.intrinsicContentSize
+        return CGSize(
+            width: intrinsic.width + containerPadding * 2,
+            height: intrinsic.height + containerPadding * 2
+        )
+    }
+
     class Coordinator: NSObject {
         var onSelectionChanged: (Int) -> Void
         weak var control: UISegmentedControl?


### PR DESCRIPTION
## Summary

On iOS 26+, `LemonadeUi.SegmentedControl` uses `LemonadeNativeSegmentedControl` (a `UIViewRepresentable` wrapping `UISegmentedControl`) for Liquid Glass styling. That representable did not propagate `intrinsicContentSize` to SwiftUI, so callers using `.fixedSize()` collapsed to the outer 32pt `buttonMinWidth` instead of hugging their segment labels (e.g. `Week | Day` rendered as `We... Day`).

This blocked inline patterns like `HStack { Text("Total spent"); Spacer(); SegmentedControl().fixedSize() }` — the typical "section header + filter" layout used by the Card Spend widget in the Teya app.

## Fix

Implement `sizeThatFits(_:uiView:context:)` on the `UIViewRepresentable`:
- Measure the container's intrinsic size via `systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)` — derives the size through Auto Layout from the embedded `UISegmentedControl` + `containerPadding` constraints, no coordinator state dependency.
- Honor finite `proposal.width` / `proposal.height` so non-`.fixedSize()` callers still fill the proposed width.
- Fall back to intrinsic for `nil` (`.fixedSize()`) and `.infinity` (unbounded probes) proposals.

Sample app gains a "Hug Content (.fixedSize)" section demonstrating both standalone and HStack-with-Spacer use cases.

## Before / After

| Before (main) | After (this PR) |
| :---: | :---: |
| <img src="https://github.com/saltpay/lemonade-design-system/raw/91dde4635847a1bda8c78594496bd7746c4be800/.screenshots/before.png" width="300" /> | <img src="https://github.com/saltpay/lemonade-design-system/raw/91dde4635847a1bda8c78594496bd7746c4be800/.screenshots/after.png" width="300" /> |
| `Week \| Day` collapses, "Week" truncates to `We...` | `Week \| Day` hugs content; full-width variants (Large/Medium/Small/Icons) unchanged |

### Full-width still works (Light/Dark control on HomeView, no `.fixedSize()`)

<img src="https://github.com/saltpay/lemonade-design-system/raw/91dde4635847a1bda8c78594496bd7746c4be800/.screenshots/home-fullwidth.png" width="300" />

## Test plan
- [x] DS sample app builds and runs on iOS 26 simulator
- [x] `Week | Day` renders without truncation in both standalone `.fixedSize()` and `HStack { Text; Spacer; …fixedSize() }` layouts
- [x] Large / Medium / Small / With Icons sections still render full-width with the container pill background visible (matches main behavior)
- [x] Light/Dark control on HomeView (no `.fixedSize()`) still renders full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)