### PR TITLE
fix(ui): make KMP ContentListItem label fill available width

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -130,14 +130,12 @@ private fun HorizontalContentListItem(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-            modifier = Modifier.weight(weight = 1f),
         ) {
             LemonadeUi.Text(
                 text = value,
                 textStyle = LocalTypographies.current.bodyMediumMedium,
                 color = LocalColors.current.content.contentPrimary,
                 textAlign = TextAlign.End,
-                modifier = Modifier.weight(weight = 1f),
             )
 
             if (trailingSlot != null) {


### PR DESCRIPTION
## What

In the horizontal layout of `ContentListItem` (KMP), the label area now fills the leftover horizontal space while the value + trailing slot hug their content — matching the SwiftUI implementation.

Previously the value `Row` and value `Text` both carried `weight(1f)`, forcing a fixed 50/50 split between label and value regardless of whether a trailing slot was present. SwiftUI instead gives the label `.frame(maxWidth: .infinity)` and lets the value `HStack` hug its content. This change removes the two `weight(1f)` modifiers on the value side so the KMP behavior lines up.

## Why

The two ports diverged: KMP pinned the label to ~50% of the row, while SwiftUI let it expand. This unifies the behavior on the SwiftUI model.

## Scope

- Affects only the `private` `HorizontalContentListItem` composable. The vertical layout already gives the label full width.

## API Dump

No public API changes.

## Screenshots
<img width="360" src="https://github.com/user-attachments/assets/9c5978af-bfe3-4d88-8546-a6e1f640bd22" />

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)