### PR TITLE
fix(top-bar): reset isScrolled when content reaches the top

### DIFF
--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -242,6 +242,14 @@ public class TopBarState internal constructor(
             source: NestedScrollSource,
         ): Offset {
             accumulateScrolledFade(deltaY = consumed.y)
+            // `available.y > 0f` after the child has run means the child stopped consuming an
+            // upward gesture — the content has reached its top edge. The delta-accumulator can
+            // drift on fling (the down + up passes don't always net to exactly 0 in practice), so
+            // hard-pin to 0 here. `isScrolled` flips false the moment the user bottoms out at the
+            // top, even after asymmetric scroll/fling sessions.
+            if (available.y > 0f) {
+                scrolledOffsetPx = 0f
+            }
             if (lockGestureAnimation) {
                 return Offset.Zero
             }


### PR DESCRIPTION
# Summary

Fixes a bug shipped with the scroll-fade feature in #223: `TopBarState.isScrolled` could stay `true` after the user scrolled all the way back to the top, so any bar using \`scrolledBackgroundColor\` stayed in its solid scrolled appearance instead of fading back to the transparent unscrolled appearance.

## Root cause

The internal `scrolledOffsetPx` accumulator is fed from `consumed.y` deltas in `onPostScroll`:

```kotlin
scrolledOffsetPx = (scrolledOffsetPx - deltaY).coerceAtLeast(0f)
```

On paper the down-pass and up-pass cancel out (`-100` then `+100` ≡ 0). In practice fling animations and asymmetric nested-scroll dispatches leave a small positive residual, so `isScrolled` (`scrolledOffsetPx > 0f`) sticks at `true` even when the scroll position is back at 0.

## Fix

Hard-pin the accumulator to 0 inside `onPostScroll` whenever `available.y > 0f`. That condition means the child rejected an upward gesture — only possible when the content has reached its top edge. So any drift is wiped exactly when we have a ground-truth signal that we're at zero scroll, and the bar's `isScrolled` flips back to `false` reliably.

```kotlin
override fun onPostScroll(consumed, available, source): Offset {
    accumulateScrolledFade(deltaY = consumed.y)
    if (available.y > 0f) {
        scrolledOffsetPx = 0f
    }
    ...
}
```

The new check sits outside the `lockGestureAnimation` branch so it works for both locked detail-screen bars (the original motivating use case) and the regular collapsable bar.

## API Dump

**Verdict:** NO_CHANGES — pure internal logic, no public surface touched.

## Test plan

- [x] `:ui:compileDebugKotlinAndroid` — passes
- [x] `:ui:ktlintMobileMainSourceSetCheck` — passes
- [x] `bcv-check.sh --ci` — verdict NO_CHANGES
- [ ] Manual: in the Teya app, open a transaction details screen, scroll down, scroll all the way back up — confirm the bar fades back to transparent (it currently stays solid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)