### PR TITLE
ci(kmp): re-run failed API gate in place on review (drop stale-check reconcile)

### DIFF
--- a/.github/workflows/kmp_api_review_rerun.yml
+++ b/.github/workflows/kmp_api_review_rerun.yml
@@ -1,0 +1,130 @@
+name: KMP API Gate Re-run on Review
+
+# The "API Stability Review" gate in kmp_ci.yml goes red on an ABI-breaking
+# change until a named maintainer approves the head commit. That check runs on
+# `pull_request`, so it has no way to notice an approval that lands afterwards.
+#
+# The old fix re-triggered the job as a brand-new run, which left the original
+# red check behind and needed a flaky cross-run check-run PATCH to "reconcile"
+# it. This workflow drops that approach entirely: on a new review it re-runs the
+# already-failed job IN PLACE on the original CI run, so the SAME check flips
+# red -> green once the approval is visible. No second check_run, no
+# reconciliation.
+#
+# Flow:
+#   1. Find the "KMP CI" run for the PR's current head SHA.
+#   2. If that run is still in progress, WAIT for it to finish — a run can only
+#      be re-run once it has concluded.
+#   3. If a binary-compatibility gate job failed, re-run the failed jobs in
+#      place. If nothing relevant failed, do nothing.
+#
+# Concurrency is keyed per-PR with cancel-in-progress, so when a second review
+# lands while we are still waiting, the stale waiter is cancelled and a fresh
+# run starts — by then every review (and its approval) is already visible.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: kmp-api-review-rerun-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  actions: write        # re-run the failed jobs of an existing run
+  checks: read          # read job/check conclusions
+  pull-requests: read
+
+jobs:
+  rerun-failed-api-gate:
+    name: Re-run failed API gate on review
+    runs-on: ubuntu-latest
+    # Generous: the original CI Build job can take ~45 min and we may have to
+    # wait for it before anything can be re-run.
+    timeout-minutes: 60
+    # Nothing to gate on draft or already-closed PRs.
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # CI workflow whose run we inspect and re-run.
+      CI_WORKFLOW_FILE: kmp_ci.yml
+    steps:
+      - name: Find the KMP CI run for this commit
+        id: find
+        run: |
+          set -euo pipefail
+          echo "Looking for '${CI_WORKFLOW_FILE}' run on ${HEAD_SHA} (PR #${PR_NUMBER})."
+
+          RUN_ID=$(gh api \
+            "repos/${REPO}/actions/workflows/${CI_WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+
+          if [ -z "${RUN_ID}" ]; then
+            echo "::notice::No KMP CI run found for ${HEAD_SHA} (PR may not touch kmp/**). Nothing to re-run."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found run ${RUN_ID}."
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the run to finish
+        id: wait
+        if: steps.find.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          RUN_ID="${{ steps.find.outputs.run_id }}"
+
+          # Poll until the run completes. ~50 min cap (150 * 20s) covers the
+          # slowest Build job; if it is still going we bail out and let the next
+          # review (or a manual re-run) reconcile it.
+          for _ in $(seq 1 150); do
+            STATUS=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.status')
+            echo "Run ${RUN_ID} status: ${STATUS}"
+            if [ "${STATUS}" = "completed" ]; then
+              CONCLUSION=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
+              echo "Run ${RUN_ID} conclusion: ${CONCLUSION}"
+              echo "conclusion=${CONCLUSION}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 20
+          done
+
+          echo "::warning::KMP CI run ${RUN_ID} did not finish within the wait window. Skipping; a later review or manual re-run will reconcile."
+          echo "conclusion=timed_out" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run the failed API gate (if it failed)
+        if: steps.find.outputs.found == 'true' && steps.wait.outputs.conclusion == 'failure'
+        run: |
+          set -euo pipefail
+          RUN_ID="${{ steps.find.outputs.run_id }}"
+
+          # Which binary-compatibility gate job(s) actually failed on this run?
+          # "API Stability Review" is the one a new approval flips; the apiCheck
+          # baseline job is included so a co-failure is re-run alongside it.
+          # jq compares exact strings, so the literal "(apiCheck)" needs no
+          # escaping (unlike a regex).
+          FAILED_GATE=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[]
+                  | select(.conclusion == "failure")
+                  | select(.name == "API Stability Review" or .name == "Binary Compatibility (apiCheck)")
+                  | .name')
+
+          if [ -z "${FAILED_GATE}" ]; then
+            echo "::notice::Run ${RUN_ID} failed, but no binary-compatibility gate job did. A review cannot fix the other failures, so nothing to re-run."
+            exit 0
+          fi
+
+          echo "Failed gate job(s) on run ${RUN_ID}:"
+          echo "${FAILED_GATE}"
+          echo "Re-running the failed jobs in place so the existing check re-evaluates against the new approval."
+          gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+
+      - name: Nothing to do
+        if: steps.find.outputs.found == 'true' && steps.wait.outputs.conclusion != 'failure'
+        run: |
+          echo "KMP CI run for ${HEAD_SHA} concluded '${{ steps.wait.outputs.conclusion }}' — the API gate is not red, skipping re-run."

--- a/.github/workflows/kmp_ci.yml
+++ b/.github/workflows/kmp_ci.yml
@@ -15,16 +15,8 @@ on:
       - '.github/workflows/kmp_ci.yml'
       - '.github/actions/setup-gradle/**'
       - '!**/*.md'
-  pull_request_review:
-    # Re-evaluate api-stability-review when a maintainer adds/dismisses a
-    # review, so the gate flips automatically without a manual re-run.
-    types: [submitted, dismissed]
-
 concurrency:
-  # push / pull_request: group per ref so a new commit cancels stale runs.
-  # pull_request_review: unique group per run so review-triggered runs never
-  # cancel an in-progress full CI run for the same PR.
-  group: ${{ github.event_name == 'pull_request_review' && format('kmp-ci-review-{0}', github.run_id) || format('kmp-ci-{0}', github.ref) }}
+  group: kmp-ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -32,7 +24,6 @@ jobs:
     name: Detekt
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -50,7 +41,6 @@ jobs:
     name: Ktlint
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -68,7 +58,6 @@ jobs:
     name: Dependency Allowlist
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name != 'pull_request_review'
     env:
       GRADLE_OPTS: -Xmx3g
     steps:
@@ -86,7 +75,6 @@ jobs:
     name: Binary Compatibility (apiCheck)
     runs-on: macos-latest
     timeout-minutes: 30
-    if: github.event_name != 'pull_request_review'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -117,14 +105,19 @@ jobs:
     # Classifies the PR's `.api` / `.klib.api` diff and — for ABI-breaking
     # changes — requires an APPROVED review from one of the named maintainers
     # tied to the latest commit. Pure additions auto-pass.
+    #
+    # On a breaking change this check is red until a maintainer approves the
+    # head commit. Re-evaluating it against that approval is handled out-of-band
+    # by `.github/workflows/kmp_api_review_rerun.yml`, which re-runs this exact
+    # failed job in place on `pull_request_review` so the SAME check flips green
+    # — no second check_run and no stale-check reconciliation.
     name: API Stability Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read
-      checks: write
     env:
       APPROVERS: caiqueslp williankl DevSrSouza
     steps:
@@ -217,47 +210,10 @@ jobs:
           echo "::error::Re-request review after every new push — approvals are matched against the latest commit SHA."
           exit 1
 
-      - name: Reconcile stale failed check on approval
-        # On a pull_request_review re-run, the original commit-triggered run left a
-        # FAILED "API Stability Review" check on this same head SHA. We only reach
-        # this step when the verdict now passes (additive, or breaking-but-approved),
-        # because the steps above exit non-zero otherwise and skip this one. Flip the
-        # stale failed check to success so the merge gate reflects the current verdict.
-        #
-        # The newly-created check from this run is the authoritative one, so this is
-        # belt-and-suspenders cleanup of the old one. It is allowed to fail soft: if
-        # the API ever rejects the cross-run update, we fall back to GitHub picking
-        # the latest check run of the same name.
-        if: github.event_name == 'pull_request_review'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -uo pipefail
-          STALE=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs?per_page=100" \
-            --jq '.check_runs[] | select(.name == "API Stability Review" and .status == "completed" and .conclusion == "failure") | .id' || true)
-
-          if [ -z "${STALE}" ]; then
-            echo "No stale failed 'API Stability Review' check on ${HEAD_SHA} to reconcile."
-            exit 0
-          fi
-
-          for id in ${STALE}; do
-            echo "Flipping stale check run ${id} to success."
-            if ! gh api -X PATCH "repos/${{ github.repository }}/check-runs/${id}" \
-                -f status=completed \
-                -f conclusion=success \
-                -f 'output[title]=Superseded by approved review' \
-                -f 'output[summary]=A later API Stability Review run on this commit passed (additive change, or breaking change approved by a maintainer). This stale failed check was reconciled so it no longer blocks merge.'; then
-              echo "::warning::Could not update stale check run ${id}. Merge still relies on the latest passing check of the same name."
-            fi
-          done
-
   build:
     name: Build
     runs-on: macos-latest
     timeout-minutes: 45
-    if: github.event_name != 'pull_request_review'
     permissions:
       contents: write
     steps:
@@ -286,11 +242,7 @@ jobs:
 
   ci-status:
     name: CI Status
-    # Skip on pull_request_review re-runs: those only re-evaluate
-    # api-stability-review (which reports its own check status) and skip every
-    # other job, so aggregating would either falsely pass or falsely fail.
-    # The CI Status check_run from the prior full-CI run stays valid.
-    if: always() && github.event_name != 'pull_request_review'
+    if: always()
     needs: [ detekt, ktlint, dependency-allowlist, api-compatibility, build ]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
# Summary

Replaces the flaky `pull_request_review` handling that was added in #204.

**The problem.** When an ABI-breaking change needs maintainer approval, the **API Stability Review** check is red. #204 tried to flip it green on approval by re-triggering `api-stability-review` as a *brand-new* workflow run. That:
- created a **second** "API Stability Review" check on the same head SHA, leaving the original red one in place, and
- relied on a cross-run check-run `PATCH` ("Reconcile stale failed check") to retro-flip the stale check.

That reconciliation is the broken part — it's brittle and branch protection keeps enforcing whichever check it treats as authoritative.

**The fix — re-run the failed job *in place*.** A new workflow re-runs the already-failed job on the **original** CI run, so the **same** check goes red→green once the approval is visible. No second check, no reconciliation.

## What changed

**`.github/workflows/kmp_ci.yml`** — back to a clean push/PR CI:
- Removed the `pull_request_review` trigger, the per-event concurrency group, and the per-job `if: github.event_name != 'pull_request_review'` guards.
- `api-stability-review` is `pull_request`-only again; dropped its now-unused `checks: write` permission and the whole "Reconcile stale failed check" step.
- `ci-status` reverts to `if: always()`.

**`.github/workflows/kmp_api_review_rerun.yml`** (new, `pull_request_review: [submitted]`):
1. Find the KMP CI run for the PR's current head SHA. (None → nothing touched `kmp/**` → skip.)
2. **If it's still running, wait** for it to conclude — a run can only be re-run once finished.
3. **If a binary-compat gate job failed, re-run the failed jobs in place** via `rerun-failed-jobs`. If nothing relevant failed → skip.
4. **Concurrency keyed per-PR with `cancel-in-progress`** — a second review while we're still waiting cancels the stale waiter and starts fresh, so by the time it checks, every review (and approval) is visible.

## Note on the gated check name

You described keying on `Binary Compatibility (apiCheck)`. The check that actually flips on a **new approval** is **API Stability Review** (the approval-gated job) — `apiCheck` just compares the baseline and is review-independent, so re-running it on an approval changes nothing. The new workflow therefore keys on **API Stability Review**, while still re-running a co-failed `Binary Compatibility (apiCheck)` if it happens to be red too. Shout if you'd rather it key strictly on `apiCheck`.

## Behavioral notes for review

- `pull_request_review` workflows run from the **default branch's** copy of the file (like `pull_request_target`), so this only takes effect **after merge to `main`** — this PR won't exercise it.
- `api-stability-review` stays a standalone required check (not in `ci-status`'s `needs`, unchanged from #204). The in-place re-run flips that exact check, so the merge gate clears without touching `ci-status`.
- Scoped to review **`submitted`**. Per your spec ("if it didn't fail, skip"), a review *dismissal* is intentionally **not** handled — re-running can't turn a green job red, and dismissal-driven re-failing was out of scope. Happy to add it if you want the gate to re-close on dismissal.

## API Dump

No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)