### PR TITLE
feat(ui): update text field radius to radius-400

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/TextField.kt
@@ -810,7 +810,7 @@ private val TextFieldSize?.data: TextFieldData
     @Composable get() {
         return when (this) {
             TextFieldSize.Small -> TextFieldData(
-                containerShape = LocalShapes.current.radius200,
+                containerShape = LocalShapes.current.radius400,
                 horizontalPadding = LocalSpaces.current.spacing200,
                 verticalPadding = LocalSpaces.current.spacing100,
                 itemsSpacing = LocalSpaces.current.spacing200,
@@ -819,7 +819,7 @@ private val TextFieldSize?.data: TextFieldData
             )
 
             TextFieldSize.Medium -> TextFieldData(
-                containerShape = LocalShapes.current.radius200,
+                containerShape = LocalShapes.current.radius400,
                 horizontalPadding = LocalSpaces.current.spacing300,
                 verticalPadding = LocalSpaces.current.spacing200,
                 itemsSpacing = LocalSpaces.current.spacing300,
@@ -828,7 +828,7 @@ private val TextFieldSize?.data: TextFieldData
             )
 
             TextFieldSize.Large -> TextFieldData(
-                containerShape = LocalShapes.current.radius300,
+                containerShape = LocalShapes.current.radius400,
                 horizontalPadding = LocalSpaces.current.spacing300,
                 verticalPadding = LocalSpaces.current.spacing300,
                 itemsSpacing = LocalSpaces.current.spacing300,
@@ -838,7 +838,7 @@ private val TextFieldSize?.data: TextFieldData
 
             null -> {
                 TextFieldData(
-                    containerShape = LocalShapes.current.radius300,
+                    containerShape = LocalShapes.current.radius400,
                     horizontalPadding = LocalSpaces.current.spacing300,
                     verticalPadding = LocalSpaces.current.spacing300,
                     itemsSpacing = LocalSpaces.current.spacing300,

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 enum TextFieldConstants {
     static var minHeight: CGFloat { LemonadeTheme.sizes.size1400 }
-    static let cornerRadius: CGFloat = LemonadeTheme.radius.radius300
+    static let cornerRadius: CGFloat = LemonadeTheme.radius.radius400
     static let horizontalPadding: CGFloat = LemonadeTheme.spaces.spacing300
     static let verticalPadding: CGFloat = LemonadeTheme.spaces.spacing300
 }
@@ -171,12 +171,11 @@ struct TextFieldContainerModifier: ViewModifier {
                     .stroke(borderColor, lineWidth: LemonadeTheme.borderWidth.base.border25)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius + 2)
+                RoundedRectangle(cornerRadius: cornerRadius)
                     .stroke(
-                        isFocused ? LemonadeTheme.colors.background.bgElevated : .clear,
-                        lineWidth: LemonadeTheme.borderWidth.base.border50
+                        isFocused ? LemonadeTheme.colors.border.borderSelected : .clear,
+                        lineWidth: LemonadeTheme.borderWidth.state.focusRing
                     )
-                    .padding(-2)
             )
             .opacity(applyOpacity && !enabled ? LemonadeTheme.opacity.state.opacityDisabled : 1.0)
             .onHover { hovering in


### PR DESCRIPTION
## Summary
- Updated SwiftUI `TextFieldConstants.cornerRadius` from `radius300` to `radius400`
- Updated KMP/Compose container shape to `radius400` across all sizes (Small, Medium, Large, default)
- Fixed SwiftUI focus ring to overlap the field using `borderSelected` color and semantic `state.focusRing` width token

## Test plan
- [ ] Text fields render with visibly rounder corners on iOS
- [ ] Text fields render with visibly rounder corners on Android/KMP
- [ ] Focus ring appears overlapping the field on iOS when focused
- [ ] No regression in error state border or disabled state opacity

## API Dump

**Verdict:** NO_CHANGES

No public API changes — the update only swaps radius token values inside the private `TextFieldSize.data` mapping; no `api/*.api` or `*.klib.api` baseline file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
