### PR TITLE
fix(ci): auto re-run API Stability Review on pull_request_review

### DIFF
--- a/.github/workflows/kmp_ci.yml
+++ b/.github/workflows/kmp_ci.yml
@@ -15,9 +15,16 @@ on:
       - '.github/workflows/kmp_ci.yml'
       - '.github/actions/setup-gradle/**'
       - '!**/*.md'
+  pull_request_review:
+    # Re-evaluate api-stability-review when a maintainer adds/dismisses a
+    # review, so the gate flips automatically without a manual re-run.
+    types: [submitted, dismissed]
 
 concurrency:
-  group: kmp-ci-${{ github.ref }}
+  # push / pull_request: group per ref so a new commit cancels stale runs.
+  # pull_request_review: unique group per run so review-triggered runs never
+  # cancel an in-progress full CI run for the same PR.
+  group: ${{ github.event_name == 'pull_request_review' && format('kmp-ci-review-{0}', github.run_id) || format('kmp-ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -25,6 +32,7 @@ jobs:
     name: Detekt
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -42,6 +50,7 @@ jobs:
     name: Ktlint
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -59,6 +68,7 @@ jobs:
     name: Dependency Allowlist
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -76,6 +86,7 @@ jobs:
     name: Binary Compatibility (apiCheck)
     runs-on: macos-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request_review'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -109,7 +120,7 @@ jobs:
     name: API Stability Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
     permissions:
       contents: read
       pull-requests: read
@@ -203,6 +214,7 @@ jobs:
     name: Build
     runs-on: macos-latest
     timeout-minutes: 45
+    if: github.event_name != 'pull_request_review'
     permissions:
       contents: write
     steps:
@@ -231,28 +243,23 @@ jobs:
 
   ci-status:
     name: CI Status
-    if: always()
-    needs: [ detekt, ktlint, dependency-allowlist, api-compatibility, api-stability-review, build ]
+    # Skip on pull_request_review re-runs: those only re-evaluate
+    # api-stability-review (which reports its own check status) and skip every
+    # other job, so aggregating would either falsely pass or falsely fail.
+    # The CI Status check_run from the prior full-CI run stays valid.
+    if: always() && github.event_name != 'pull_request_review'
+    needs: [ detekt, ktlint, dependency-allowlist, api-compatibility, build ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check CI results
         run: |
-          # `api-stability-review` is skipped on push events (PR-only); treat skipped as a pass.
-          ASR="${{ needs['api-stability-review'].result }}"
-          if [[ "$ASR" != "success" && "$ASR" != "skipped" ]]; then
-            ASR_BAD=1
-          else
-            ASR_BAD=0
-          fi
-
           if [[ "${{ needs.detekt.result }}" != "success" || \
                 "${{ needs.ktlint.result }}" != "success" || \
                 "${{ needs['dependency-allowlist'].result }}" != "success" || \
                 "${{ needs['api-compatibility'].result }}" != "success" || \
-                "$ASR_BAD" == "1" || \
                 "${{ needs.build.result }}" != "success" ]]; then
-            echo "CI did not succeed: detekt=${{ needs.detekt.result }}, ktlint=${{ needs.ktlint.result }}, dependency-allowlist=${{ needs['dependency-allowlist'].result }}, api-compatibility=${{ needs['api-compatibility'].result }}, api-stability-review=$ASR, build=${{ needs.build.result }}"
+            echo "CI did not succeed: detekt=${{ needs.detekt.result }}, ktlint=${{ needs.ktlint.result }}, dependency-allowlist=${{ needs['dependency-allowlist'].result }}, api-compatibility=${{ needs['api-compatibility'].result }}, build=${{ needs.build.result }}"
             exit 1
           fi
           echo "All CI checks passed"


### PR DESCRIPTION
# Summary

The `api-stability-review` CI job correctly fails when an ABI-breaking PR is missing a maintainer approval — but it **never re-runs on its own** when an approval lands. Today, the only way to flip the check from red to green is for someone to click **"Re-run jobs"** manually. This PR makes the gate self-healing.

## What changed

- **New trigger:** `pull_request_review` (types `submitted`, `dismissed`). When a maintainer adds or dismisses a review, the workflow fires automatically.
- **Targeted re-run:** on review-triggered runs only `api-stability-review` executes; `detekt`, `ktlint`, `dependency-allowlist`, `api-compatibility`, and `build` are skipped because the PR head SHA hasn't changed and their existing check_runs from the prior full-CI run are still valid.
- **Concurrency:** review-triggered runs get a unique group (`kmp-ci-review-<run_id>`), so they never cancel an in-flight full CI run for the same PR. Push/PR runs keep the existing per-ref group with `cancel-in-progress`.
- **Independent check status:** `api-stability-review` is removed from `ci-status`'s `needs`. It reports its own check status directly on the PR. `ci-status` itself skips on `pull_request_review` events so its prior result is preserved (avoids both false-pass and false-fail from aggregating skipped needs).

## Before / after

| Scenario | Before | After |
|----------|--------|-------|
| Approver hits **Approve** on an ABI-breaking PR | Check stays red until someone clicks Re-run | Workflow auto-fires; check flips to green within minutes |
| Approver pushes a new commit | Full CI runs (unchanged) | Full CI runs (unchanged) |
| Approver **Dismisses** a previously-approving review | No re-evaluation; stale green | Re-evaluates and flips back to red |
| New push lands while a review-triggered run is in flight | n/a | New full CI run starts in its own group; review run finishes |

## Test plan

- [ ] Open a PR that touches `kmp/*/api/*.api` or `*.klib.api` with a breaking diff — verify `api-stability-review` fails as before.
- [ ] Add an APPROVED review from one of `@caiqueslp`, `@williankl`, `@DevSrSouza`.
- [ ] Confirm a new workflow run starts on its own, with only the **API Stability Review** job running and the heavier jobs skipped.
- [ ] Confirm the check transitions to ✅ on the PR without any manual "Re-run jobs" click.
- [ ] On the same PR, push a new commit — verify the full CI fires (per-ref concurrency cancels the prior full run, as before) and `api-stability-review` goes back to failing until re-approved on the new SHA.
- [ ] Dismiss the approving review — verify the check re-runs and flips to ❌.