### PR TITLE
perf(list-item): cut per-row render cost (draw floor, gating, layout)

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -581,17 +581,20 @@ private fun CoreListItem(
     SafeArea(modifier = modifier, showDivider = showDivider) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = if (onListItemClick != null) {
-                Modifier.interactiveBackground(
-                    interactionSource = interactionSource,
-                    voice = voice,
-                    enabled = enabled,
-                    role = role,
-                    onClick = onListItemClick,
-                )
-            } else {
-                Modifier
-            }.defaultMinSize(minHeight = LocalSizes.current.size1200)
+            modifier = Modifier
+                .then(
+                    other = if (onListItemClick != null) {
+                        Modifier.interactiveBackground(
+                            interactionSource = interactionSource,
+                            voice = voice,
+                            enabled = enabled,
+                            role = role,
+                            onClick = onListItemClick,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ).defaultMinSize(minHeight = LocalSizes.current.size1200)
                 .padding(
                     horizontal = LocalSpaces.current.spacing300,
                     vertical = LocalSpaces.current.spacing300,
@@ -735,7 +738,10 @@ private fun SafeArea(
         return
     }
 
-    Column(modifier = modifier) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier,
+    ) {
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier.padding(all = LocalSpaces.current.spacing100),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -1,7 +1,6 @@
 package com.teya.lemonade
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -23,8 +22,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -578,37 +578,20 @@ private fun CoreListItem(
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     leadingVerticalAlignment: Alignment.Vertical = Alignment.Top,
 ) {
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val isHovering by interactionSource.collectIsHoveredAsState()
-
-    val animatedBackgroundColor by animateColorAsState(
-        targetValue = if (isHovering || isPressed) {
-            voice.interactionBackground
-        } else {
-            voice.interactionBackground.copy(
-                alpha = LocalOpacities.current.base.opacity0,
-            )
-        },
-    )
     SafeArea(modifier = modifier, showDivider = showDivider) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .clip(shape = LocalShapes.current.radius500)
-                .then(
-                    other = if (onListItemClick != null) {
-                        Modifier.clickable(
-                            enabled = enabled,
-                            role = role,
-                            onClick = onListItemClick,
-                            interactionSource = interactionSource,
-                            indication = LocalEffects.current.interactionIndication,
-                        )
-                    } else {
-                        Modifier
-                    },
-                ).background(color = animatedBackgroundColor)
-                .defaultMinSize(minHeight = LocalSizes.current.size1200)
+            modifier = if (onListItemClick != null) {
+                Modifier.interactiveBackground(
+                    interactionSource = interactionSource,
+                    voice = voice,
+                    enabled = enabled,
+                    role = role,
+                    onClick = onListItemClick,
+                )
+            } else {
+                Modifier
+            }.defaultMinSize(minHeight = LocalSizes.current.size1200)
                 .padding(
                     horizontal = LocalSpaces.current.spacing300,
                     vertical = LocalSpaces.current.spacing300,
@@ -649,33 +632,92 @@ private fun CoreListItem(
                         ),
                 )
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (trailingSlot != null) {
-                        trailingSlot()
-                    }
+                if (trailingSlot != null || navigationIndicator) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (trailingSlot != null) {
+                            trailingSlot()
+                        }
 
-                    if (navigationIndicator) {
-                        LemonadeUi.Icon(
-                            icon = LemonadeIcons.ChevronRight,
-                            tint = LocalColors.current.content.contentTertiary,
-                            size = LemonadeAssetSize.Medium,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .then(
-                                    other = if (!enabled) {
-                                        Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                                    } else {
-                                        Modifier
-                                    },
-                                ).padding(start = LocalSpaces.current.spacing100),
-                        )
+                        if (navigationIndicator) {
+                            LemonadeUi.Icon(
+                                icon = LemonadeIcons.ChevronRight,
+                                tint = LocalColors.current.content.contentTertiary,
+                                size = LemonadeAssetSize.Medium,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .then(
+                                        other = if (!enabled) {
+                                            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+                                        } else {
+                                            Modifier
+                                        },
+                                    ).padding(start = LocalSpaces.current.spacing100),
+                            )
+                        }
                     }
                 }
             }
         }
     }
+}
+
+/**
+ * Applies click handling and the animated press/hover highlight for interactive rows.
+ *
+ * Only used for clickable rows: a row without an `onListItemClick` can never be pressed or
+ * hovered, so it needs none of this apparatus and is left untouched.
+ *
+ * The highlight is painted directly in the draw phase via [drawWithCache], reading the animated
+ * colour at draw time (not composition time) and using the row's rounded [androidx.compose.ui.graphics.Shape]
+ * outline instead of a [androidx.compose.ui.draw.clip] graphics layer. During a scroll the colour is fully
+ * transparent, so the row draws nothing and pays no clip/background cost — this removes the
+ * per-row draw floor seen in the scroll-jank profiling. The click indication is `null` (no
+ * ripple); press feedback is the animated fill, mirroring the iOS `ListItemButtonStyle`.
+ */
+@Composable
+private fun Modifier.interactiveBackground(
+    interactionSource: MutableInteractionSource,
+    voice: LemonadeListItemVoice,
+    enabled: Boolean,
+    role: Role?,
+    onClick: () -> Unit,
+): Modifier {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val isHovering by interactionSource.collectIsHoveredAsState()
+
+    val highlightShape = LocalShapes.current.radius500
+    val transparentColor = voice.interactionBackground.copy(
+        alpha = LocalOpacities.current.base.opacity0,
+    )
+    val highlightColor by animateColorAsState(
+        targetValue = if (isHovering || isPressed) {
+            voice.interactionBackground
+        } else {
+            transparentColor
+        },
+    )
+
+    return this
+        .clickable(
+            enabled = enabled,
+            role = role,
+            onClick = onClick,
+            interactionSource = interactionSource,
+            indication = null,
+        ).drawWithCache {
+            val outline = highlightShape.createOutline(
+                size = size,
+                layoutDirection = layoutDirection,
+                density = this,
+            )
+            onDrawBehind {
+                if (highlightColor.alpha > 0f) {
+                    drawOutline(outline = outline, color = highlightColor)
+                }
+            }
+        }
 }
 
 @Composable
