### PR TITLE
fix(swiftui): render Date Picker on macOS and widen Segmented Control tap target

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -293,6 +293,7 @@ private struct CoreDatePickerView: View {
             
             Spacer().frame(height: LemonadeTheme.spaces.spacing100)
             
+            #if os(iOS)
             TabView(selection: $displayedMonthOffset) {
                 ForEach(-centerPage..<centerPage, id: \.self) { offset in
                     MonthGridView(
@@ -309,6 +310,18 @@ private struct CoreDatePickerView: View {
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .frame(height: 300)
+            #else
+            MonthGridView(
+                monthOffset: displayedMonthOffset,
+                baseDate: today,
+                selectedDates: selectedDates,
+                minDate: minDate,
+                maxDate: maxDate,
+                onDateSelected: onDateSelected
+            )
+            .padding(.horizontal, LemonadeTheme.spaces.spacing400)
+            .frame(height: 300)
+            #endif
         }
         .onChange(of: displayedMonthOffset) { _ in
             onMonthDisplayed?(currentYearMonth)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSegmentedControl.swift
@@ -220,6 +220,7 @@ private struct LemonadeSegmentedControlView: View {
                     }
                     .padding(.horizontal, size.buttonHorizontalPadding)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(SegmentPressStyle())
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
# Summary

Two independent SwiftUI component fixes, one per commit:

- **Date Picker — render on macOS.** `.tabViewStyle(.page(indexDisplayMode:))` is iOS-only, so the month grid never appeared on macOS. The paged `TabView` is now guarded behind `#if os(iOS)`; on other platforms the selected month's `MonthGridView` is rendered directly, with month navigation driven by the existing header prev/next chevrons.
- **Segmented Control — full-segment tap target.** Without an explicit content shape only the label/icon was hit-testable, so taps landing on a segment's horizontal padding were ignored. Added `.contentShape(Rectangle())` so the entire segment registers taps. This is hit-testing only — it has no visual effect.

## Figma component
N/A

## Screenshot
N/A — behavioural/platform fixes with no visual change on iOS.

## API Dump

No public API changes. These touch only the SwiftUI package (`swiftui/Sources/Lemonade/Components/`); no `kmp/<module>/api/*.api` or `*.klib.api` baseline files are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)