### PR TITLE
feat(tag): add NeutralOnColor voice variant

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
@@ -193,11 +193,11 @@ internal fun TagDisplay() {
 private fun OnColorContainer(content: @Composable () -> Unit) {
     Box(
         modifier = Modifier
+            .padding(LemonadeTheme.spaces.spacing200)
             .background(
                 color = LemonadeTheme.colors.background.bgAlwaysDark,
                 shape = LocalShapes.current.radius150,
-            ).padding(LemonadeTheme.spaces.spacing200),
-    ) {
+            ),
         content()
     }
 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
@@ -53,6 +53,10 @@ internal fun TagDisplay() {
                     LemonadeUi.Tag(label = "Info", voice = TagVoice.Info)
                     LemonadeUi.Tag(label = "Positive", voice = TagVoice.Positive)
                 }
+
+                OnColorContainer {
+                    LemonadeUi.Tag(label = "Neutral On Color", voice = TagVoice.NeutralOnColor)
+                }
             }
         }
 
@@ -66,6 +70,9 @@ internal fun TagDisplay() {
                 LemonadeUi.Tag(label = "Warning", icon = LemonadeIcons.TriangleAlert, voice = TagVoice.Warning)
                 LemonadeUi.Tag(label = "Info", icon = LemonadeIcons.CircleInfo, voice = TagVoice.Info)
                 LemonadeUi.Tag(label = "Success", icon = LemonadeIcons.CircleCheck, voice = TagVoice.Positive)
+                OnColorContainer {
+                    LemonadeUi.Tag(label = "Neutral On Color", icon = LemonadeIcons.Heart, voice = TagVoice.NeutralOnColor)
+                }
             }
         }
 
@@ -175,6 +182,20 @@ internal fun TagDisplay() {
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun OnColorContainer(content: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = LemonadeTheme.colors.background.bgAlwaysDark,
+                shape = LocalShapes.current.radius150,
+            )
+            .padding(LemonadeTheme.spaces.spacing200),
+    ) {
+        content()
     }
 }
 

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
@@ -192,8 +192,7 @@ private fun OnColorContainer(content: @Composable () -> Unit) {
             .background(
                 color = LemonadeTheme.colors.background.bgAlwaysDark,
                 shape = LocalShapes.current.radius150,
-            )
-            .padding(LemonadeTheme.spaces.spacing200),
+            ).padding(LemonadeTheme.spaces.spacing200),
     ) {
         content()
     }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
@@ -71,7 +71,11 @@ internal fun TagDisplay() {
                 LemonadeUi.Tag(label = "Info", icon = LemonadeIcons.CircleInfo, voice = TagVoice.Info)
                 LemonadeUi.Tag(label = "Success", icon = LemonadeIcons.CircleCheck, voice = TagVoice.Positive)
                 OnColorContainer {
-                    LemonadeUi.Tag(label = "Neutral On Color", icon = LemonadeIcons.Heart, voice = TagVoice.NeutralOnColor)
+                    LemonadeUi.Tag(
+                        label = "Neutral On Color",
+                        icon = LemonadeIcons.Heart,
+                        voice = TagVoice.NeutralOnColor,
+                    )
                 }
             }
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/TagDisplay.kt
@@ -198,6 +198,7 @@ private fun OnColorContainer(content: @Composable () -> Unit) {
                 color = LemonadeTheme.colors.background.bgAlwaysDark,
                 shape = LocalShapes.current.radius150,
             ),
+    ) {
         content()
     }
 }

