### PR TITLE
fix(calendar): stop StackOverflow in today-less DatePicker/InlineCalendar overloads

### DIFF
--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/DatePicker.kt
@@ -318,6 +318,7 @@ public fun LemonadeUi.DatePicker(
         modifier = modifier,
         state = state,
         firstDayOfWeek = firstDayOfWeek,
+        today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) },
         onMonthDisplayed = onMonthDisplayed,
     )
 }
@@ -337,6 +338,7 @@ public fun LemonadeUi.DateRangePicker(
         modifier = modifier,
         state = state,
         firstDayOfWeek = firstDayOfWeek,
+        today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) },
         onMonthDisplayed = onMonthDisplayed,
     )
 }

--- a/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
+++ b/kmp/calendar/src/commonMain/kotlin/com/teya/lemonade/InlineCalendar.kt
@@ -434,6 +434,7 @@ public fun LemonadeUi.InlineCalendar(
         expandSelectionToLabel = expandSelectionToLabel,
         selectionBackgroundColor = selectionBackgroundColor,
         selectionContentColor = selectionContentColor,
+        today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) },
         trailingContent = trailingContent,
     )
 }


### PR DESCRIPTION
## Problem

PR #203 added a `today: LocalDate` parameter to `DatePicker`, `DateRangePicker`, and `InlineCalendar`, and kept the old today-less signatures as plain public overloads for binary compatibility.

Each compat overload delegated with the **exact same argument set** (no `today`):

```kotlin
public fun LemonadeUi.DatePicker(/* …, no today */) {
    DatePicker(/* same args, still no today */) // ← resolves back to THIS overload
}
```

Kotlin overload resolution prefers the most specific match, so the call binds back to the compat overload itself → **infinite recursion → StackOverflow** the moment any caller uses the today-less signature.

This crashes the Teya app's `EditScheduleCalendar`, which calls `DatePicker(...)` without `today`. Surfaced by the Lemonade bump in saltpay/teya-business-app#1258, and not fixed in 0.15.7.

## Fix

Pass `today` explicitly in each delegating call. A named `today =` argument excludes the today-less overload (which has no such parameter) from the candidate set, forcing resolution to the full overload. The value reproduces the previous default exactly:

```kotlin
today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
```

Applied to all three affected components: `DatePicker`, `DateRangePicker`, `InlineCalendar`.

## Compatibility

Signatures are unchanged — only function bodies — so the ABI is preserved. `:calendar:apiCheck` and `:calendar:checkKotlinAbi` pass.

## Verification

- `./gradlew :calendar:compileDebugKotlinAndroid` ✅
- `./gradlew :calendar:apiCheck :calendar:checkKotlinAbi` ✅ (ABI preserved)
- `./gradlew :calendar:ktlintCheck :calendar:detekt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)