### PR TITLE
Match tile's min height on android and ios

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -459,7 +459,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
                 leadingSlot()
                 tileTextContent
             }
-            .frame(minWidth: minWidth, maxWidth: .infinity, minHeight: minHeightHorizontal, alignment: .leading)
+            .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
             .padding(LemonadeTheme.spaces.spacing300)
         case .vertical:
             VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing300) {


### PR DESCRIPTION
# Summary
Tile's min height was applied after the padding on android, while on ios it was applied before the padding, leading to a taller min height on ios. I removed the min height before the padding on ios, leaving the one in tile shape which is after the padding

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->
 
<img width="300" alt="IMG_0028" src="https://github.com/user-attachments/assets/4f9d6eb5-5f22-4423-b5f9-88b461667f95" />


## API Dump
<!--
Required when any kmp/<module>/api/*.api or *.klib.api file changed.
Run `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` to get the verdict.
If nothing in api/ changed, write "No public API changes" and delete the rest.
-->

**Verdict:** <!-- NO_CHANGES / ADDITIONS_ONLY / BREAKING -->

**Changes that are not a concern, and why:**
<!--
- Interface addition — the interface is local-only, no external implementers.
- Enum entry addition — config enum; the component owns the `when`.
- `@Deprecated(HIDDEN)` overload — the `-` line is only the `synthetic` flag,
  the JVM descriptor is unchanged, so already-compiled consumers keep linking.
-->

**Genuine breaking changes (if any):**
<!--
List each one, who needs to approve (@caiqueslp / @williankl / @DevSrSouza),
and why the break is acceptable. Leave empty if the verdict is not BREAKING.
-->