--- a/kmp/core/api/android/core.api
+++ b/kmp/core/api/android/core.api
@@ -1047,6 +1047,7 @@ public final class com/teya/lemonade/core/TagVoice : java/lang/Enum {
 	public static final field Critical Lcom/teya/lemonade/core/TagVoice;
 	public static final field Info Lcom/teya/lemonade/core/TagVoice;
 	public static final field Neutral Lcom/teya/lemonade/core/TagVoice;
+	public static final field NeutralOnColor Lcom/teya/lemonade/core/TagVoice;
 	public static final field Positive Lcom/teya/lemonade/core/TagVoice;
 	public static final field Warning Lcom/teya/lemonade/core/TagVoice;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/core/api/core.klib.api
+++ b/kmp/core/api/core.klib.api
@@ -1141,6 +1141,7 @@ final enum class com.teya.lemonade.core/TagVoice : kotlin/Enum<com.teya.lemonade
     enum entry Critical // com.teya.lemonade.core/TagVoice.Critical|null[0]
     enum entry Info // com.teya.lemonade.core/TagVoice.Info|null[0]
     enum entry Neutral // com.teya.lemonade.core/TagVoice.Neutral|null[0]
+    enum entry NeutralOnColor // com.teya.lemonade.core/TagVoice.NeutralOnColor|null[0]
     enum entry Positive // com.teya.lemonade.core/TagVoice.Positive|null[0]
     enum entry Warning // com.teya.lemonade.core/TagVoice.Warning|null[0]
 

--- a/kmp/core/api/desktop/core.api
+++ b/kmp/core/api/desktop/core.api
@@ -1047,6 +1047,7 @@ public final class com/teya/lemonade/core/TagVoice : java/lang/Enum {
 	public static final field Critical Lcom/teya/lemonade/core/TagVoice;
 	public static final field Info Lcom/teya/lemonade/core/TagVoice;
 	public static final field Neutral Lcom/teya/lemonade/core/TagVoice;
+	public static final field NeutralOnColor Lcom/teya/lemonade/core/TagVoice;
 	public static final field Positive Lcom/teya/lemonade/core/TagVoice;
 	public static final field Warning Lcom/teya/lemonade/core/TagVoice;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tag.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/Tag.kt
@@ -8,4 +8,5 @@ public enum class TagVoice {
     Warning,
     Info,
     Positive,
+    NeutralOnColor,
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tag.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tag.kt
@@ -102,6 +102,7 @@ private val TagVoice.tintColor: Color
             TagVoice.Warning -> LocalColors.current.content.contentCaution
             TagVoice.Info -> LocalColors.current.content.contentInfo
             TagVoice.Positive -> LocalColors.current.content.contentPositive
+            TagVoice.NeutralOnColor -> LocalColors.current.content.contentAlwaysDark
         }
     }
 
@@ -113,6 +114,7 @@ private val TagVoice.containerColor: Color
             TagVoice.Warning -> LocalColors.current.background.bgCautionSubtle
             TagVoice.Info -> LocalColors.current.background.bgInfoSubtle
             TagVoice.Positive -> LocalColors.current.background.bgPositiveSubtle
+            TagVoice.NeutralOnColor -> LocalColors.current.background.bgAlwaysLight
         }
     }
 
@@ -124,6 +126,7 @@ private val TagVoice.borderColor: Color
             TagVoice.Warning -> LocalColors.current.border.borderCautionSubtle
             TagVoice.Info -> LocalColors.current.border.borderInfoSubtle
             TagVoice.Positive -> LocalColors.current.border.borderPositiveSubtle
+            TagVoice.NeutralOnColor -> LocalColors.current.border.borderNeutralLow
         }
     }
 

--- a/swiftui/SampleApp/TagDisplayView.swift
+++ b/swiftui/SampleApp/TagDisplayView.swift
@@ -17,8 +17,12 @@ struct TagDisplayView: View {
                         HStack(spacing: 8) {
                             LemonadeUi.Tag(label: "Info", voice: .info)
                             LemonadeUi.Tag(label: "Positive", voice: .positive)
-                            LemonadeUi.Tag(label: "Neutral On Color", voice: .neutralOnColor)
                         }
+
+                        LemonadeUi.Tag(label: "Neutral On Color", voice: .neutralOnColor)
+                            .padding(.all, 8)
+                            .background(LemonadeTheme.colors.background.bgAlwaysDark)
+                            .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius150))
                     }
                 }
 
@@ -30,6 +34,10 @@ struct TagDisplayView: View {
                         LemonadeUi.Tag(label: "Warning", icon: .triangleAlert, voice: .warning)
                         LemonadeUi.Tag(label: "Info", icon: .circleInfo, voice: .info)
                         LemonadeUi.Tag(label: "Success", icon: .circleCheck, voice: .positive)
+                        LemonadeUi.Tag(label: "Neutral On Color", icon: .heart, voice: .neutralOnColor)
+                            .padding(.all, 8)
+                            .background(LemonadeTheme.colors.background.bgAlwaysDark)
+                            .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius150))
                     }
                 }
 

