### PR TITLE
fix(ui): make ContentListItem label fill width when no value/trailing

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ContentListItemDisplay.kt
@@ -50,6 +50,61 @@ internal fun ContentListItemDisplay() {
             )
         }
 
+        // Horizontal — label only (no value, no trailing): label fills available width
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal — Label Only"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Account holder",
+                value = "",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "Terms and conditions agreement for the account holder " +
+                    "regarding international transfers and currency exchange policies",
+                value = "",
+                layout = LemonadeContentListItemLayout.Horizontal,
+            )
+        }
+
+        // Horizontal — label only with leading (still no trailing)
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Horizontal — Label Only & Leading"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Favourite",
+                value = "",
+                layout = LemonadeContentListItemLayout.Horizontal,
+                leadingSlot = {
+                    LemonadeUi.SymbolContainer(
+                        icon = LemonadeIcons.Heart,
+                        voice = SymbolContainerVoice.Neutral,
+                        size = SymbolContainerSize.Medium,
+                        contentDescription = null,
+                    )
+                },
+            )
+        }
+
+        // Vertical — label only (no value, no trailing)
+        LemonadeUi.Card(
+            header = CardHeaderConfig(title = "Vertical — Label Only"),
+        ) {
+            LemonadeUi.ContentListItem(
+                label = "Balance",
+                value = "",
+                layout = LemonadeContentListItemLayout.Vertical,
+                showDivider = true,
+            )
+            LemonadeUi.ContentListItem(
+                label = "A much longer label that should fill the available width " +
+                    "when there is no value or trailing element to share the row with",
+                value = "",
+                layout = LemonadeContentListItemLayout.Vertical,
+            )
+        }
+
         // Horizontal simple — long text
         LemonadeUi.Card(
             header = CardHeaderConfig(title = "Horizontal Simple — Long Text"),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ContentListItem.kt
@@ -173,21 +173,25 @@ private fun HorizontalContentListItem(
             }
         }
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
-            modifier = Modifier.weight(weight = 1f),
-        ) {
-            LemonadeUi.Text(
-                text = value,
-                textStyle = LocalTypographies.current.bodyMediumMedium,
-                color = LocalColors.current.content.contentPrimary,
-                textAlign = TextAlign.End,
+        // Only reserve space for the value/trailing side when there is something to
+        // show; otherwise the label fills the full available width.
+        if (value.isNotEmpty() || trailingSlot != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing300),
                 modifier = Modifier.weight(weight = 1f),
-            )
+            ) {
+                LemonadeUi.Text(
+                    text = value,
+                    textStyle = LocalTypographies.current.bodyMediumMedium,
+                    color = LocalColors.current.content.contentPrimary,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.weight(weight = 1f),
+                )
 
-            if (trailingSlot != null) {
-                trailingSlot()
+                if (trailingSlot != null) {
+                    trailingSlot()
+                }
             }
         }
     }
@@ -220,23 +224,27 @@ private fun VerticalContentListItem(
                 color = LocalColors.current.content.contentSecondary,
             )
 
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
-            ) {
-                LemonadeUi.Text(
-                    text = value,
-                    textStyle = if (contentSlot != null) {
-                        LocalTypographies.current.bodyXLargeSemiBold
-                    } else {
-                        LocalTypographies.current.bodyMediumMedium
-                    },
-                    color = LocalColors.current.content.contentPrimary,
-                    modifier = Modifier.weight(weight = 1f),
-                )
+            // Skip the value/trailing row entirely when there is nothing to show, so a
+            // label-only item doesn't leave a blank line under the label.
+            if (value.isNotEmpty() || trailingSlot != null) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
+                ) {
+                    LemonadeUi.Text(
+                        text = value,
+                        textStyle = if (contentSlot != null) {
+                            LocalTypographies.current.bodyXLargeSemiBold
+                        } else {
+                            LocalTypographies.current.bodyMediumMedium
+                        },
+                        color = LocalColors.current.content.contentPrimary,
+                        modifier = Modifier.weight(weight = 1f),
+                    )
 
-                if (trailingSlot != null) {
-                    trailingSlot()
+                    if (trailingSlot != null) {
+                        trailingSlot()
+                    }
                 }
             }
 


### PR DESCRIPTION
## What & why

The horizontal `ContentListItem` layout always reserved `weight(1f)` for the value/trailing side, so the label was forced to wrap at ~50% width even when there was no value and no trailing element to share the row with. A label-only item should let the label fill the full available width.

### Changes
- **`ui` — `ContentListItem.kt`**: gate the value/trailing `Row` on `value.isNotEmpty() || trailingSlot != null` in both `HorizontalContentListItem` and `VerticalContentListItem`. When there's nothing on the right, the label `Column` (still `weight(1f)`) fills the full width; vertical no longer leaves a blank line under the label. As a side benefit, the empty `Row`+`Text` are no longer composed in the label-only case.
- **`composeApp` — `ContentListItemDisplay.kt`**: add sample cards demonstrating label-only items — *Horizontal — Label Only*, *Horizontal — Label Only & Leading*, and *Vertical — Label Only*.

## How tested
Built and installed on a Pixel 10a (`:composeApp:installDebug`, `BUILD SUCCESSFUL`) and verified the horizontal label-only label now spans the full width.

## API Dump
No public API changes. The edits are limited to private `@Composable` function bodies (`HorizontalContentListItem` / `VerticalContentListItem`) and the unpublished `composeApp` sample. Classifier verdict: `NO_CHANGES`.

## Screenshots
<img width="360" src="https://github.com/user-attachments/assets/9c5978af-bfe3-4d88-8546-a6e1f640bd22" />

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)