### PR TITLE
fix: remove 3932 mode entries and update border-selected colour token

### DIFF
--- a/flutter/lib/src/foundation/primitive_colors.dart
+++ b/flutter/lib/src/foundation/primitive_colors.dart
@@ -205,7 +205,7 @@ class _PinkSolid {
 class _NeutralSolid {
   final Color neutral600 = const Color(0xFF555450);
 
-  final Color neutral100 = const Color(0xFFF5F4F3);
+  final Color neutral100 = const Color(0xFFF1F0ED);
 
   final Color neutral400 = const Color(0xFFA5A3A0);
 
@@ -217,37 +217,37 @@ class _NeutralSolid {
 
   final Color neutral700 = const Color(0xFF42413E);
 
-  final Color neutral800 = const Color(0xFF282725);
+  final Color neutral800 = const Color(0xFF252422);
 
-  final Color neutral900 = const Color(0xFF1A1918);
+  final Color neutral900 = const Color(0xFF201F1D);
 
-  final Color neutral50 = const Color(0xFFF8F7F6);
+  final Color neutral50 = const Color(0xFFF6F5F3);
 
-  final Color neutral950 = const Color(0xFF0B0A0A);
+  final Color neutral950 = const Color(0xFF151513);
 }
 
 class _RedSolid {
-  final Color red300 = const Color(0xFFFFA1A2);
+  final Color red300 = const Color(0xFFFFC8CC);
 
-  final Color red100 = const Color(0xFFFEE1E1);
+  final Color red100 = const Color(0xFFFFE1E3);
 
-  final Color red700 = const Color(0xFFC10007);
+  final Color red700 = const Color(0xFFC01520);
 
-  final Color red900 = const Color(0xFF811719);
+  final Color red900 = const Color(0xFF831920);
 
-  final Color red400 = const Color(0xFFFF6366);
+  final Color red400 = const Color(0xFFFE535E);
 
-  final Color red800 = const Color(0xFF9E0711);
+  final Color red800 = const Color(0xFF9F151E);
 
-  final Color red500 = const Color(0xFFFA2B36);
+  final Color red500 = const Color(0xFFF73C48);
 
-  final Color red600 = const Color(0xFFE7000A);
+  final Color red600 = const Color(0xFFE41E2B);
 
-  final Color red200 = const Color(0xFFFFC9C9);
+  final Color red200 = const Color(0xFFFFC8CC);
 
-  final Color red50 = const Color(0xFFFEF2F2);
+  final Color red50 = const Color(0xFFFFF1F2);
 
-  final Color red950 = const Color(0xFF460808);
+  final Color red950 = const Color(0xFF48070B);
 }
 
 class _CyanSolid {
@@ -565,27 +565,27 @@ class _Alpha {
 }
 
 class _NeutralAlpha {
-  final Color neutral900 = const Color(0xE51B1A18);
+  final Color neutral900 = const Color(0xEB090806);
 
-  final Color neutral700 = const Color(0xB21B1A18);
+  final Color neutral700 = const Color(0xC60C0A07);
 
-  final Color neutral600 = const Color(0x991B1A18);
+  final Color neutral600 = const Color(0xB50F0E09);
 
-  final Color neutral300 = const Color(0x4C1B1A18);
+  final Color neutral300 = const Color(0x4C766F5F);
 
-  final Color neutral200 = const Color(0x331B1A18);
+  final Color neutral200 = const Color(0x338E8675);
 
-  final Color neutral500 = const Color(0x7F1B1A18);
+  final Color neutral500 = const Color(0x8C15140D);
 
-  final Color neutral800 = const Color(0xCC1B1A18);
+  final Color neutral800 = const Color(0xE1090805);
 
-  final Color neutral100 = const Color(0x191B1A18);
+  final Color neutral100 = const Color(0x19756B56);
 
-  final Color neutral400 = const Color(0x661B1A18);
+  final Color neutral400 = const Color(0x66211C11);
 
-  final Color neutral50 = const Color(0x0C1B1A18);
+  final Color neutral50 = const Color(0x0C5E4F2F);
 
-  final Color neutral950 = const Color(0xF21B1A18);
+  final Color neutral950 = const Color(0xF4080706);
 }
 
 class _YellowAlpha {
@@ -661,25 +661,25 @@ class _OrangeAlpha {
 }
 
 class _RedAlpha {
-  final Color red50 = const Color(0x0CFA2B36);
+  final Color red50 = const Color(0x0CF73C48);
 
-  final Color red100 = const Color(0x19FA2B36);
+  final Color red100 = const Color(0x19F73C48);
 
-  final Color red200 = const Color(0x33FA2B36);
+  final Color red200 = const Color(0x33F73C48);
 
-  final Color red300 = const Color(0x4CFA2B36);
+  final Color red300 = const Color(0x4CF73C48);
 
-  final Color red400 = const Color(0x66FA2B36);
+  final Color red400 = const Color(0x66F73C48);
 
-  final Color red500 = const Color(0x7FFA2B36);
+  final Color red500 = const Color(0x7FF73C48);
 
-  final Color red600 = const Color(0x99FA2B36);
+  final Color red600 = const Color(0x99F73C48);
 
-  final Color red700 = const Color(0xB2FA2B36);
+  final Color red700 = const Color(0xB2F73C48);
 
-  final Color red800 = const Color(0xCCFA2B36);
+  final Color red800 = const Color(0xCCF73C48);
 
-  final Color red900 = const Color(0xE5FA2B36);
+  final Color red900 = const Color(0xE5F73C48);
 
   final Color red950 = const Color(0xF2FA2B36);
 }

--- a/swiftui/Sources/Lemonade/Extensions/Color+Lemonade.swift
+++ b/swiftui/Sources/Lemonade/Extensions/Color+Lemonade.swift
@@ -158,7 +158,7 @@ public struct LemonadeShadowColorsShorthand {
 
 public extension ShapeStyle where Self == Color {
     /// Interaction color tokens
-    /// Usage: `.foregroundStyle(.interaction.borderNeutralMedium)`
+    /// Usage: `.foregroundStyle(.interaction.interactionDefault)`
     static var interaction: LemonadeInteractionColorsShorthand { LemonadeInteractionColorsShorthand() }
 
     /// Border color tokens

--- a/swiftui/Sources/Lemonade/Extensions/Color+Lemonade.swift
+++ b/swiftui/Sources/Lemonade/Extensions/Color+Lemonade.swift
@@ -158,7 +158,7 @@ public struct LemonadeShadowColorsShorthand {
 
 public extension ShapeStyle where Self == Color {
     /// Interaction color tokens
-    /// Usage: `.foregroundStyle(.interaction.interactionDefault)`
+    /// Usage: `.foregroundStyle(.interaction.bgDefaultInteractive)`
     static var interaction: LemonadeInteractionColorsShorthand { LemonadeInteractionColorsShorthand() }
 
     /// Border color tokens

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-border-selected.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-border-selected.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.925",
-          "blue" : "0.024",
-          "green" : "0.031",
-          "red" : "0.035"
+          "alpha" : "1.000",
+          "blue" : "0.046",
+          "green" : "0.194",
+          "red" : "0.160"
         }
       },
       "idiom" : "universal"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.900",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "alpha" : "1.000",
+          "blue" : "0.100",
+          "green" : "0.900",
+          "red" : "0.882"
         }
       },
       "idiom" : "universal"

--- a/tokens/theme-colors.json
+++ b/tokens/theme-colors.json
@@ -1233,33 +1233,33 @@
       "valuesByMode": {
         "3037:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:23654674cbdb8671c55108ccce491e16c33a1d57/501:487"
+          "id": "VariableID:32edd553f4f45306d1ba866c5595851700a96c50/121:75"
         },
         "4431:0": {
           "type": "VARIABLE_ALIAS",
-          "id": "VariableID:1cde25931e5330368f430707ddecf5da880df6d6/109:32"
+          "id": "VariableID:108bd7e242693fc88285aa40fbffaacb28702a24/74:87"
         }
       },
       "resolvedValuesByMode": {
         "3037:0": {
           "resolvedValue": {
-            "r": 0.03529411926865578,
-            "g": 0.0313725508749485,
-            "b": 0.0235294122248888,
-            "a": 0.925000011920929
+            "r": 0.1595725268125534,
+            "g": 0.19419847428798676,
+            "b": 0.04580152779817581,
+            "a": 1
           },
-          "alias": "VariableID:23654674cbdb8671c55108ccce491e16c33a1d57/501:487",
-          "aliasName": "neutral/alpha/900"
+          "alias": "VariableID:32edd553f4f45306d1ba866c5595851700a96c50/121:75",
+          "aliasName": "yellow-lime/900"
         },
         "4431:0": {
           "resolvedValue": {
-            "r": 1,
-            "g": 1,
-            "b": 1,
-            "a": 0.8999999761581421
+            "r": 0.8820960521697998,
+            "g": 0.8995633125305176,
+            "b": 0.10043667256832123,
+            "a": 1
           },
-          "alias": "VariableID:1cde25931e5330368f430707ddecf5da880df6d6/109:32",
-          "aliasName": "white/900"
+          "alias": "VariableID:108bd7e242693fc88285aa40fbffaacb28702a24/74:87",
+          "aliasName": "yellow-lime/500"
         }
       },
       "scopes": [


### PR DESCRIPTION
## Summary
- Remove all `3932:0` mode entries from `theme-colors.json`
- Update `border-selected` colour token to use yellow-lime palette (was neutral/alpha)
- Regenerate Flutter, SwiftUI, and color asset outputs

## Test plan
- [ ] Verify border-selected renders correctly in light and dark mode
- [ ] Confirm no `3932:0` references remain in `theme-colors.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)