### PR TITLE
fix(swiftui): guard iOS-only .page tab style so Lemonade builds on macOS

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -307,7 +307,12 @@ private struct CoreDatePickerView: View {
                     .tag(offset)
                 }
             }
+            #if os(iOS)
+            // `.page` (PageTabViewStyle) is unavailable on macOS; fall back to the
+            // default TabView style there so the package builds for its declared
+            // macOS deployment target.
             .tabViewStyle(.page(indexDisplayMode: .never))
+            #endif
             .frame(height: 300)
         }
         .onChange(of: displayedMonthOffset) { _ in


### PR DESCRIPTION
## Problem

The SwiftUI `Lemonade` product declares `.macOS(.v12)` support in `Package.swift`, but fails to compile for macOS:

```
LemonadeDatePicker.swift:310:28: error: 'page(indexDisplayMode:)' is unavailable in macOS
```

`PageTabViewStyle` (`.page`) is available only on iOS/tvOS/watchOS. This is the **only** unguarded platform-specific API in the SwiftUI target — every other UIKit usage is already behind `#if canImport(UIKit)`. As a result, any macOS app depending on the package cannot build at all.

## Fix

Gate the `.page` tab style behind `#if os(iOS)`. On macOS the `TabView` falls back to the default style. iOS behaviour is unchanged.

## Verification

`swift build` (macOS) now completes cleanly:

```
[69/87] Compiling Lemonade LemonadeDatePicker.swift
...
Build complete! (10.92s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)