--- a/swiftui/SampleApp/TagDisplayView.swift
+++ b/swiftui/SampleApp/TagDisplayView.swift
@@ -17,6 +17,7 @@ struct TagDisplayView: View {
                         HStack(spacing: 8) {
                             LemonadeUi.Tag(label: "Info", voice: .info)
                             LemonadeUi.Tag(label: "Positive", voice: .positive)
+                            LemonadeUi.Tag(label: "Neutral On Color", voice: .neutralOnColor)
                         }
                     }
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTag.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTag.swift
@@ -10,6 +10,7 @@ public enum TagVoice {
     case warning
     case info
     case positive
+    case neutralOnColor
 
     var tintColor: Color {
         switch self {
@@ -18,6 +19,7 @@ public enum TagVoice {
         case .warning: return LemonadeTheme.colors.content.contentCaution
         case .info: return LemonadeTheme.colors.content.contentInfo
         case .positive: return LemonadeTheme.colors.content.contentPositive
+        case .neutralOnColor: return LemonadeTheme.colors.content.contentAlwaysDark
         }
     }
 
@@ -28,6 +30,7 @@ public enum TagVoice {
         case .warning: return LemonadeTheme.colors.background.bgCautionSubtle
         case .info: return LemonadeTheme.colors.background.bgInfoSubtle
         case .positive: return LemonadeTheme.colors.background.bgPositiveSubtle
+        case .neutralOnColor: return LemonadeTheme.colors.background.bgAlwaysLight
         }
     }
 
@@ -38,6 +41,7 @@ public enum TagVoice {
         case .warning: return LemonadeTheme.colors.border.borderCautionSubtle
         case .info: return LemonadeTheme.colors.border.borderInfoSubtle
         case .positive: return LemonadeTheme.colors.border.borderPositiveSubtle
+        case .neutralOnColor: return LemonadeTheme.colors.border.borderNeutralLow
         }
     }
 }
@@ -119,17 +123,17 @@ private struct LemonadeTagView: View {
 #if DEBUG
 struct LemonadeTag_Previews: PreviewProvider {
     static var previews: some View {
-        VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 16) {
             // All voices without icon
-            HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 8) {
                 LemonadeUi.Tag(label: "Neutral", voice: .neutral)
                 LemonadeUi.Tag(label: "Critical", voice: .critical)
                 LemonadeUi.Tag(label: "Warning", voice: .warning)
-            }
-
-            HStack(spacing: 8) {
                 LemonadeUi.Tag(label: "Info", voice: .info)
                 LemonadeUi.Tag(label: "Positive", voice: .positive)
+                LemonadeUi.Tag(label: "Neutral On Color", voice: .neutralOnColor)
+                    .padding(.all)
+                    .background(LemonadeTheme.colors.background.bgAlwaysDark)
             }
 
             // All voices with icon
@@ -139,6 +143,9 @@ struct LemonadeTag_Previews: PreviewProvider {
                 LemonadeUi.Tag(label: "Warning", icon: .triangleAlert, voice: .warning)
                 LemonadeUi.Tag(label: "Info", icon: .circleInfo, voice: .info)
                 LemonadeUi.Tag(label: "Positive", icon: .circleCheck, voice: .positive)
+                LemonadeUi.Tag(label: "Neutral On Color", icon: .heart, voice: .neutralOnColor)
+                    .padding(.all)
+                    .background(LemonadeTheme.colors.background.bgAlwaysDark)
             }
         }
         .padding()


### PR DESCRIPTION
## Summary
- Adds `TagVoice.NeutralOnColor` (`neutralOnColor` in Swift) — a new voice intended for use on colored/dark surfaces
- Uses `contentAlwaysDark`, `bgAlwaysLight`, and `borderNeutralLow` tokens (theme-invariant, sourced from Figma variable inspection)
- Updates KMP and SwiftUI sample apps to show the variant on a `bgAlwaysDark` background in both Voices and With Icons sections
- Updates KMP binary compatibility baselines (addition-only, auto-passes CI)

## API Dump
Addition-only: one new enum entry (`NeutralOnColor`) added to `TagVoice`. No removals, no renames. Auto-passes the API Stability Review.

## Screenshot
<img width="393" alt="Screenshot_20260601-115937" src="https://github.com/user-attachments/assets/397d552a-51a3-43d9-a0a1-b895528c6071" />

## Test plan
- [ ] KMP sample app: Tag screen shows `NeutralOnColor` on dark background in Voices and With Icons sections
- [ ] SwiftUI sample app: Tag screen shows `neutralOnColor` on dark background in Voices section
- [ ] Both light and dark mode — tag remains visually consistent (always-light background, always-dark text)
- [ ] CI `apiCheck` passes (additions-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)