### PR TITLE
feat: update positive color tokens from Green to GreenLime palette

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeDarkTheme.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeDarkTheme.kt
@@ -24,13 +24,13 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
     override val interaction: LemonadeSemanticColors.InteractionColors =
         object : LemonadeSemanticColors.InteractionColors {
             override val bgNeutralSubtleInteractive = LemonadePrimitiveColors.Solid.Black.black200
-            override val bgPositiveSubtleInteractive = LemonadePrimitiveColors.Alpha.Green.alpha200
+            override val bgPositiveSubtleInteractive = LemonadePrimitiveColors.Alpha.GreenLime.alpha200
             override val bgInfoSubtleInteractive = LemonadePrimitiveColors.Alpha.Blue.alpha200
             override val bgNeutralInteractive = LemonadePrimitiveColors.Solid.Neutral.neutral700
             override val bgBrandHighInteractive = LemonadePrimitiveColors.Solid.YellowLime.yellowLime900
             override val bgDefaultInteractive = LemonadePrimitiveColors.Solid.Neutral.neutral50
             override val bgCautionInteractive = LemonadePrimitiveColors.Solid.Orange.orange500
-            override val bgPositiveInteractive = LemonadePrimitiveColors.Solid.Green.green500
+            override val bgPositiveInteractive = LemonadePrimitiveColors.Solid.GreenLime.greenLime500
             override val bgSubtleInteractive = LemonadePrimitiveColors.Alpha.Neutral.alpha100
             override val bgInfoInteractive = LemonadePrimitiveColors.Solid.Blue.blue500
             override val bgCautionSubtleInteractive = LemonadePrimitiveColors.Alpha.Orange.alpha200
@@ -51,7 +51,7 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
             override val bgCriticalSubtlePressed = LemonadePrimitiveColors.Alpha.Red.alpha300
             override val bgCautionSubtlePressed = LemonadePrimitiveColors.Alpha.Amber.alpha300
             override val bgInfoSubtlePressed = LemonadePrimitiveColors.Alpha.Blue.alpha300
-            override val bgPositiveSubtlePressed = LemonadePrimitiveColors.Alpha.Green.alpha300
+            override val bgPositiveSubtlePressed = LemonadePrimitiveColors.Alpha.GreenLime.alpha300
             override val bgNeutralSubtlePressed = LemonadePrimitiveColors.Solid.Black.black300
             override val bgElevatedHighInteractive = LemonadePrimitiveColors.Alpha.Neutral.alpha300
             override val bgBrandElevatedInteractive = LemonadePrimitiveColors.Solid.White.white500
@@ -64,11 +64,11 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
             override val borderNeutralMediumInverse = LemonadePrimitiveColors.Alpha.Neutral.alpha200
             override val borderNeutralLowInverse = LemonadePrimitiveColors.Alpha.Neutral.alpha100
             override val borderAlwaysDark = LemonadePrimitiveColors.Alpha.Neutral.alpha900
-            override val borderPositiveSubtle = LemonadePrimitiveColors.Alpha.Green.alpha400
-            override val borderInfoSubtle = LemonadePrimitiveColors.Alpha.Blue.alpha400
-            override val borderCautionSubtle = LemonadePrimitiveColors.Alpha.Orange.alpha400
-            override val borderCriticalSubtle = LemonadePrimitiveColors.Alpha.Red.alpha400
-            override val borderPositive = LemonadePrimitiveColors.Solid.Green.green400
+            override val borderPositiveSubtle = LemonadePrimitiveColors.Alpha.GreenLime.alpha300
+            override val borderInfoSubtle = LemonadePrimitiveColors.Alpha.Blue.alpha300
+            override val borderCautionSubtle = LemonadePrimitiveColors.Alpha.Orange.alpha300
+            override val borderCriticalSubtle = LemonadePrimitiveColors.Alpha.Red.alpha300
+            override val borderPositive = LemonadePrimitiveColors.Solid.GreenLime.greenLime400
             override val borderInfo = LemonadePrimitiveColors.Solid.Blue.blue400
             override val borderCaution = LemonadePrimitiveColors.Solid.Amber.amber400
             override val borderOnBrandMedium = LemonadePrimitiveColors.Solid.White.white600
@@ -99,7 +99,7 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
             override val contentAlwaysLight = LemonadePrimitiveColors.Solid.White.white950
             override val contentSecondary = LemonadePrimitiveColors.Solid.White.white600
             override val contentPrimaryInverse = LemonadePrimitiveColors.Alpha.Neutral.alpha900
-            override val contentPositive = LemonadePrimitiveColors.Solid.Green.green500
+            override val contentPositive = LemonadePrimitiveColors.Solid.GreenLime.greenLime500
             override val contentTertiaryInverse = LemonadePrimitiveColors.Alpha.Neutral.alpha500
             override val contentAlwaysDark = LemonadePrimitiveColors.Alpha.Neutral.alpha950
             override val contentNeutral = LemonadePrimitiveColors.Solid.White.white900
@@ -111,7 +111,7 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
             override val contentCriticalOnColor = LemonadePrimitiveColors.Solid.Red.red600
             override val contentCautionOnColor = LemonadePrimitiveColors.Solid.Amber.amber600
             override val contentInfoOnColor = LemonadePrimitiveColors.Solid.Blue.blue700
-            override val contentPositiveOnColor = LemonadePrimitiveColors.Solid.Green.green700
+            override val contentPositiveOnColor = LemonadePrimitiveColors.Solid.GreenLime.greenLime700
             override val contentNeutralOnColor = LemonadePrimitiveColors.Alpha.Neutral.alpha900
             override val contentBrandHigh = LemonadePrimitiveColors.Solid.YellowLime.yellowLime500
         }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeLightTheme.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeLightTheme.kt
