### PR TITLE
fix(top-bar): paint the scroll-fade background once so the fade stays uniform

### DIFF
--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -279,6 +279,15 @@ public class TopBarState internal constructor(
     }
 }
 
+// 400ms tween over FastOutSlowInEasing — gentle enough that high-contrast transitions
+// (e.g. Color.Transparent → bgDefault on a details screen) read as a fade rather than a snap.
+// The default `animateColorAsState` spring (StiffnessMedium = 1500f) completes in ~150ms which
+// looked like a hard jump on the bar background.
+private val TopBarBackgroundAnimationSpec: AnimationSpec<Color> = tween(
+    durationMillis = 400,
+    easing = FastOutSlowInEasing,
+)
+
 /**
  * Creates and remembers a [TopBarState] instance.
  *
@@ -413,6 +422,7 @@ public fun LemonadeUi.TopBar(
 ) {
     val effectiveBackgroundColor by animateColorAsState(
         targetValue = if (state.isScrolled) scrolledBackgroundColor else backgroundColor,
+        animationSpec = TopBarBackgroundAnimationSpec,
         label = "TopBarBackgroundColor",
     )
     CoreTopBar(
@@ -435,7 +445,6 @@ public fun LemonadeUi.TopBar(
                 subtitle = subtitle,
                 isCollapsed = state.isCollapsed,
                 modifier = fixedHeaderModifier
-                    .background(color = effectiveBackgroundColor)
                     .zIndex(zIndex = 1f)
                     .padding(
                         horizontal = LocalSpaces.current.spacing200,
@@ -514,7 +523,6 @@ public fun LemonadeUi.TopBar(
                 subtitle = subtitle,
                 isCollapsed = state.isCollapsed,
                 modifier = fixedHeaderModifier
-                    .background(color = backgroundColor)
                     .zIndex(zIndex = 1f)
                     .padding(
                         horizontal = LocalSpaces.current.spacing200,
@@ -628,6 +636,7 @@ public fun LemonadeUi.TopBar(
     }
     val effectiveBackgroundColor by animateColorAsState(
         targetValue = if (state.isScrolled) scrolledBackgroundColor else backgroundColor,
+        animationSpec = TopBarBackgroundAnimationSpec,
         label = "TopBarBackgroundColor",
     )
     CoreTopBar(
@@ -636,7 +645,6 @@ public fun LemonadeUi.TopBar(
         fixedHeaderSlot = { fixedHeaderModifier ->
             AnimatedContent(
                 modifier = fixedHeaderModifier
-                    .background(color = effectiveBackgroundColor)
                     .zIndex(zIndex = 1f)
                     .padding(
                         horizontal = LocalSpaces.current.spacing200,
@@ -776,7 +784,6 @@ public fun LemonadeUi.TopBar(
         fixedHeaderSlot = { fixedHeaderModifier ->
             AnimatedContent(
                 modifier = fixedHeaderModifier
-                    .background(color = backgroundColor)
                     .zIndex(zIndex = 1f)
                     .padding(
                         horizontal = LocalSpaces.current.spacing200,
@@ -949,6 +956,7 @@ public fun LemonadeUi.TopBar(
 ) {
     val effectiveBackgroundColor by animateColorAsState(
         targetValue = if (state.isScrolled) scrolledBackgroundColor else backgroundColor,
+        animationSpec = TopBarBackgroundAnimationSpec,
         label = "TopBarBackgroundColor",
     )
     CoreTopBar(
@@ -964,7 +972,6 @@ public fun LemonadeUi.TopBar(
                     subheading = subheading,
                     trailingSlot = trailingSlot,
                     modifier = fixedHeaderModifier
-                        .background(color = effectiveBackgroundColor)
                         .zIndex(zIndex = 1f),
                 )
             }
@@ -1016,7 +1023,6 @@ public fun LemonadeUi.TopBar(
                     subheading = subheading,
                     trailingSlot = trailingSlot,
                     modifier = fixedHeaderModifier
-                        .background(color = backgroundColor)
                         .zIndex(zIndex = 1f),
                 )
             }
@@ -1104,6 +1110,7 @@ public fun LemonadeUi.TopBar(
     }
     val effectiveBackgroundColor by animateColorAsState(
         targetValue = if (state.isScrolled) scrolledBackgroundColor else backgroundColor,
+        animationSpec = TopBarBackgroundAnimationSpec,
         label = "TopBarBackgroundColor",
     )
     CoreTopBar(
@@ -1113,7 +1120,6 @@ public fun LemonadeUi.TopBar(
         fixedHeaderSlot = { fixedHeaderModifier ->
             AnimatedContent(
                 modifier = fixedHeaderModifier
-                    .background(color = effectiveBackgroundColor)
                     .zIndex(zIndex = 1f),
                 targetState = isSearchFocused,
                 transitionSpec = { expandVertically() togetherWith shrinkVertically() },
@@ -1187,7 +1193,6 @@ public fun LemonadeUi.TopBar(
         fixedHeaderSlot = { fixedHeaderModifier ->
             AnimatedContent(
                 modifier = fixedHeaderModifier
-                    .background(color = backgroundColor)
                     .zIndex(zIndex = 1f),
                 targetState = isSearchFocused,
                 transitionSpec = { expandVertically() togetherWith shrinkVertically() },
@@ -1344,6 +1349,11 @@ internal fun TopBarLayout(
             collapsableSlot(
                 Modifier
                     .layoutId(layoutId = LAYOUT_ID_COLLAPSABLE_SLOT)
+                    // Clip before translating: the slot's top edge is the fixed header's bottom
+                    // edge, so the title disappears under the header without the header needing
+                    // its own background coat. A second translucent coat on the header would
+                    // alpha-stack over the root background and desync the fade above/below it.
+                    .clipToBounds()
                     .graphicsLayer {
                         translationY = state.heightOffset
                         alpha = 1f - state.collapseProgress


### PR DESCRIPTION
# Summary

Fixes a visible seam during the `scrolledBackgroundColor` scroll fade (introduced in #223): the bar painted its background **twice** — once on the `CoreTopBar` root (which covers the status-bar inset, since the background is applied before `statusBarsPadding()`), and again on the fixed header row. With opaque colors the double coat is invisible, but mid-fade the color is semi-transparent and the coats **alpha-stack**: the header region composited to ~2× the opacity of the status-bar strip above it, so the two zones visibly faded at different speeds with a hard horizontal cut between them.

Changes:

- **Removed the fixed header's background coat from all overloads.** It only existed to occlude the large title sliding under the header during collapse. That occlusion is now done by **clipping the collapsable slot at its own bounds** in `TopBarLayout` (`.clipToBounds()` before the `translationY` graphics layer) — the slot's top edge is exactly the header's bottom edge, so the title disappears at the same line it used to be occluded at. Pixel-identical collapse visuals for existing opaque consumers; uniform single-coat fade for translucent ones.
- **400ms `FastOutSlowInEasing` tween on the fade.** The default `animateColorAsState` spring completes in ~150ms, which reads as a snap on high-contrast transitions (e.g. alpha-0 `bgDefault` → `bgDefault` over a colored gradient header).

Verified on the Teya app details screens (Transaction / Sale / Payment Link): the status-bar strip and the bar now fade as one uniform surface in both scroll directions.

## Figma component

N/A — behavior fix, no visual spec change.

## Screenshot

N/A — best seen in motion; the artifact was a mid-fade seam at the status-bar boundary.

## API Dump

No public API changes.

**Verdict:** NO_CHANGES

🤖 Generated with [Claude Code](https://claude.com/claude-code)