### PR TITLE
fix(kmp, swiftui): add voice-specific border to SymbolContainer

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -270,7 +270,7 @@ private fun CoreSymbolContainer(
                         modifier = Modifier
                             .clip(shape = resolvedShape)
                             .background(color = voice.containerColor)
-                            .border(LocalBorderWidths.current.base.border25, voice.borderColor, resolvedShape)
+                            .border(width = LocalBorderWidths.current.base.border25, color = voice.borderColor, shape = resolvedShape)
                             .requiredSize(size = dimensions.containerSize),
                     )
                 },
@@ -282,7 +282,7 @@ private fun CoreSymbolContainer(
                 modifier = modifier
                     .clip(shape = resolvedShape)
                     .background(color = voice.containerColor)
-                    .border(LocalBorderWidths.current.base.border25, voice.borderColor, resolvedShape)
+                    .border(width = LocalBorderWidths.current.base.border25, color = voice.borderColor, shape = resolvedShape)
                     .requiredSize(size = dimensions.containerSize),
             )
         }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -2,6 +2,7 @@ package com.teya.lemonade
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.requiredSize
@@ -269,6 +270,11 @@ private fun CoreSymbolContainer(
                         modifier = Modifier
                             .clip(shape = resolvedShape)
                             .background(color = voice.containerColor)
+                            .border(
+                                width = LocalBorderWidths.current.base.border25,
+                                color = voice.borderColor,
+                                shape = resolvedShape,
+                            )
                             .requiredSize(size = dimensions.containerSize),
                     )
                 },
@@ -280,6 +286,11 @@ private fun CoreSymbolContainer(
                 modifier = modifier
                     .clip(shape = resolvedShape)
                     .background(color = voice.containerColor)
+                    .border(
+                        width = LocalBorderWidths.current.base.border25,
+                        color = voice.borderColor,
+                        shape = resolvedShape,
+                    )
                     .requiredSize(size = dimensions.containerSize),
             )
         }
@@ -314,6 +325,19 @@ private val SymbolContainerVoice.containerColor: Color
             SymbolContainerVoice.Positive -> LocalColors.current.background.bgPositiveSubtle
             SymbolContainerVoice.Brand -> LocalColors.current.background.bgBrand
             SymbolContainerVoice.BrandSubtle -> LocalColors.current.background.bgBrandSubtle
+        }
+    }
+
+private val SymbolContainerVoice.borderColor: Color
+    @Composable get() {
+        return when (this) {
+            SymbolContainerVoice.Neutral -> LocalColors.current.border.borderNeutralLow
+            SymbolContainerVoice.Critical -> LocalColors.current.border.borderCriticalSubtle
+            SymbolContainerVoice.Warning -> LocalColors.current.border.borderCautionSubtle
+            SymbolContainerVoice.Info -> LocalColors.current.border.borderInfoSubtle
+            SymbolContainerVoice.Positive -> LocalColors.current.border.borderPositiveSubtle
+            SymbolContainerVoice.Brand -> LocalColors.current.border.borderBrand
+            SymbolContainerVoice.BrandSubtle -> LocalColors.current.border.borderOnBrandLow
         }
     }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -269,9 +269,13 @@ private fun CoreSymbolContainer(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier
                             .clip(shape = resolvedShape)
-                            .background(color = voice.containerColor)
-                            .border(width = LocalBorderWidths.current.base.border25, color = voice.borderColor, shape = resolvedShape)
-                            .requiredSize(size = dimensions.containerSize),
+                            .background(
+                                color = voice.containerColor,
+                            ).border(
+                                width = LocalBorderWidths.current.base.border25,
+                                color = voice.borderColor,
+                                shape = resolvedShape,
+                            ).requiredSize(size = dimensions.containerSize),
                     )
                 },
             )
@@ -281,9 +285,13 @@ private fun CoreSymbolContainer(
                 contentAlignment = Alignment.Center,
                 modifier = modifier
                     .clip(shape = resolvedShape)
-                    .background(color = voice.containerColor)
-                    .border(width = LocalBorderWidths.current.base.border25, color = voice.borderColor, shape = resolvedShape)
-                    .requiredSize(size = dimensions.containerSize),
+                    .background(
+                        color = voice.containerColor,
+                    ).border(
+                        width = LocalBorderWidths.current.base.border25,
+                        color = voice.borderColor,
+                        shape = resolvedShape,
+                    ).requiredSize(size = dimensions.containerSize),
             )
         }
     }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -270,11 +270,7 @@ private fun CoreSymbolContainer(
                         modifier = Modifier
                             .clip(shape = resolvedShape)
                             .background(color = voice.containerColor)
-                            .border(
-                                width = LocalBorderWidths.current.base.border25,
-                                color = voice.borderColor,
-                                shape = resolvedShape,
-                            )
+                            .border(LocalBorderWidths.current.base.border25, voice.borderColor, resolvedShape)
                             .requiredSize(size = dimensions.containerSize),
                     )
                 },