@@ -24,13 +24,13 @@ public object LemonadeLightTheme : LemonadeSemanticColors {
     override val interaction: LemonadeSemanticColors.InteractionColors =
         object : LemonadeSemanticColors.InteractionColors {
             override val bgNeutralSubtleInteractive = LemonadePrimitiveColors.Solid.Black.black200
-            override val bgPositiveSubtleInteractive = LemonadePrimitiveColors.Alpha.Green.alpha200
+            override val bgPositiveSubtleInteractive = LemonadePrimitiveColors.Alpha.GreenLime.alpha200
             override val bgInfoSubtleInteractive = LemonadePrimitiveColors.Alpha.Blue.alpha200
             override val bgNeutralInteractive = LemonadePrimitiveColors.Solid.Neutral.neutral700
             override val bgBrandHighInteractive = LemonadePrimitiveColors.Solid.YellowLime.yellowLime900
             override val bgDefaultInteractive = LemonadePrimitiveColors.Solid.Neutral.neutral50
             override val bgCautionInteractive = LemonadePrimitiveColors.Solid.Orange.orange500
-            override val bgPositiveInteractive = LemonadePrimitiveColors.Solid.Green.green500
+            override val bgPositiveInteractive = LemonadePrimitiveColors.Solid.GreenLime.greenLime500
             override val bgSubtleInteractive = LemonadePrimitiveColors.Alpha.Neutral.alpha100
             override val bgInfoInteractive = LemonadePrimitiveColors.Solid.Blue.blue500
             override val bgCautionSubtleInteractive = LemonadePrimitiveColors.Alpha.Orange.alpha200
@@ -51,7 +51,7 @@ public object LemonadeLightTheme : LemonadeSemanticColors {
             override val bgCriticalSubtlePressed = LemonadePrimitiveColors.Alpha.Red.alpha300
             override val bgCautionSubtlePressed = LemonadePrimitiveColors.Alpha.Amber.alpha300
             override val bgInfoSubtlePressed = LemonadePrimitiveColors.Alpha.Blue.alpha300
-            override val bgPositiveSubtlePressed = LemonadePrimitiveColors.Alpha.Green.alpha300
+            override val bgPositiveSubtlePressed = LemonadePrimitiveColors.Alpha.GreenLime.alpha300
             override val bgNeutralSubtlePressed = LemonadePrimitiveColors.Solid.Black.black300
             override val bgElevatedHighInteractive = LemonadePrimitiveColors.Alpha.Neutral.alpha300
             override val bgBrandElevatedInteractive = LemonadePrimitiveColors.Solid.White.white500
@@ -64,11 +64,11 @@ public object LemonadeLightTheme : LemonadeSemanticColors {
             override val borderNeutralMediumInverse = LemonadePrimitiveColors.Solid.White.white300
             override val borderNeutralLowInverse = LemonadePrimitiveColors.Solid.White.white200
             override val borderAlwaysDark = LemonadePrimitiveColors.Alpha.Neutral.alpha900
-            override val borderPositiveSubtle = LemonadePrimitiveColors.Alpha.Green.alpha300
-            override val borderInfoSubtle = LemonadePrimitiveColors.Alpha.Blue.alpha300
-            override val borderCautionSubtle = LemonadePrimitiveColors.Alpha.Orange.alpha300
-            override val borderCriticalSubtle = LemonadePrimitiveColors.Alpha.Red.alpha300
-            override val borderPositive = LemonadePrimitiveColors.Solid.Green.green600
+            override val borderPositiveSubtle = LemonadePrimitiveColors.Alpha.GreenLime.alpha100
+            override val borderInfoSubtle = LemonadePrimitiveColors.Alpha.Blue.alpha100
+            override val borderCautionSubtle = LemonadePrimitiveColors.Alpha.Orange.alpha100
+            override val borderCriticalSubtle = LemonadePrimitiveColors.Alpha.Red.alpha100
+            override val borderPositive = LemonadePrimitiveColors.Solid.GreenLime.greenLime600
             override val borderInfo = LemonadePrimitiveColors.Solid.Blue.blue600
             override val borderCaution = LemonadePrimitiveColors.Solid.Amber.amber600
             override val borderOnBrandMedium = LemonadePrimitiveColors.Solid.White.white500
@@ -99,7 +99,7 @@ public object LemonadeLightTheme : LemonadeSemanticColors {
             override val contentAlwaysLight = LemonadePrimitiveColors.Solid.White.white950
             override val contentSecondary = LemonadePrimitiveColors.Alpha.Neutral.alpha500
             override val contentPrimaryInverse = LemonadePrimitiveColors.Solid.White.white950
-            override val contentPositive = LemonadePrimitiveColors.Solid.Green.green700
+            override val contentPositive = LemonadePrimitiveColors.Solid.GreenLime.greenLime700
             override val contentTertiaryInverse = LemonadePrimitiveColors.Solid.White.white700
             override val contentAlwaysDark = LemonadePrimitiveColors.Alpha.Neutral.alpha950
             override val contentNeutral = LemonadePrimitiveColors.Alpha.Neutral.alpha900
@@ -111,7 +111,7 @@ public object LemonadeLightTheme : LemonadeSemanticColors {
             override val contentCriticalOnColor = LemonadePrimitiveColors.Solid.Red.red400
             override val contentCautionOnColor = LemonadePrimitiveColors.Solid.Amber.amber400
             override val contentInfoOnColor = LemonadePrimitiveColors.Solid.Blue.blue400
-            override val contentPositiveOnColor = LemonadePrimitiveColors.Solid.Green.green400
+            override val contentPositiveOnColor = LemonadePrimitiveColors.Solid.GreenLime.greenLime400
             override val contentNeutralOnColor = LemonadePrimitiveColors.Solid.White.white800
             override val contentBrandHigh = LemonadePrimitiveColors.Solid.YellowLime.yellowLime900
         }

--- a/scripts/swiftui-color-assets-generator.main.kts
+++ b/scripts/swiftui-color-assets-generator.main.kts
@@ -250,7 +250,14 @@ fun generateColorShorthand(resources: List<ColorResource>): String {
                 else -> group.lowercase()
             }
             appendLine("    /// $group color tokens")
-            appendLine("    /// Usage: `.foregroundStyle(.$shorthandName.${if (group == "Content") "contentPrimary" else if (group == "Background") "bgDefault" else "borderNeutralMedium"})`")
+            val exampleToken = when (group) {
+                "Content" -> "contentPrimary"
+                "Background" -> "bgDefault"
+                "Border" -> "borderNeutralMedium"
+                "Shadow" -> "shadowDefault"
+                else -> "${shorthandName}Default"
+            }
+            appendLine("    /// Usage: `.foregroundStyle(.$shorthandName.$exampleToken)`")
             appendLine("    static var $shorthandName: Lemonade${group}ColorsShorthand { Lemonade${group}ColorsShorthand() }")
             appendLine()
         }

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-caution-subtle.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-caution-subtle.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.300",
+          "alpha" : "0.100",
           "blue" : "0.000",
           "green" : "0.411",
           "red" : "1.000"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
+          "alpha" : "0.300",
           "blue" : "0.000",
           "green" : "0.411",
           "red" : "1.000"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-critical-subtle.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-critical-subtle.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.300",
+          "alpha" : "0.100",
           "blue" : "0.282",
           "green" : "0.235",
           "red" : "0.969"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
+          "alpha" : "0.300",
           "blue" : "0.282",
           "green" : "0.235",
           "red" : "0.969"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-info-subtle.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-info-subtle.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.300",
+          "alpha" : "0.100",
           "blue" : "1.000",
           "green" : "0.498",
           "red" : "0.169"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
+          "alpha" : "0.300",
           "blue" : "1.000",
           "green" : "0.498",
           "red" : "0.169"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-positive-subtle.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-positive-subtle.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.300",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "alpha" : "0.100",
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "alpha" : "0.300",
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-positive.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-voice-border-positive.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.242",
-          "green" : "0.651",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.647",
+          "red" : "0.369"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.449",
-          "green" : "0.875",
-          "red" : "0.020"
+          "blue" : "0.000",
+          "green" : "0.902",
+          "red" : "0.602"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-content-voice-content-positive.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-content-voice-content-positive.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.210",
-          "green" : "0.510",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.492",
+          "red" : "0.285"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-content-voice-on color-content-positive-on-color.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-content-voice-on color-content-positive-on-color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.449",
-          "green" : "0.875",
-          "red" : "0.020"
+          "blue" : "0.000",
+          "green" : "0.902",
+          "red" : "0.602"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.210",
-          "green" : "0.510",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.492",
+          "red" : "0.285"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-interactive-background-bg-positive-interactive.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-interactive-background-bg-positive-interactive.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-interactive-background-bg-positive-subtle-interactive.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-interactive-background-bg-positive-subtle-interactive.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.200",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.200",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-pressed-background-bg-positive-subtle-pressed.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-interaction-pressed-background-bg-positive-subtle-pressed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.300",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.300",
-          "blue" : "0.316",
-          "green" : "0.787",
-          "red" : "0.000"
+          "blue" : "0.000",
+          "green" : "0.810",
+          "red" : "0.487"
         }
       },
       "idiom" : "universal"

--- a/tokens/theme-colors.json
+++ b/tokens/theme-colors.json
@@ -180,33 +180,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:94898b7cc1bd97ad6aa3503d1b34d63957fbcc26/76:383"
+          "id": "VariableID:cd519cce5202dd4608f48c522bd2274976028603/76:405"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:94898b7cc1bd97ad6aa3503d1b34d63957fbcc26/76:383"
+          "id": "VariableID:cd519cce5202dd4608f48c522bd2274976028603/76:405"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.20000000298023224
           },
-          "alias": "VariableID:94898b7cc1bd97ad6aa3503d1b34d63957fbcc26/76:383",
-          "aliasName": "green/alpha/200"
+          "alias": "VariableID:cd519cce5202dd4608f48c522bd2274976028603/76:405",
+          "aliasName": "green-lime/alpha/200"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.20000000298023224
           },
