### PR TITLE
fix(ui, composeApp): single-line SearchField placeholder + CountryFlag screen crash

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CountryFlagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/CountryFlagDisplay.kt
@@ -64,10 +64,7 @@ internal fun CountryFlagDisplay() {
             }
 
             CountryFlagShape.entries.forEach { shape ->
-                item(
-                    span = { GridItemSpan(3) },
-                    key = { "header-${shape.name}" },
-                ) {
+                item(span = { GridItemSpan(3) }) {
                     LemonadeUi.Text(
                         text = "Country Flags - ${shape.name}",
                         textStyle = LemonadeTheme.typography.headingXXSmall,
@@ -81,10 +78,9 @@ internal fun CountryFlagDisplay() {
                     key = { flag -> "${shape.name}-${flag.ordinal}" },
                 ) { flag ->
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Center,
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
                         FlagBox(
                             flag = flag,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
@@ -237,6 +238,8 @@ private fun CoreSearchFieldDecorationBox(
                     text = placeholder,
                     textStyle = LocalTypographies.current.bodyMediumRegular,
                     color = LocalColors.current.content.contentTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }


### PR DESCRIPTION
## Summary
- **SearchField placeholder** (`kmp/ui`) — constrain the hint `LemonadeUi.Text` to `maxLines = 1` + `TextOverflow.Ellipsis` so long placeholders stop wrapping to multiple lines. Matches the convention already used by `Tag`, `Tile` and `Chip`.
- **CountryFlag demo screen** (`kmp/composeApp`) — the singular `LazyVerticalGrid.item(...)` overload takes `key: Any?` directly, not a lambda. The previous code wrapped the key in `{ ... }`, so the lambda *object* became the key, which Compose can't store in a `Bundle`. Removed the offending `key` to fix the `IllegalArgumentException` that crashed the screen on open.

## Test plan
- [x] Reproduced the CountryFlag crash via adb (`IllegalArgumentException: Type of the key ... is not supported`) before the fix.
- [x] After fix, verified the source change by re-reading the file and rebuilt + reinstalled the example app.
- [ ] Manual visual check of the SearchField with a long placeholder (e.g. via `SearchFieldDisplay`) to confirm single-line + ellipsis behavior.
- [ ] Open the CountryFlag screen in the example app and confirm it renders without crashing.