### PR TITLE
feat(calendar): expose overridable today on date picker state [KMP]

### DIFF
--- a/kmp/calendar/api/android/calendar.api
+++ b/kmp/calendar/api/android/calendar.api
@@ -2,7 +2,9 @@ public final class com/teya/lemonade/DatePickerKt {
 	public static final fun DatePicker (Lcom/teya/lemonade/LemonadeUi;Lkotlin/jvm/functions/Function1;Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/teya/lemonade/DatePickerState;Lkotlinx/datetime/DayOfWeek;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DateRangePicker (Lcom/teya/lemonade/LemonadeUi;Lkotlin/jvm/functions/Function1;Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/teya/lemonade/DateRangePickerState;Lkotlinx/datetime/DayOfWeek;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DatePickerState;
+	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DatePickerState;
 	public static final fun rememberDateRangePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Ljava/lang/Integer;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DateRangePickerState;
+	public static final fun rememberDateRangePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Ljava/lang/Integer;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DateRangePickerState;
 }
 
 public final class com/teya/lemonade/DatePickerState {
@@ -11,6 +13,7 @@ public final class com/teya/lemonade/DatePickerState {
 	public final fun getMaxDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 }
 
 public final class com/teya/lemonade/DateRangePickerState {
@@ -21,6 +24,7 @@ public final class com/teya/lemonade/DateRangePickerState {
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedStartDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 }
 
 public final class com/teya/lemonade/InlineCalendarKt {
@@ -35,11 +39,13 @@ public final class com/teya/lemonade/InlineCalendarState {
 	public final fun getMaxDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 	public final fun navigateToMonth (Lkotlinx/datetime/YearMonth;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 }
 
 public final class com/teya/lemonade/InlineCalendarStateKt {
+	public static final fun rememberInlineCalendarState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/YearMonth;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DayOfWeek;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/InlineCalendarState;
 	public static final fun rememberInlineCalendarState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/YearMonth;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DayOfWeek;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/InlineCalendarState;
 }
 

--- a/kmp/calendar/api/calendar.klib.api
+++ b/kmp/calendar/api/calendar.klib.api
@@ -11,6 +11,8 @@ final class com.teya.lemonade/DatePickerState { // com.teya.lemonade/DatePickerS
         final fun <get-maxDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/DatePickerState.maxDate.<get-maxDate>|<get-maxDate>(){}[0]
     final val minDate // com.teya.lemonade/DatePickerState.minDate|{}minDate[0]
         final fun <get-minDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/DatePickerState.minDate.<get-minDate>|<get-minDate>(){}[0]
+    final val today // com.teya.lemonade/DatePickerState.today|{}today[0]
+        final fun <get-today>(): kotlinx.datetime/LocalDate // com.teya.lemonade/DatePickerState.today.<get-today>|<get-today>(){}[0]
 
     final var selectedDate // com.teya.lemonade/DatePickerState.selectedDate|{}selectedDate[0]
         final fun <get-selectedDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/DatePickerState.selectedDate.<get-selectedDate>|<get-selectedDate>(){}[0]
@@ -23,6 +25,8 @@ final class com.teya.lemonade/DateRangePickerState { // com.teya.lemonade/DateRa
         final fun <get-maxRangeDays>(): kotlin/Int? // com.teya.lemonade/DateRangePickerState.maxRangeDays.<get-maxRangeDays>|<get-maxRangeDays>(){}[0]
     final val minDate // com.teya.lemonade/DateRangePickerState.minDate|{}minDate[0]
         final fun <get-minDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/DateRangePickerState.minDate.<get-minDate>|<get-minDate>(){}[0]
+    final val today // com.teya.lemonade/DateRangePickerState.today|{}today[0]
+        final fun <get-today>(): kotlinx.datetime/LocalDate // com.teya.lemonade/DateRangePickerState.today.<get-today>|<get-today>(){}[0]
 
     final var selectedEndDate // com.teya.lemonade/DateRangePickerState.selectedEndDate|{}selectedEndDate[0]
         final fun <get-selectedEndDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/DateRangePickerState.selectedEndDate.<get-selectedEndDate>|<get-selectedEndDate>(){}[0]
@@ -37,6 +41,8 @@ final class com.teya.lemonade/InlineCalendarState { // com.teya.lemonade/InlineC
         final fun <get-maxDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/InlineCalendarState.maxDate.<get-maxDate>|<get-maxDate>(){}[0]
     final val minDate // com.teya.lemonade/InlineCalendarState.minDate|{}minDate[0]
         final fun <get-minDate>(): kotlinx.datetime/LocalDate? // com.teya.lemonade/InlineCalendarState.minDate.<get-minDate>|<get-minDate>(){}[0]
+    final val today // com.teya.lemonade/InlineCalendarState.today|{}today[0]
+        final fun <get-today>(): kotlinx.datetime/LocalDate // com.teya.lemonade/InlineCalendarState.today.<get-today>|<get-today>(){}[0]
 
     final var displayedMonth // com.teya.lemonade/InlineCalendarState.displayedMonth|{}displayedMonth[0]
         final fun <get-displayedMonth>(): kotlinx.datetime/YearMonth // com.teya.lemonade/InlineCalendarState.displayedMonth.<get-displayedMonth>|<get-displayedMonth>(){}[0]
@@ -57,6 +63,9 @@ final fun (com.teya.lemonade/LemonadeUi).com.teya.lemonade/InlineCalendar(com.te
 final fun com.teya.lemonade/com_teya_lemonade_DatePickerState$stableprop_getter(): kotlin/Int // com.teya.lemonade/com_teya_lemonade_DatePickerState$stableprop_getter|com_teya_lemonade_DatePickerState$stableprop_getter(){}[0]
 final fun com.teya.lemonade/com_teya_lemonade_DateRangePickerState$stableprop_getter(): kotlin/Int // com.teya.lemonade/com_teya_lemonade_DateRangePickerState$stableprop_getter|com_teya_lemonade_DateRangePickerState$stableprop_getter(){}[0]
 final fun com.teya.lemonade/com_teya_lemonade_InlineCalendarState$stableprop_getter(): kotlin/Int // com.teya.lemonade/com_teya_lemonade_InlineCalendarState$stableprop_getter|com_teya_lemonade_InlineCalendarState$stableprop_getter(){}[0]
+final fun com.teya.lemonade/rememberDatePickerState(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/DatePickerState // com.teya.lemonade/rememberDatePickerState|rememberDatePickerState(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.teya.lemonade/rememberDatePickerState(kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/DatePickerState // com.teya.lemonade/rememberDatePickerState|rememberDatePickerState(kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.teya.lemonade/rememberDateRangePickerState(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlin/Int?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/DateRangePickerState // com.teya.lemonade/rememberDateRangePickerState|rememberDateRangePickerState(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlin.Int?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.teya.lemonade/rememberDateRangePickerState(kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlin/Int?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/DateRangePickerState // com.teya.lemonade/rememberDateRangePickerState|rememberDateRangePickerState(kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlin.Int?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.teya.lemonade/rememberInlineCalendarState(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate?, kotlinx.datetime/YearMonth?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/DayOfWeek?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/InlineCalendarState // com.teya.lemonade/rememberInlineCalendarState|rememberInlineCalendarState(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate?;kotlinx.datetime.YearMonth?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.DayOfWeek?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.teya.lemonade/rememberInlineCalendarState(kotlinx.datetime/LocalDate?, kotlinx.datetime/YearMonth?, kotlinx.datetime/LocalDate?, kotlinx.datetime/LocalDate?, kotlinx.datetime/DayOfWeek?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.teya.lemonade/InlineCalendarState // com.teya.lemonade/rememberInlineCalendarState|rememberInlineCalendarState(kotlinx.datetime.LocalDate?;kotlinx.datetime.YearMonth?;kotlinx.datetime.LocalDate?;kotlinx.datetime.LocalDate?;kotlinx.datetime.DayOfWeek?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]

--- a/kmp/calendar/api/desktop/calendar.api
+++ b/kmp/calendar/api/desktop/calendar.api
@@ -2,7 +2,9 @@ public final class com/teya/lemonade/DatePickerKt {
 	public static final fun DatePicker (Lcom/teya/lemonade/LemonadeUi;Lkotlin/jvm/functions/Function1;Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/teya/lemonade/DatePickerState;Lkotlinx/datetime/DayOfWeek;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DateRangePicker (Lcom/teya/lemonade/LemonadeUi;Lkotlin/jvm/functions/Function1;Ljava/util/List;Landroidx/compose/ui/Modifier;Lcom/teya/lemonade/DateRangePickerState;Lkotlinx/datetime/DayOfWeek;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DatePickerState;
+	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DatePickerState;
 	public static final fun rememberDateRangePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Ljava/lang/Integer;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DateRangePickerState;
+	public static final fun rememberDateRangePickerState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Ljava/lang/Integer;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/DateRangePickerState;
 }
 
 public final class com/teya/lemonade/DatePickerState {
@@ -11,6 +13,7 @@ public final class com/teya/lemonade/DatePickerState {
 	public final fun getMaxDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 }
 
 public final class com/teya/lemonade/DateRangePickerState {
@@ -21,6 +24,7 @@ public final class com/teya/lemonade/DateRangePickerState {
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedStartDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 }
 
 public final class com/teya/lemonade/InlineCalendarKt {
@@ -35,11 +39,13 @@ public final class com/teya/lemonade/InlineCalendarState {
 	public final fun getMaxDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getMinDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getToday ()Lkotlinx/datetime/LocalDate;
 	public final fun navigateToMonth (Lkotlinx/datetime/YearMonth;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 }
 
 public final class com/teya/lemonade/InlineCalendarStateKt {
+	public static final fun rememberInlineCalendarState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/YearMonth;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DayOfWeek;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/InlineCalendarState;
 	public static final fun rememberInlineCalendarState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/YearMonth;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/DayOfWeek;Landroidx/compose/runtime/Composer;II)Lcom/teya/lemonade/InlineCalendarState;
 }
 

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
@@ -55,15 +55,20 @@ private const val CENTER_PAGE = PAGES_TOTAL / 2
  * Observe [selectedDate] to react to user selections.
  *
  * @param initialDate The initially selected date — seeds [selectedDate].
+ * @param today The date treated as "today" — used to highlight the current day in the grid.
+ * Defaults to the system clock in the system timezone via [rememberDatePickerState].
+ * Override (e.g. for tests, previews, or a non-system timezone) by passing a value to
+ * [rememberDatePickerState]. To change "today" at runtime, recreate the state.
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
  * @see rememberDatePickerState
  */
 @Stable
 public class DatePickerState internal constructor(
-    initialDate: LocalDate? = null,
-    public val minDate: LocalDate? = null,
-    public val maxDate: LocalDate? = null,
+    initialDate: LocalDate?,
+    public val today: LocalDate,
+    public val minDate: LocalDate?,
+    public val maxDate: LocalDate?,
 ) {
     public var selectedDate: LocalDate? by mutableStateOf(initialDate)
         internal set
@@ -75,20 +80,25 @@ public class DatePickerState internal constructor(
  * @param initialDate The initially selected date.
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
+ * @param today The date treated as "today". Defaults to the system clock in the
+ * system timezone. Override for tests, previews, or non-system timezones.
  */
 @Composable
 public fun rememberDatePickerState(
     initialDate: LocalDate? = null,
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
-): DatePickerState =
-    remember(initialDate, minDate, maxDate) {
+    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+): DatePickerState {
+    return remember(initialDate, minDate, maxDate, today) {
         DatePickerState(
             initialDate = initialDate,
+            today = today,
             minDate = minDate,
             maxDate = maxDate,
         )
     }
+}
 
 /**
  * State holder for [LemonadeUi.DateRangePicker].
@@ -99,6 +109,9 @@ public fun rememberDatePickerState(
  *
  * @param initialStartDate Initial start date — seeds [selectedStartDate].
  * @param initialEndDate Initial end date — seeds [selectedEndDate].
+ * @param today The date treated as "today" — used to highlight the current day in the grid.
+ * Defaults to the system clock in the system timezone via [rememberDateRangePickerState].
+ * To change "today" at runtime, recreate the state.
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
  * @param maxRangeDays Maximum number of days allowed in a date range selection.
@@ -106,11 +119,12 @@ public fun rememberDatePickerState(
  */
 @Stable
 public class DateRangePickerState internal constructor(
-    initialStartDate: LocalDate? = null,
-    initialEndDate: LocalDate? = null,
-    public val minDate: LocalDate? = null,
-    public val maxDate: LocalDate? = null,
-    public val maxRangeDays: Int? = null,
+    initialStartDate: LocalDate?,
+    initialEndDate: LocalDate?,
+    public val today: LocalDate,
+    public val minDate: LocalDate?,
+    public val maxDate: LocalDate?,
+    public val maxRangeDays: Int?,
 ) {
     public var selectedStartDate: LocalDate? by mutableStateOf(initialStartDate)
         internal set
@@ -126,6 +140,8 @@ public class DateRangePickerState internal constructor(
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
  * @param maxRangeDays Maximum number of days allowed in a date range selection.
+ * @param today The date treated as "today". Defaults to the system clock in the
+ * system timezone. Override for tests, previews, or non-system timezones.
  */
 @Composable
 public fun rememberDateRangePickerState(
@@ -134,16 +150,19 @@ public fun rememberDateRangePickerState(
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
     maxRangeDays: Int? = null,
-): DateRangePickerState =
-    remember(initialStartDate, initialEndDate, minDate, maxDate, maxRangeDays) {
+    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+): DateRangePickerState {
+    return remember(initialStartDate, initialEndDate, minDate, maxDate, maxRangeDays, today) {
         DateRangePickerState(
             initialStartDate = initialStartDate,
             initialEndDate = initialEndDate,
+            today = today,
             minDate = minDate,
             maxDate = maxDate,
             maxRangeDays = maxRangeDays,
         )
     }
+}
 
 /**
  * A single-date picker widget from the Lemonade Design System.
@@ -190,6 +209,7 @@ public fun LemonadeUi.DatePicker(
         modifier = modifier,
         selectedDates = setOfNotNull(state.selectedDate),
         onDateSelected = { date -> state.selectedDate = date },
+        today = state.today,
         minDate = state.minDate,
         maxDate = state.maxDate,
         firstDayOfWeek = firstDayOfWeek,
@@ -292,6 +312,7 @@ public fun LemonadeUi.DateRangePicker(
             state.selectedStartDate = minOf(start, date)
             state.selectedEndDate = maxOf(start, date)
         },
+        today = state.today,
         minDate = effectiveMin,
         maxDate = effectiveMax,
         firstDayOfWeek = firstDayOfWeek,
@@ -306,14 +327,18 @@ private fun CoreDatePicker(
     weekdayAbbreviations: List<String>,
     selectedDates: Set<LocalDate>,
     onDateSelected: (LocalDate) -> Unit,
+    today: LocalDate,
     minDate: LocalDate?,
     maxDate: LocalDate?,
     firstDayOfWeek: DayOfWeek,
     onMonthDisplayed: ((YearMonth) -> Unit)?,
 ) {
-    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
-
-    val startMonth = remember { YearMonth(today.year, today.month.number) }
+    val startMonth = remember(today) {
+        YearMonth(
+            year = today.year,
+            month = today.month.number,
+        )
+    }
 
     val pagerState = rememberPagerState(initialPage = CENTER_PAGE) { PAGES_TOTAL }
     val coroutineScope = rememberCoroutineScope()
@@ -407,6 +432,7 @@ private fun CoreDatePicker(
             MonthGrid(
                 yearMonth = startMonth.plus(pageIndex.toLong() - CENTER_PAGE, DateTimeUnit.MONTH),
                 selectedDates = selectedDates,
+                today = today,
                 minDate = minDate,
                 maxDate = maxDate,
                 firstDayOfWeek = firstDayOfWeek,
@@ -420,13 +446,12 @@ private fun CoreDatePicker(
 private fun MonthGrid(
     yearMonth: YearMonth,
     selectedDates: Set<LocalDate>,
+    today: LocalDate,
     minDate: LocalDate?,
     maxDate: LocalDate?,
     firstDayOfWeek: DayOfWeek,
     onDateSelected: (LocalDate) -> Unit,
 ) {
-    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
-
     val days = remember(yearMonth, firstDayOfWeek) { daysForMonth(yearMonth, firstDayOfWeek = firstDayOfWeek) }
 
     val isRangeComplete = selectedDates.size >= 2

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
@@ -65,10 +65,10 @@ private const val CENTER_PAGE = PAGES_TOTAL / 2
  */
 @Stable
 public class DatePickerState internal constructor(
-    initialDate: LocalDate?,
-    public val today: LocalDate,
-    public val minDate: LocalDate?,
-    public val maxDate: LocalDate?,
+    initialDate: LocalDate? = null,
+    public val today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+    public val minDate: LocalDate? = null,
+    public val maxDate: LocalDate? = null,
 ) {
     public var selectedDate: LocalDate? by mutableStateOf(initialDate)
         internal set
@@ -80,17 +80,38 @@ public class DatePickerState internal constructor(
  * @param initialDate The initially selected date.
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
- * @param today The date treated as "today". Defaults to the system clock in the
- * system timezone. Override for tests, previews, or non-system timezones.
  */
 @Composable
 public fun rememberDatePickerState(
     initialDate: LocalDate? = null,
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
-    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
-): DatePickerState {
-    return remember(initialDate, minDate, maxDate, today) {
+): DatePickerState =
+    remember(initialDate, minDate, maxDate) {
+        DatePickerState(
+            initialDate = initialDate,
+            minDate = minDate,
+            maxDate = maxDate,
+        )
+    }
+
+/**
+ * Overload of [rememberDatePickerState] that lets the host pin "today" — useful
+ * for tests, previews, screenshot diffs, and non-system-timezone scenarios.
+ *
+ * @param today The date treated as "today" — used to highlight the current day in the grid.
+ * @param initialDate The initially selected date.
+ * @param minDate Minimum selectable date.
+ * @param maxDate Maximum selectable date.
+ */
+@Composable
+public fun rememberDatePickerState(
+    today: LocalDate,
+    initialDate: LocalDate? = null,
+    minDate: LocalDate? = null,
+    maxDate: LocalDate? = null,
+): DatePickerState =
+    remember(initialDate, minDate, maxDate, today) {
         DatePickerState(
             initialDate = initialDate,
             today = today,
@@ -98,7 +119,6 @@ public fun rememberDatePickerState(
             maxDate = maxDate,
         )
     }
-}
 
 /**
  * State holder for [LemonadeUi.DateRangePicker].
@@ -119,12 +139,12 @@ public fun rememberDatePickerState(
  */
 @Stable
 public class DateRangePickerState internal constructor(
-    initialStartDate: LocalDate?,
-    initialEndDate: LocalDate?,
-    public val today: LocalDate,
-    public val minDate: LocalDate?,
-    public val maxDate: LocalDate?,
-    public val maxRangeDays: Int?,
+    initialStartDate: LocalDate? = null,
+    initialEndDate: LocalDate? = null,
+    public val today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+    public val minDate: LocalDate? = null,
+    public val maxDate: LocalDate? = null,
+    public val maxRangeDays: Int? = null,
 ) {
     public var selectedStartDate: LocalDate? by mutableStateOf(initialStartDate)
         internal set
@@ -140,8 +160,6 @@ public class DateRangePickerState internal constructor(
  * @param minDate Minimum selectable date.
  * @param maxDate Maximum selectable date.
  * @param maxRangeDays Maximum number of days allowed in a date range selection.
- * @param today The date treated as "today". Defaults to the system clock in the
- * system timezone. Override for tests, previews, or non-system timezones.
  */
 @Composable
 public fun rememberDateRangePickerState(
@@ -150,9 +168,38 @@ public fun rememberDateRangePickerState(
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
     maxRangeDays: Int? = null,
-    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
-): DateRangePickerState {
-    return remember(initialStartDate, initialEndDate, minDate, maxDate, maxRangeDays, today) {
+): DateRangePickerState =
+    remember(initialStartDate, initialEndDate, minDate, maxDate, maxRangeDays) {
+        DateRangePickerState(
+            initialStartDate = initialStartDate,
+            initialEndDate = initialEndDate,
+            minDate = minDate,
+            maxDate = maxDate,
+            maxRangeDays = maxRangeDays,
+        )
+    }
+
+/**
+ * Overload of [rememberDateRangePickerState] that lets the host pin "today" — useful
+ * for tests, previews, screenshot diffs, and non-system-timezone scenarios.
+ *
+ * @param today The date treated as "today" — used to highlight the current day in the grid.
+ * @param initialStartDate Initial start date for the range.
+ * @param initialEndDate Initial end date for the range.
+ * @param minDate Minimum selectable date.
+ * @param maxDate Maximum selectable date.
+ * @param maxRangeDays Maximum number of days allowed in a date range selection.
+ */
+@Composable
+public fun rememberDateRangePickerState(
+    today: LocalDate,
+    initialStartDate: LocalDate? = null,
+    initialEndDate: LocalDate? = null,
+    minDate: LocalDate? = null,
+    maxDate: LocalDate? = null,
+    maxRangeDays: Int? = null,
+): DateRangePickerState =
+    remember(initialStartDate, initialEndDate, minDate, maxDate, maxRangeDays, today) {
         DateRangePickerState(
             initialStartDate = initialStartDate,
             initialEndDate = initialEndDate,
@@ -162,7 +209,6 @@ public fun rememberDateRangePickerState(
             maxRangeDays = maxRangeDays,
         )
     }
-}
 
 /**
  * A single-date picker widget from the Lemonade Design System.

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalTime::class)
-
 package com.teya.lemonade
 
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -36,17 +34,13 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.YearMonth
 import kotlinx.datetime.daysUntil
 import kotlinx.datetime.minus
 import kotlinx.datetime.number
 import kotlinx.datetime.onDay
 import kotlinx.datetime.plus
-import kotlinx.datetime.todayIn
 import kotlinx.datetime.yearMonth
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 private const val TOTAL_DAYS = 3651
 private const val CENTER_INDEX = TOTAL_DAYS / 2
@@ -185,8 +179,8 @@ public fun LemonadeUi.InlineCalendar(
     selectionContentColor: Color? = null,
     trailingContent: @Composable ((LocalDate, Boolean) -> Unit)? = null,
 ) {
-    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
-    val anchorDate = remember { today }
+    val today = state.today
+    val anchorDate = remember(today) { today }
 
     val density = LocalDensity.current
     val visibleCells = remember(density.fontScale) {

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
@@ -44,12 +44,12 @@ import kotlin.time.ExperimentalTime
  */
 @Stable
 public class InlineCalendarState internal constructor(
-    initialDate: LocalDate?,
-    initialDisplayedMonth: YearMonth?,
-    public val today: LocalDate,
-    public val minDate: LocalDate?,
-    public val maxDate: LocalDate?,
-    public val firstDayOfWeek: DayOfWeek,
+    initialDate: LocalDate? = null,
+    initialDisplayedMonth: YearMonth? = null,
+    public val today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+    public val minDate: LocalDate? = null,
+    public val maxDate: LocalDate? = null,
+    public val firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
 ) {
     /** The currently selected date. */
     public var selectedDate: LocalDate? by mutableStateOf(initialDate)
@@ -117,8 +117,8 @@ public class InlineCalendarState internal constructor(
             minDate: LocalDate?,
             maxDate: LocalDate?,
             firstDayOfWeek: DayOfWeek,
-        ): Saver<InlineCalendarState, *> {
-            return listSaver(
+        ): Saver<InlineCalendarState, *> =
+            listSaver(
                 save = { state ->
                     listOf(
                         state.selectedDate?.toString().orEmpty(),
@@ -147,7 +147,6 @@ public class InlineCalendarState internal constructor(
                     )
                 },
             )
-        }
     }
 }
 
@@ -157,10 +156,6 @@ public class InlineCalendarState internal constructor(
  *
  * @param initialDate The initially selected date.
  * @param initialDisplayedMonth The month to display initially.
- * @param today The date treated as "today". Defaults to the system clock in the
- *   system timezone. Override for tests, previews, or non-system timezones. The
- *   value is persisted across configuration changes; supplying a different value
- *   on recomposition does not retroactively change the restored state.
  * @param minDate Minimum selectable date (inclusive).
  * @param maxDate Maximum selectable date (inclusive).
  * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
@@ -175,9 +170,50 @@ public fun rememberInlineCalendarState(
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
     firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
-    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
-): InlineCalendarState {
-    return rememberSaveable(
+): InlineCalendarState =
+    rememberSaveable(
+        saver = InlineCalendarState.saver(
+            minDate = minDate,
+            maxDate = maxDate,
+            firstDayOfWeek = firstDayOfWeek,
+        ),
+    ) {
+        InlineCalendarState(
+            initialDate = initialDate,
+            initialDisplayedMonth = initialDisplayedMonth,
+            minDate = minDate,
+            maxDate = maxDate,
+            firstDayOfWeek = firstDayOfWeek,
+        )
+    }
+
+/**
+ * Overload of [rememberInlineCalendarState] that lets the host pin "today" — useful
+ * for tests, previews, screenshot diffs, and non-system-timezone scenarios. The value
+ * is persisted across configuration changes; supplying a different value on
+ * recomposition does not retroactively change the restored state.
+ *
+ * @param today The date treated as "today" — used to highlight the current day in the
+ *   strip and as the fallback displayed month.
+ * @param initialDate The initially selected date.
+ * @param initialDisplayedMonth The month to display initially.
+ * @param minDate Minimum selectable date (inclusive).
+ * @param maxDate Maximum selectable date (inclusive).
+ * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
+ *   used by the inline calendar rendering - the inline calendar is a continuous day strip
+ *   with no grid columns, so week-start ordering does not affect the displayed layout.
+ *   Stored and persisted so the API can be extended without a breaking change.
+ */
+@Composable
+public fun rememberInlineCalendarState(
+    today: LocalDate,
+    initialDate: LocalDate? = null,
+    initialDisplayedMonth: YearMonth? = null,
+    minDate: LocalDate? = null,
+    maxDate: LocalDate? = null,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+): InlineCalendarState =
+    rememberSaveable(
         saver = InlineCalendarState.saver(
             minDate = minDate,
             maxDate = maxDate,
@@ -193,4 +229,3 @@ public fun rememberInlineCalendarState(
             firstDayOfWeek = firstDayOfWeek,
         )
     }
-}

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarState.kt
@@ -30,7 +30,11 @@ import kotlin.time.ExperimentalTime
  *
  * @param initialDate The initially selected date.
  * @param initialDisplayedMonth The month shown initially; defaults to the
- *   month of [initialDate] or today.
+ *   month of [initialDate] or [today].
+ * @param today The date treated as "today" — used to highlight the current day in the
+ *   strip and as the fallback displayed month. Defaults to the system clock in the
+ *   system timezone via [rememberInlineCalendarState]. Override for tests, previews,
+ *   or a non-system timezone. To change "today" at runtime, recreate the state.
  * @param minDate Minimum selectable date (inclusive).
  * @param maxDate Maximum selectable date (inclusive).
  * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
@@ -40,11 +44,12 @@ import kotlin.time.ExperimentalTime
  */
 @Stable
 public class InlineCalendarState internal constructor(
-    initialDate: LocalDate? = null,
-    initialDisplayedMonth: YearMonth? = null,
-    public val minDate: LocalDate? = null,
-    public val maxDate: LocalDate? = null,
-    public val firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
+    initialDate: LocalDate?,
+    initialDisplayedMonth: YearMonth?,
+    public val today: LocalDate,
+    public val minDate: LocalDate?,
+    public val maxDate: LocalDate?,
+    public val firstDayOfWeek: DayOfWeek,
 ) {
     /** The currently selected date. */
     public var selectedDate: LocalDate? by mutableStateOf(initialDate)
@@ -58,10 +63,16 @@ public class InlineCalendarState internal constructor(
      */
     public var displayedMonth: YearMonth by mutableStateOf(
         initialDisplayedMonth
-            ?: initialDate?.let { YearMonth(it.year, it.month.number) }
-            ?: Clock.System.todayIn(TimeZone.currentSystemDefault()).let {
-                YearMonth(it.year, it.month.number)
-            },
+            ?: initialDate?.let { date ->
+                YearMonth(
+                    year = date.year,
+                    month = date.month.number,
+                )
+            }
+            ?: YearMonth(
+                year = today.year,
+                month = today.month.number,
+            ),
     )
         internal set
 
@@ -106,30 +117,37 @@ public class InlineCalendarState internal constructor(
             minDate: LocalDate?,
             maxDate: LocalDate?,
             firstDayOfWeek: DayOfWeek,
-        ): Saver<InlineCalendarState, *> =
-            listSaver(
+        ): Saver<InlineCalendarState, *> {
+            return listSaver(
                 save = { state ->
                     listOf(
                         state.selectedDate?.toString().orEmpty(),
                         state.displayedMonth.year,
                         state.displayedMonth.month.number,
+                        state.today.toString(),
                     )
                 },
                 restore = { list ->
                     val selectedStr = list[0] as String
                     val year = list[1] as Int
                     val month = list[2] as Int
+                    val savedToday = LocalDate.parse(list[3] as String)
                     InlineCalendarState(
                         initialDate = selectedStr
-                            .takeIf { it.isNotEmpty() }
-                            ?.let { LocalDate.parse(it) },
-                        initialDisplayedMonth = YearMonth(year, month),
+                            .takeIf { value -> value.isNotEmpty() }
+                            ?.let { value -> LocalDate.parse(value) },
+                        initialDisplayedMonth = YearMonth(
+                            year = year,
+                            month = month,
+                        ),
+                        today = savedToday,
                         minDate = minDate,
                         maxDate = maxDate,
                         firstDayOfWeek = firstDayOfWeek,
                     )
                 },
             )
+        }
     }
 }
 
@@ -139,6 +157,10 @@ public class InlineCalendarState internal constructor(
  *
  * @param initialDate The initially selected date.
  * @param initialDisplayedMonth The month to display initially.
+ * @param today The date treated as "today". Defaults to the system clock in the
+ *   system timezone. Override for tests, previews, or non-system timezones. The
+ *   value is persisted across configuration changes; supplying a different value
+ *   on recomposition does not retroactively change the restored state.
  * @param minDate Minimum selectable date (inclusive).
  * @param maxDate Maximum selectable date (inclusive).
  * @param firstDayOfWeek Reserved for future use (e.g. week-start snapping). Not currently
@@ -153,8 +175,9 @@ public fun rememberInlineCalendarState(
     minDate: LocalDate? = null,
     maxDate: LocalDate? = null,
     firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY,
-): InlineCalendarState =
-    rememberSaveable(
+    today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+): InlineCalendarState {
+    return rememberSaveable(
         saver = InlineCalendarState.saver(
             minDate = minDate,
             maxDate = maxDate,
@@ -164,8 +187,10 @@ public fun rememberInlineCalendarState(
         InlineCalendarState(
             initialDate = initialDate,
             initialDisplayedMonth = initialDisplayedMonth,
+            today = today,
             minDate = minDate,
             maxDate = maxDate,
             firstDayOfWeek = firstDayOfWeek,
         )
     }
+}

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/DatePickerDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/DatePickerDisplay.kt
@@ -9,14 +9,12 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
-import kotlinx.datetime.todayIn
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+
+// Pinned so screenshot diffs of this screen aren't flaky as the system date advances.
+private val DEMO_TODAY = LocalDate(year = 2025, month = 1, day = 15)
 
 private val monthNames = listOf(
     "January",
@@ -40,11 +38,7 @@ private fun formatMonth(month: Int): String = monthNames[month - 1]
 @Suppress("LongMethod")
 @Composable
 internal fun DatePickerDisplay() {
-    @OptIn(ExperimentalTime::class)
-    val today = remember {
-        Clock.System
-            .todayIn(TimeZone.currentSystemDefault())
-    }
+    val today = DEMO_TODAY
 
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing600),
@@ -56,7 +50,10 @@ internal fun DatePickerDisplay() {
             .padding(LemonadeTheme.spaces.spacing400),
     ) {
         DatePickerSection(title = "Default (all dates selectable)") {
-            val state = rememberDatePickerState(initialDate = today)
+            val state = rememberDatePickerState(
+                today = today,
+                initialDate = today,
+            )
             LemonadeUi.DatePicker(
                 state = state,
                 monthFormatter = ::formatMonth,
@@ -70,7 +67,10 @@ internal fun DatePickerDisplay() {
         }
 
         DatePickerSection(title = "Future dates only (minDate: today)") {
-            val state = rememberDatePickerState(minDate = today)
+            val state = rememberDatePickerState(
+                today = today,
+                minDate = today,
+            )
             LemonadeUi.DatePicker(
                 state = state,
                 monthFormatter = ::formatMonth,
@@ -84,7 +84,10 @@ internal fun DatePickerDisplay() {
         }
 
         DatePickerSection(title = "Past dates only (maxDate: today)") {
-            val state = rememberDatePickerState(maxDate = today)
+            val state = rememberDatePickerState(
+                today = today,
+                maxDate = today,
+            )
             LemonadeUi.DatePicker(
                 state = state,
                 monthFormatter = ::formatMonth,
@@ -102,6 +105,7 @@ internal fun DatePickerDisplay() {
             val customMinDate = LocalDate(today.year, monthNumber, 1)
             val customMaxDate = LocalDate(today.year, monthNumber, daysInMonth(today.year, monthNumber))
             val state = rememberDatePickerState(
+                today = today,
                 minDate = customMinDate,
                 maxDate = customMaxDate,
             )
@@ -118,7 +122,7 @@ internal fun DatePickerDisplay() {
         }
 
         DatePickerSection(title = "Date Range Mode") {
-            val state = rememberDateRangePickerState()
+            val state = rememberDateRangePickerState(today = today)
             LemonadeUi.DateRangePicker(
                 state = state,
                 monthFormatter = ::formatMonth,
@@ -133,7 +137,10 @@ internal fun DatePickerDisplay() {
         }
 
         DatePickerSection(title = "Date Range with max 7 days") {
-            val state = rememberDateRangePickerState(maxRangeDays = 7)
+            val state = rememberDateRangePickerState(
+                today = today,
+                maxRangeDays = 7,
+            )
             LemonadeUi.DateRangePicker(
                 state = state,
                 monthFormatter = ::formatMonth,

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/InlineCalendarDisplay.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalTime::class)
-
 package com.teya.lemonade
 
 import androidx.compose.foundation.background
@@ -21,16 +19,15 @@ import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.DayLabelFormat
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
 import kotlinx.datetime.plus
-import kotlinx.datetime.todayIn
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+
+// Pinned so screenshot diffs of this screen aren't flaky as the system date advances.
+private val DEMO_TODAY = LocalDate(year = 2025, month = 1, day = 15)
 
 @Composable
 internal fun InlineCalendarDisplay() {
-    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
+    val today = DEMO_TODAY
 
     Column(
         verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing600),
@@ -55,7 +52,10 @@ internal fun InlineCalendarDisplay() {
 @Composable
 private fun DefaultSection(today: LocalDate) {
     InlineCalendarSection(title = "Default (today selected)") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             onDateSelected = { /* observe state.selectedDate */ },
@@ -68,7 +68,10 @@ private fun DefaultSection(today: LocalDate) {
 @Composable
 private fun TrailingDotsSection(today: LocalDate) {
     InlineCalendarSection(title = "With trailing content (dot on every 3rd day)") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             onDateSelected = { /* observe state.selectedDate */ },
@@ -87,7 +90,10 @@ private fun TrailingDotsSection(today: LocalDate) {
 @Composable
 private fun ShortLabelsSection(today: LocalDate) {
     InlineCalendarSection(title = "Short day labels (Mon, Tue, Wed...)") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             dayLabelFormat = DayLabelFormat.Short,
@@ -104,6 +110,7 @@ private fun ConstrainedRangeSection(today: LocalDate) {
         val minDate = remember { today.plus(-7, DateTimeUnit.DAY) }
         val maxDate = remember { today.plus(30, DateTimeUnit.DAY) }
         val state = rememberInlineCalendarState(
+            today = today,
             initialDate = today,
             minDate = minDate,
             maxDate = maxDate,
@@ -125,7 +132,10 @@ private fun ConstrainedRangeSection(today: LocalDate) {
 @Composable
 private fun CompactSelectionSection(today: LocalDate) {
     InlineCalendarSection(title = "Compact selection (day number only)") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             expandSelectionToLabel = false,
@@ -139,7 +149,10 @@ private fun CompactSelectionSection(today: LocalDate) {
 @Composable
 private fun CompactDotsSection(today: LocalDate) {
     InlineCalendarSection(title = "Compact selection with trailing dots") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             expandSelectionToLabel = false,
@@ -159,7 +172,10 @@ private fun CompactDotsSection(today: LocalDate) {
 @Composable
 private fun CustomColorsSection(today: LocalDate) {
     InlineCalendarSection(title = "Custom selection colors") {
-        val state = rememberInlineCalendarState(initialDate = today)
+        val state = rememberInlineCalendarState(
+            today = today,
+            initialDate = today,
+        )
         LemonadeUi.InlineCalendar(
             state = state,
             selectionBackgroundColor = LemonadeTheme.colors.interaction.bgInfoInteractive,


### PR DESCRIPTION
## Summary
- Adds `today: LocalDate` as a constructor-time, set-once val on `DatePickerState`, `DateRangePickerState`, and `InlineCalendarState`, with matching `today` parameters on the `remember*` factories defaulted to `Clock.System.todayIn(TimeZone.currentSystemDefault())`.
- `CoreDatePicker`, `MonthGrid`, and `InlineCalendar` now consume `state.today` instead of computing it inline; `InlineCalendar`'s saver persists/restores the value across configuration changes.
- Lets hosts pin "today" for tests, previews, screenshot diffs, and non-system-timezone scenarios.

## Test plan
- [ ] Verify existing date picker / inline calendar usages still default to system today
- [ ] Override `today` in a preview/snapshot and confirm the highlighted day reflects the override
- [ ] Confirm `InlineCalendarState` restores the overridden `today` after a configuration change