### PR TITLE
feat(bottomsheet): add background variant (Default/Subtle) [KMP]

### DIFF
--- a/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/BottomSheetDisplay.kt
+++ b/kmp/composeApp/src/mobileMain/kotlin/com/teya/lemonade/BottomSheetDisplay.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.teya.lemonade.core.LemonadeBottomSheetVariant
 import com.teya.lemonade.core.LemonadeButtonSize
 import com.teya.lemonade.core.LemonadeButtonVariant
 
@@ -25,6 +26,7 @@ import com.teya.lemonade.core.LemonadeButtonVariant
 internal fun BottomSheetSampleDisplay() {
     var showBasicSheet by remember { mutableStateOf(false) }
     var showNoDragHandleSheet by remember { mutableStateOf(false) }
+    var showSubtleSheet by remember { mutableStateOf(false) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing600),
@@ -55,6 +57,21 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Open Without Drag Handle",
                 onClick = { showNoDragHandleSheet = true },
+                variant = LemonadeButtonVariant.Secondary,
+                size = LemonadeButtonSize.Medium,
+            )
+        }
+
+        // Subtle Background
+        BottomSheetSection(title = "Subtle Background") {
+            LemonadeUi.Text(
+                text = "This bottom sheet uses the Subtle background variant (bgSubtle)",
+                textStyle = LemonadeTheme.typography.bodySmallRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+            LemonadeUi.Button(
+                label = "Open Subtle Background",
+                onClick = { showSubtleSheet = true },
                 variant = LemonadeButtonVariant.Secondary,
                 size = LemonadeButtonSize.Medium,
             )
@@ -116,6 +133,38 @@ internal fun BottomSheetSampleDisplay() {
             LemonadeUi.Button(
                 label = "Close",
                 onClick = { showNoDragHandleSheet = false },
+                variant = LemonadeButtonVariant.Primary,
+                size = LemonadeButtonSize.Medium,
+            )
+            Spacer(
+                modifier = Modifier.height(LemonadeTheme.spaces.spacing400),
+            )
+        }
+    }
+
+    // Subtle Background
+    LemonadeUi.BottomSheet(
+        expanded = showSubtleSheet,
+        onDismissRequest = { showSubtleSheet = false },
+        background = LemonadeBottomSheetVariant.Subtle,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(LemonadeTheme.spaces.spacing400),
+        ) {
+            LemonadeUi.Text(
+                text = "Subtle Background",
+                textStyle = LemonadeTheme.typography.headingSmall,
+            )
+            LemonadeUi.Text(
+                text = "This bottom sheet uses the Subtle background variant, applying bgSubtle from the Lemonade tokens.",
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+            LemonadeUi.Button(
+                label = "Close",
+                onClick = { showSubtleSheet = false },
                 variant = LemonadeButtonVariant.Primary,
                 size = LemonadeButtonSize.Medium,
             )

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeBottomSheetVariant.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeBottomSheetVariant.kt
@@ -1,0 +1,16 @@
+package com.teya.lemonade.core
+
+/**
+ * Background variants available for `LemonadeUi.BottomSheet`.
+ */
+public enum class LemonadeBottomSheetVariant {
+    /**
+     * Default background, using `LemonadeTheme.colors.background.bgDefault`.
+     */
+    Default,
+
+    /**
+     * Subtle background, using `LemonadeTheme.colors.background.bgSubtle`.
+     */
+    Subtle,
+}

--- a/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
+++ b/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.teya.lemonade.core.LemonadeBottomSheetVariant
 
 /**
  * Android-specific [BottomSheet][LemonadeUi.BottomSheet] variant that can hide the system
@@ -31,6 +32,8 @@ import androidx.core.view.WindowInsetsControllerCompat
  * @param hideNavigationBar Whether to hide the system navigation bar in the dialog window.
  * @param showDragHandle Whether to display the drag handle at the top of the sheet.
  * @param skipPartiallyExpanded Whether the partially expanded state should be skipped.
+ * @param background The background variant of the bottom sheet. Defaults to
+ *   [LemonadeBottomSheetVariant.Default].
  * @param content A composable lambda with [ColumnScope] receiver that defines the sheet's content.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -41,6 +44,7 @@ public fun LemonadeUi.BottomSheet(
     hideNavigationBar: Boolean,
     showDragHandle: Boolean = true,
     skipPartiallyExpanded: Boolean = false,
+    background: LemonadeBottomSheetVariant = LemonadeBottomSheetVariant.Default,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     CoreBottomSheet(
@@ -48,6 +52,7 @@ public fun LemonadeUi.BottomSheet(
         onDismissRequest = onDismissRequest,
         showDragHandle = showDragHandle,
         skipPartiallyExpanded = skipPartiallyExpanded,
+        background = background,
         contentWindowInsets = if (hideNavigationBar) {
             { WindowInsets.statusBars }
         } else {

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomSheet.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
+import com.teya.lemonade.core.LemonadeBottomSheetVariant
 
 /**
  * A bottom sheet overlay following the Lemonade Design System.
@@ -31,6 +32,9 @@ import androidx.compose.ui.unit.dp
  * @param skipPartiallyExpanded Whether the partially expanded state should be skipped. If `true`,
  *   the bottom sheet will always expand to the full height, skipping the intermediate (half-expanded)
  *   state. Defaults to `false`.
+ * @param background The background variant of the bottom sheet. Defaults to
+ *   [LemonadeBottomSheetVariant.Default], which uses [LemonadeTheme.colors.background.bgDefault];
+ *   use [LemonadeBottomSheetVariant.Subtle] for [LemonadeTheme.colors.background.bgSubtle].
  * @param content A composable lambda with [ColumnScope] receiver that defines the sheet's content.
  *
  * ## Usage Example
@@ -57,7 +61,9 @@ import androidx.compose.ui.unit.dp
  * ## Design Notes
  *
  * - The sheet uses [LemonadeTheme.radius.radius500] for the top corners.
- * - Background color is [LemonadeTheme.colors.background.bgDefault].
+ * - Background color is resolved from [background]: [LemonadeBottomSheetVariant.Default] maps to
+ *   [LemonadeTheme.colors.background.bgDefault] and [LemonadeBottomSheetVariant.Subtle] maps to
+ *   [LemonadeTheme.colors.background.bgSubtle].
  * - Tonal elevation is set to 0.dp; the sheet relies on Lemonade color tokens for visual hierarchy.
  * - The drag handle uses the default [BottomSheetDefaults.DragHandle] styling.
  * - For overlay components with a unified visibility API, see also [LemonadeUi.Dialog] and
@@ -74,6 +80,7 @@ public fun LemonadeUi.BottomSheet(
     onDismissRequest: () -> Unit,
     showDragHandle: Boolean = true,
     skipPartiallyExpanded: Boolean = false,
+    background: LemonadeBottomSheetVariant = LemonadeBottomSheetVariant.Default,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     CoreBottomSheet(
@@ -81,6 +88,7 @@ public fun LemonadeUi.BottomSheet(
         onDismissRequest = onDismissRequest,
         showDragHandle = showDragHandle,
         skipPartiallyExpanded = skipPartiallyExpanded,
+        background = background,
         content = content,
     )
 }
@@ -92,6 +100,7 @@ internal fun CoreBottomSheet(
     onDismissRequest: () -> Unit,
     showDragHandle: Boolean = true,
     skipPartiallyExpanded: Boolean = false,
+    background: LemonadeBottomSheetVariant = LemonadeBottomSheetVariant.Default,
     contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -102,6 +111,11 @@ internal fun CoreBottomSheet(
         }
     }
 
+    val containerColor = when (background) {
+        LemonadeBottomSheetVariant.Default -> LemonadeTheme.colors.background.bgDefault
+        LemonadeBottomSheetVariant.Subtle -> LemonadeTheme.colors.background.bgSubtle
+    }
+
     if (expanded || sheetState.isVisible) {
         ModalBottomSheet(
             onDismissRequest = onDismissRequest,
@@ -110,7 +124,7 @@ internal fun CoreBottomSheet(
                 topStart = LemonadeTheme.radius.radius500,
                 topEnd = LemonadeTheme.radius.radius500,
             ),
-            containerColor = LemonadeTheme.colors.background.bgDefault,
+            containerColor = containerColor,
             tonalElevation = 0.dp,
             dragHandle = if (showDragHandle) {
                 { BottomSheetDefaults.DragHandle() }


### PR DESCRIPTION
## Summary
- Adds a new `LemonadeBottomSheetVariant` enum (`Default`, `Subtle`) in `:core`.
- `LemonadeUi.BottomSheet` (common + Android `hideNavigationBar` overload) now takes a `background: LemonadeBottomSheetVariant = Default` parameter. `Default` maps to `bgDefault`, `Subtle` maps to `bgSubtle`. Existing call-sites remain source-compatible.
- The composeApp BottomSheet sample gets a third *Subtle Background* section to demo the new variant.

## Screenshots
Captured on Android emulator (SP-2). Files are also on the author's `~/Desktop` (`bottomsheet-default.png`, `bottomsheet-no-handle.png`, `bottomsheet-subtle.png`) and will be attached inline below.

| Default | Without Drag Handle | Subtle |
|---|---|---|
| <img width="300" alt="bottomsheet-default" src="https://github.com/user-attachments/assets/d9442315-a36c-4a32-9f9c-7dc9a7837f9f" /> | <img width="300" alt="bottomsheet-no-handle" src="https://github.com/user-attachments/assets/85a68379-13fc-4f25-bd2b-05c4ec529c96" /> | <img width="300" alt="bottomsheet-subtle" src="https://github.com/user-attachments/assets/731f5ef7-f031-4854-bfa0-c63cfbd82330" /> |

## Test plan
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew detektMetadataCommonMain detektDesktopMain` passes
  - Note: pre-existing `detektAndroidDebug` failure in `HiddenNavBarBottomSheetSample.kt` from #177 is unrelated to this change
- [x] Manually verified on Android emulator: Default sheet renders `bgDefault`, Subtle sheet renders `bgSubtle` (visible difference in screenshots)