### PR TITLE
fix(expressive): stop BottomSheet nav-bar flicker on dismiss

### DIFF
--- a/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
+++ b/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
@@ -109,11 +109,6 @@ public fun LemonadeUi.BottomSheet(
  * obtained via [DialogWindowProvider] and configured independently from the Activity window.
  * [DisposableEffect] with key [Unit] runs once when the dialog enters composition, which
  * is early enough — layout happens after composition.
- *
- * No cleanup is performed in [onDispose]: the dialog window is destroyed on dismiss, and
- * the Activity window beneath it was never modified. Calling `show(navigationBars())` here
- * would tell the OS to animate the navigation bar back into the dying dialog window,
- * producing a brief visible flicker on close.
  */
 @Composable
 private fun HideNavigationBarEffect() {
@@ -121,7 +116,7 @@ private fun HideNavigationBarEffect() {
     DisposableEffect(Unit) {
         val dialogWindow = (view.parent as? DialogWindowProvider)
             ?.window
-            ?: return@DisposableEffect onDispose { /* Nothing */ }
+            ?: return@DisposableEffect onDispose { }
 
         val insetsController = WindowCompat.getInsetsController(
             dialogWindow,
@@ -135,6 +130,6 @@ private fun HideNavigationBarEffect() {
             hide(WindowInsetsCompat.Type.navigationBars())
             systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
-        onDispose { /* Dialog window is destroyed on dismiss; no restore needed. */ }
+        onDispose { }
     }
 }

--- a/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
+++ b/kmp/expressive/src/androidMain/kotlin/com/teya/lemonade/BottomSheet.android.kt
@@ -109,6 +109,11 @@ public fun LemonadeUi.BottomSheet(
  * obtained via [DialogWindowProvider] and configured independently from the Activity window.
  * [DisposableEffect] with key [Unit] runs once when the dialog enters composition, which
  * is early enough — layout happens after composition.
+ *
+ * No cleanup is performed in [onDispose]: the dialog window is destroyed on dismiss, and
+ * the Activity window beneath it was never modified. Calling `show(navigationBars())` here
+ * would tell the OS to animate the navigation bar back into the dying dialog window,
+ * producing a brief visible flicker on close.
  */
 @Composable
 private fun HideNavigationBarEffect() {
@@ -130,11 +135,6 @@ private fun HideNavigationBarEffect() {
             hide(WindowInsetsCompat.Type.navigationBars())
             systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
-        onDispose {
-            with(insetsController) {
-                show(WindowInsetsCompat.Type.navigationBars())
-                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-            }
-        }
+        onDispose { /* Dialog window is destroyed on dismiss; no restore needed. */ }
     }
 }


### PR DESCRIPTION
## Summary

- When `LemonadeUi.BottomSheet(..., hideNavigationBar = true, ...)` is dismissed on Android, the system navigation bar briefly flashes in and out during the close transition.
- Root cause: `HideNavigationBarEffect`'s `onDispose` called `show(WindowInsetsCompat.Type.navigationBars())` and reset `systemBarsBehavior = BEHAVIOR_DEFAULT` on the dialog window's `WindowInsetsControllerCompat`. The OS started animating the nav bar back into the dialog window at the same moment the dialog window was being torn down, painting one or two frames of the slide-in before the window disappeared — the flicker the user saw.
- The controller targets the **dialog window**, not the Activity window. The Activity window beneath was never modified, so on dismiss its own nav-bar state is what becomes visible again. There is nothing to "restore" — drop the show()/behavior reset and let the dialog window die quietly.
- KDoc on `HideNavigationBarEffect` updated to explain why no cleanup is done.

Sweep across `kmp/` (`expressive`, `ui`, `calendar`) confirmed `BottomSheet.android.kt` is the **only** file that touches `WindowInsetsControllerCompat` / `DialogWindowProvider` / `systemBarsBehavior`. `Dialog`, `Dropdown`, `DatePicker`, and the common `BottomSheet` all use plain Material3 composables with no system-bar manipulation — nothing else to fix.

## API Dump

No public API changes. `HideNavigationBarEffect` is `private` — the published surface is unchanged and `api/*.api` / `*.klib.api` baselines were not regenerated.

## Test plan

- [ ] Run the Android `composeApp` and open `HiddenNavBarBottomSheetSample` (the existing `hideNavigationBar = true` demo).
- [ ] Open the sheet — the nav bar hides as before (`hide(navigationBars())` on enter is unchanged).
- [ ] While open, swipe up from the bottom edge — the nav bar still appears transiently (`BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` on enter is unchanged).
- [ ] Dismiss the sheet via swipe-down, scrim tap, and back press — **no nav-bar flicker on close**.
- [ ] Repeat opening/closing several times — the Activity window's nav-bar state before opening matches its state after closing.
- [ ] Sanity-check a non-`hideNavigationBar` BottomSheet sample (e.g. the default sample) — behaviour unchanged; the effect is only attached when `hideNavigationBar = true`.