### PR TITLE
Use mask for gradient in swift ui Tabs

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
@@ -83,7 +83,7 @@ private struct LemonadeTabsView: View {
     @State private var didInitialScroll = false
     @State private var contentWrapperWidths: [Int: CGFloat] = [:]
 
-    // Mirrors KMP's `scrollState.canScrollForward`: the fade only paints when
+    // Mirrors KMP's `scrollState.canScrollForward`: the fade only applies when
     // the strip is scrollable AND there is still content beyond the trailing
     // edge. `scrollOffset` is observed live from the underlying UIScrollView
     // via `ScrollViewOffsetObserver`, since SwiftUI's ScrollView doesn't
@@ -122,16 +122,17 @@ private struct LemonadeTabsView: View {
                                 .onChange(of: geo.size.width) { containerWidth = $0 }
                         }
                     )
-                    .overlay(alignment: .trailing) {
-                        if showTrailingFade {
+                    .mask(alignment: .leading) {
+                        HStack(spacing: 0) {
+                            Rectangle().fill(Color.black)
                             LinearGradient(
-                                colors: [.clear, LemonadeTheme.colors.background.bgDefault],
+                                colors: [.black, .clear],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
-                            .frame(width: max(containerWidth * 0.15, 0))
-                            .allowsHitTesting(false)
+                            .frame(width: showTrailingFade ? max(containerWidth * 0.15, 0) : 0)
                         }
+                        .animation(.easeInOut(duration: 0.2), value: showTrailingFade)
                     }
                     .onChange(of: selectedIndex) { newIndex in
                         // Any intentional selection change supersedes the


### PR DESCRIPTION
# Summary
Use mask for gradient in swift ui Tabs. Looks the same but doesn't use a specific color, just fades to transparent

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->
<img width="300" alt="IMG_0025" src="https://github.com/user-attachments/assets/ebe46a74-34ac-4893-823a-4aa4a198a673" />


## API Dump
<!--
Required when any kmp/<module>/api/*.api or *.klib.api file changed.
Run `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` to get the verdict.
If nothing in api/ changed, write "No public API changes" and delete the rest.
-->

**Verdict:** <!-- NO_CHANGES / ADDITIONS_ONLY / BREAKING -->

**Changes that are not a concern, and why:**
<!--
- Interface addition — the interface is local-only, no external implementers.
- Enum entry addition — config enum; the component owns the `when`.
- `@Deprecated(HIDDEN)` overload — the `-` line is only the `synthetic` flag,
  the JVM descriptor is unchanged, so already-compiled consumers keep linking.
-->

**Genuine breaking changes (if any):**
<!--
List each one, who needs to approve (@caiqueslp / @williankl / @DevSrSouza),
and why the break is acceptable. Leave empty if the verdict is not BREAKING.
-->