@@ -684,24 +726,25 @@ private fun SafeArea(
     showDivider: Boolean,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        modifier = modifier.background(color = Color.Transparent),
-    ) {
+    if (!showDivider) {
         Column(
-            modifier = Modifier
-                .padding(LocalSpaces.current.spacing100)
-                .background(color = Color.Transparent),
             verticalArrangement = Arrangement.Center,
-        ) {
-            content()
-        }
+            modifier = modifier.padding(all = LocalSpaces.current.spacing100),
+            content = content,
+        )
+        return
+    }
 
-        if (showDivider) {
-            LemonadeUi.HorizontalDivider(
-                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing400),
-            )
-        }
+    Column(modifier = modifier) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(all = LocalSpaces.current.spacing100),
+            content = content,
+        )
+
+        LemonadeUi.HorizontalDivider(
+            modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing400),
+        )
     }
 }
 


### PR DESCRIPTION
## What

Reduces the per-row render cost of `LemonadeUi.ListItem` (`CoreListItem`) that causes scroll jank in long lists, per #196.

The profiling in #196 attributes the per-row floor to three things, all addressed here:

| # | Source (from #196) | Change |
|---|---|---|
| 1 | Per-row rounded **clip layer + animated background** (~2.3 ms draw) | Draw-phase rounded fill highlight; no clip layer |
| 2 | Always-on `animateColorAsState` + interaction collectors | Gated behind `onListItemClick != null` |
| 3 | Layout nesting (~6 Row + ~5 Column / row) | SafeArea collapse + skip empty trailing `Row` |

## How

**1. Clickable rows — draw-phase fill instead of clip + ripple (the big one).**
The old path kept a persistent `Modifier.clip(radius500)` graphics layer on every row purely to bound the Material ripple, plus an `animateColorAsState` background drawn each frame. The clip layer is the dominant draw cost during a fling. Replaced with a `drawWithCache`/`drawOutline` highlight that reads the animated colour **at draw time**: while scrolling the colour is transparent, so the row draws nothing and allocates no layer. Press/hover feedback is now an animated rounded fill (no ripple).

This intentionally changes Android press feedback from a ripple to a fill — chosen to match the **existing iOS `ListItemButtonStyle`** (`.background(isPressed ? color : .clear).clipShape(...)`), so the two platforms are now consistent.

**2. Non-clickable rows — pixel-identical gating.**
A row without `onListItemClick` has no `clickable`, so it can never be pressed/hovered; its background always resolved to `interactionBackground.copy(alpha = opacity0)` and `opacity0 = 0f`. Removing the clip + background + `animateColorAsState` + collectors for those rows is therefore provably pixel-identical.

**3. Layout trims (no visual change).**
- `SafeArea`: collapse the redundant outer `Column` in the common no-divider case; drop two no-op `.background(Color.Transparent)`.
- Skip the trailing `Row` when there is no trailing slot and no navigation indicator (it was an empty 0-width `Row` composed/measured on every row).

The deeper measure win (a single custom `Layout`, M3-style) is intentionally **not** in this PR — it needs visual coverage we don't have yet and is the natural follow-up.

## Verification

- ✅ `compileDebugKotlinAndroid`, `ktlintCheck`, `apiCheck` (public API unchanged), `detektAndroidDebug`
- ✅ Press highlight confirmed on a **Pixel 10a (Android 16)** via the sample app
- ✅ Cross-checked the approach against **Material 3 `ListItem`** (static `Surface` vs. `InteractiveListItem`; keeps clip only for the ripple) and the **Lemonade SwiftUI `ListItem`** (gates the highlight behind a click handler; fill, no ripple)
- ⏳ On-device scroll-jank A/B (Perfetto) on the real `teya-business-app` Transactions list — to be confirmed by the issue author

## Behavior change for reviewers / design

Press/hover feedback on **clickable** rows changes from a Material ripple to an animated rounded fill. This matches iOS. Non-clickable rows, disabled rows, and all static appearance are unchanged.

Refs #196

## API Dump

**Verdict:** NO_CHANGES

No public API changes — the change is an internal refactor of `CoreListItem`/`SafeArea` rendering. Confirmed both ways: the committed `api/*.api` / `*.klib.api` baseline is unchanged vs `main`, and a fresh `./gradlew apiDump` regenerates an identical baseline (so `apiCheck` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