-          "alias": "VariableID:94898b7cc1bd97ad6aa3503d1b34d63957fbcc26/76:383",
-          "aliasName": "green/alpha/200"
+          "alias": "VariableID:cd519cce5202dd4608f48c522bd2274976028603/76:405",
+          "aliasName": "green-lime/alpha/200"
         }
       },
       "scopes": [
@@ -706,33 +706,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:10f488664318faf3dbc2f9aa376df1c8deeacc12/76:381"
+          "id": "VariableID:169b48022f4a60164b3d49fb0e10aced4427846a/76:403"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385"
+          "id": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.10000000149011612
           },
-          "alias": "VariableID:10f488664318faf3dbc2f9aa376df1c8deeacc12/76:381",
-          "aliasName": "green/alpha/100"
+          "alias": "VariableID:169b48022f4a60164b3d49fb0e10aced4427846a/76:403",
+          "aliasName": "green-lime/alpha/100"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.30000001192092896
           },
-          "alias": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385",
-          "aliasName": "green/alpha/300"
+          "alias": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407",
+          "aliasName": "green-lime/alpha/300"
         }
       },
       "scopes": [
@@ -945,33 +945,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:8c51290ae15a1290cab12aa6056843e544bf7a7b/72:161"
+          "id": "VariableID:a42113c6629bb91bae8d01d8fcc64054dc203a48/72:180"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:692bf5198f34c4fad1721e48162ad2dbbdbb9175/72:169"
+          "id": "VariableID:6f2e22d3b16c2868dc5d087c3ea7fa7d662c58c3/72:175"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.6513022780418396,
-            "b": 0.24199268221855164,
+            "r": 0.36872008442878723,
+            "g": 0.647489070892334,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:8c51290ae15a1290cab12aa6056843e544bf7a7b/72:161",
-          "aliasName": "green/600"
+          "alias": "VariableID:a42113c6629bb91bae8d01d8fcc64054dc203a48/72:180",
+          "aliasName": "green-lime/600"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0.019869813695549965,
-            "g": 0.8753122687339783,
-            "b": 0.4485098123550415,
+            "r": 0.6024433970451355,
+            "g": 0.9016712307929993,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:692bf5198f34c4fad1721e48162ad2dbbdbb9175/72:169",
-          "aliasName": "green/400"
+          "alias": "VariableID:6f2e22d3b16c2868dc5d087c3ea7fa7d662c58c3/72:175",
+          "aliasName": "green-lime/400"
         }
       },
       "scopes": [
@@ -1570,33 +1570,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167"
+          "id": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167"
+          "id": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167",
-          "aliasName": "green/500"
+          "alias": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179",
+          "aliasName": "green-lime/500"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167",
-          "aliasName": "green/500"
+          "alias": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179",
+          "aliasName": "green-lime/500"
         }
       },
       "scopes": [
@@ -3100,33 +3100,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:cdfaf322851d9055db21e5c99f8aa75166d186d4/72:168"
+          "id": "VariableID:372abfe05c6244900e8b1a9bf4e6fb335bc63437/72:181"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167"
+          "id": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.5099976658821106,
-            "b": 0.20980969071388245,
+            "r": 0.2848081886768341,
+            "g": 0.49150213599205017,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:cdfaf322851d9055db21e5c99f8aa75166d186d4/72:168",
-          "aliasName": "green/700"
+          "alias": "VariableID:372abfe05c6244900e8b1a9bf4e6fb335bc63437/72:181",
+          "aliasName": "green-lime/700"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:a9c6c1fb4e5c8036827ef3b6bbc86eddd00bee23/72:167",
-          "aliasName": "green/500"
+          "alias": "VariableID:278146ddbf77f7d3dbf67d4311ade5a56d494056/72:179",
+          "aliasName": "green-lime/500"
         }
       },
       "scopes": [
@@ -4675,33 +4675,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385"
+          "id": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385"
+          "id": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.30000001192092896
           },