@@ -286,11 +282,7 @@ private fun CoreSymbolContainer(
                 modifier = modifier
                     .clip(shape = resolvedShape)
                     .background(color = voice.containerColor)
-                    .border(
-                        width = LocalBorderWidths.current.base.border25,
-                        color = voice.borderColor,
-                        shape = resolvedShape,
-                    )
+                    .border(LocalBorderWidths.current.base.border25, voice.borderColor, resolvedShape)
                     .requiredSize(size = dimensions.containerSize),
             )
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -345,25 +345,6 @@ private func resolveButtonColors(
     }
 }
 
-// MARK: - Button Full Shape Environment
-
-private struct LemonadeButtonFullShapeKey: EnvironmentKey {
-    static let defaultValue: Bool = false
-}
-
-extension EnvironmentValues {
-    var lemonadeButtonFullShape: Bool {
-        get { self[LemonadeButtonFullShapeKey.self] }
-        set { self[LemonadeButtonFullShapeKey.self] = newValue }
-    }
-}
-
-public extension View {
-    func fullShape(_ enabled: Bool = true) -> some View {
-        environment(\.lemonadeButtonFullShape, enabled)
-    }
-}
-
 // MARK: - Internal Core Button View
 
 private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: View {

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -345,6 +345,25 @@ private func resolveButtonColors(
     }
 }
 
+// MARK: - Button Full Shape Environment
+
+private struct LemonadeButtonFullShapeKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var lemonadeButtonFullShape: Bool {
+        get { self[LemonadeButtonFullShapeKey.self] }
+        set { self[LemonadeButtonFullShapeKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func fullShape(_ enabled: Bool = true) -> some View {
+        environment(\.lemonadeButtonFullShape, enabled)
+    }
+}
+
 // MARK: - Internal Core Button View
 
 private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: View {

--- a/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
@@ -35,6 +35,18 @@ public enum SymbolContainerVoice {
         case .brandSubtle: return LemonadeTheme.colors.background.bgBrandSubtle
         }
     }
+
+    var borderColor: Color {
+        switch self {
+        case .neutral: return LemonadeTheme.colors.border.borderNeutralLow
+        case .critical: return LemonadeTheme.colors.border.borderCriticalSubtle
+        case .warning: return LemonadeTheme.colors.border.borderCautionSubtle
+        case .info: return LemonadeTheme.colors.border.borderInfoSubtle
+        case .positive: return LemonadeTheme.colors.border.borderPositiveSubtle
+        case .brand: return LemonadeTheme.colors.border.borderBrand
+        case .brandSubtle: return LemonadeTheme.colors.border.borderOnBrandLow
+        }
+    }
 }
 
 // MARK: - SymbolContainer Size
@@ -338,9 +350,19 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
 
         switch shape {
         case .circle:
-            base.clipShape(Circle())
+            base
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .stroke(voice.borderColor, lineWidth: LemonadeTheme.borderWidth.base.border25)
+                )
         case .rounded:
-            base.clipShape(RoundedRectangle(cornerRadius: roundedRadius(for: size)))
+            base
+                .clipShape(RoundedRectangle(cornerRadius: roundedRadius(for: size)))
+                .overlay(
+                    RoundedRectangle(cornerRadius: roundedRadius(for: size))
+                        .stroke(voice.borderColor, lineWidth: LemonadeTheme.borderWidth.base.border25)
+                )
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a 1pt border to `SymbolContainer` on **KMP/Compose** and **SwiftUI**, matching the Figma spec
- Each voice maps to its semantic border token: `borderNeutralLow`, `borderCriticalSubtle`, `borderCautionSubtle`, `borderInfoSubtle`, `borderPositiveSubtle`, `borderBrand`, `borderOnBrandLow`

## Screenshots

| iOS (SwiftUI) | Android (KMP/Compose) |
|---|---|
| <img src="https://github.com/user-attachments/assets/5fde84fc-aff2-49ac-a129-156d9b729ace" width="300"/> | <img src="https://github.com/user-attachments/assets/414e2b32-394e-4b7a-bc38-778b30fa9bea" width="300"/> |

## Test plan
- [x] Verified on Android emulator (Pixel 9a API 36) — borders render with distinct colors per voice
- [x] Verified on iOS simulator (iPhone 17 Pro) — borders render with distinct colors per voice
- [ ] Check dark mode renders correctly on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)