### PR TITLE
fix(notice): align KMP and SwiftUI implementations with Figma design

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Notice.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Notice.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -107,7 +105,7 @@ private fun CoreNotice(
             Box(
                 modifier = Modifier.size(
                     width = LocalSizes.current.size500,
-                    height = LocalSizes.current.size600,
+                    height = if (title != null) LocalSizes.current.size600 else LocalSizes.current.size500,
                 ),
                 contentAlignment = Alignment.Center,
             ) {
@@ -121,7 +119,6 @@ private fun CoreNotice(
         }
 
         Column(
-            verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
             modifier = Modifier.weight(weight = 1f),
         ) {
             if (title != null) {
@@ -135,21 +132,16 @@ private fun CoreNotice(
             LemonadeUi.Text(
                 text = content,
                 color = LocalColors.current.content.contentPrimary,
-                textStyle = if (title != null) {
-                    LocalTypographies.current.bodySmallRegular
-                } else {
-                    LocalTypographies.current.bodyMediumRegular
-                },
+                textStyle = LocalTypographies.current.bodySmallRegular,
             )
 
             if (actionLabel != null) {
-                Spacer(modifier = Modifier.height(LocalSpaces.current.spacing200))
-
                 LemonadeUi.Text(
                     text = actionLabel,
-                    textStyle = LocalTypographies.current.bodyMediumSemiBold,
+                    textStyle = LocalTypographies.current.bodySmallSemiBold,
                     color = colors.actionTextColor,
                     modifier = Modifier
+                        .padding(top = LocalSpaces.current.spacing200)
                         .clickable(
                             onClick = { onActionClick?.invoke() },
                             role = Role.Button,

--- a/swiftui/Sources/Lemonade/Components/LemonadeNotice.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeNotice.swift
@@ -101,11 +101,11 @@ private struct LemonadeNoticeView: View {
                 )
                 .frame(
                     width: LemonadeTheme.sizes.size500,
-                    height: LemonadeTheme.sizes.size600
+                    height: title != nil ? LemonadeTheme.sizes.size600 : LemonadeTheme.sizes.size500
                 )
             }
 
-            VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing100) {
+            VStack(alignment: .leading, spacing: 0) {
                 if let title {
                     LemonadeUi.Text(
                         title,
@@ -116,32 +116,13 @@ private struct LemonadeNoticeView: View {
 
                 LemonadeUi.Text(
                     content,
-                    textStyle: title != nil
-                        ? LemonadeTypography.shared.bodySmallRegular
-                        : LemonadeTypography.shared.bodyMediumRegular,
+                    textStyle: LemonadeTypography.shared.bodySmallRegular,
                     color: LemonadeTheme.colors.content.contentPrimary
                 )
 
                 if let actionLabel {
-                    Spacer()
-                        .frame(height: LemonadeTheme.spaces.spacing200)
-
-                    if let onActionClick {
-                        SwiftUI.Button(action: onActionClick) {
-                            LemonadeUi.Text(
-                                actionLabel,
-                                textStyle: LemonadeTypography.shared.bodyMediumSemiBold,
-                                color: voice.actionTextColor
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    } else {
-                        LemonadeUi.Text(
-                            actionLabel,
-                            textStyle: LemonadeTypography.shared.bodyMediumSemiBold,
-                            color: voice.actionTextColor
-                        )
-                    }
+                    actionLabelView(actionLabel)
+                        .padding(.top, LemonadeTheme.spaces.spacing200)
                 }
             }
         }
@@ -149,6 +130,26 @@ private struct LemonadeNoticeView: View {
         .padding(LemonadeTheme.spaces.spacing400)
         .background(voice.containerColor)
         .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+    }
+
+    @ViewBuilder
+    private func actionLabelView(_ label: String) -> some View {
+        if let onActionClick {
+            SwiftUI.Button(action: onActionClick) {
+                LemonadeUi.Text(
+                    label,
+                    textStyle: LemonadeTypography.shared.bodySmallSemiBold,
+                    color: voice.actionTextColor
+                )
+            }
+            .buttonStyle(.plain)
+        } else {
+            LemonadeUi.Text(
+                label,
+                textStyle: LemonadeTypography.shared.bodySmallSemiBold,
+                color: voice.actionTextColor
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Content text always uses `bodySmallRegular` (14px); was incorrectly `bodyMediumRegular` when no title was present
- Action label uses `bodySmallSemiBold` (14px); was `bodyMediumSemiBold` (16px)
- Removed `spacing100` between all content column items; action gap is now expressed as `padding(top = spacing200)` on the action text itself, eliminating the standalone `Spacer`
- Icon wrapper height is now conditional: `size600` (24dp) when a title is present, `size500` (20dp) for description-only — correctly aligns the icon with the first line of text in both variants
- SwiftUI: extracted duplicated action label rendering into a private `@ViewBuilder actionLabelView` helper

## Test plan
- [ ] Notice (description-only): content renders at 14px across all 5 voices
- [ ] Notice (title + description): title at 16px semibold, content at 14px regular, icon aligned with title
- [ ] Action label renders at 14px semibold in the correct voice color
- [ ] Spacing above action label is `spacing200` (8dp), no gap between title and content
- [ ] Verified visually in SwiftUI simulator (all variants)

## API Dump
No public API changes — all modifications are internal rendering details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)