-          "alias": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385",
-          "aliasName": "green/alpha/300"
+          "alias": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407",
+          "aliasName": "green-lime/alpha/300"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.7871556282043457,
-            "b": 0.31562188267707825,
+            "r": 0.4872932434082031,
+            "g": 0.8099173903465271,
+            "b": 0,
             "a": 0.30000001192092896
           },
-          "alias": "VariableID:419d0ff71fb4cc9581405584f1a981ac2ff97937/76:385",
-          "aliasName": "green/alpha/300"
+          "alias": "VariableID:b32450d86a0a89b66789a934ac8c531e6fb946eb/76:407",
+          "aliasName": "green-lime/alpha/300"
         }
       },
       "scopes": [
@@ -5008,33 +5008,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:692bf5198f34c4fad1721e48162ad2dbbdbb9175/72:169"
+          "id": "VariableID:6f2e22d3b16c2868dc5d087c3ea7fa7d662c58c3/72:175"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:cdfaf322851d9055db21e5c99f8aa75166d186d4/72:168"
+          "id": "VariableID:372abfe05c6244900e8b1a9bf4e6fb335bc63437/72:181"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0.019869813695549965,
-            "g": 0.8753122687339783,
-            "b": 0.4485098123550415,
+            "r": 0.6024433970451355,
+            "g": 0.9016712307929993,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:692bf5198f34c4fad1721e48162ad2dbbdbb9175/72:169",
-          "aliasName": "green/400"
+          "alias": "VariableID:6f2e22d3b16c2868dc5d087c3ea7fa7d662c58c3/72:175",
+          "aliasName": "green-lime/400"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 0,
-            "g": 0.5099976658821106,
-            "b": 0.20980969071388245,
+            "r": 0.2848081886768341,
+            "g": 0.49150213599205017,
+            "b": 0,
             "a": 1
           },
-          "alias": "VariableID:cdfaf322851d9055db21e5c99f8aa75166d186d4/72:168",
-          "aliasName": "green/700"
+          "alias": "VariableID:372abfe05c6244900e8b1a9bf4e6fb335bc63437/72:181",
+          "aliasName": "green-lime/700"
         }
       },
       "scopes": [


### PR DESCRIPTION
## Summary
- Update all `positive` semantic color tokens to use the `GreenLime` palette instead of `Green` across KMP light and dark themes
- Tokens updated: `contentPositive`, `contentPositiveOnColor`, `borderPositive`, `borderPositiveSubtle`, `bgPositiveInteractive`, `bgPositiveSubtleInteractive`, `bgPositiveSubtlePressed`
- Adjust `borderInfoSubtle`, `borderCautionSubtle`, `borderCriticalSubtle` alpha levels for light and dark themes
- Update SwiftUI color assets to reflect the new token values
- Remove stale `3932:0` mode entries from `theme-colors.json`

## Test plan
- [ ] Verify positive state colors (success indicators, positive borders/content) render correctly in KMP light and dark modes
- [ ] Verify positive state colors render correctly in SwiftUI light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)