### PR TITLE
feat: improve button pressed and disabled states

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -73,6 +73,7 @@ public fun LemonadeUi.Button(
     )
     CoreButton(
         colors = colors,
+        type = type,
         size = size,
         modifier = modifier,
         enabled = enabled,
@@ -153,6 +154,7 @@ public fun LemonadeUi.Button(
     )
     CoreButton(
         colors = colors,
+        type = type,
         size = size,
         enabled = enabled,
         interactionSource = interactionSource,
@@ -347,6 +349,7 @@ private fun CoreButton(
     trailingSlot: (@Composable RowScope.(LemonadeButtonColors) -> Unit)?,
     onClick: () -> Unit,
     colors: LemonadeButtonColors,
+    type: LemonadeButtonType,
     size: LemonadeButtonSize,
     expandContents: Boolean,
     enabled: Boolean,
@@ -365,11 +368,15 @@ private fun CoreButton(
     // `bgSubtle` backdrop is drawn BEFORE the disabled [Modifier.alpha] scope. Compose applies
     // alpha as a graphics layer wrapping subsequent draws only — so when disabled, the 50% alpha
     // blends the colored fill into the opaque backdrop instead of into whatever is behind the
-    // button. When enabled, the opaque colored fill fully covers the backdrop.
+    // button. When enabled, the opaque colored fill fully covers the backdrop. Ghost buttons have
+    // no fill, so they skip the backdrop entirely and stay transparent when disabled.
     val disabledModifier = if (!enabled) {
-        Modifier
-            .background(color = LocalColors.current.background.bgSubtle)
-            .alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+        val backdrop = if (type == LemonadeButtonType.Ghost) {
+            Modifier
+        } else {
+            Modifier.background(color = LocalColors.current.background.bgSubtle)
+        }
+        backdrop.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
     } else {
         Modifier
     }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
@@ -111,16 +111,27 @@ private fun CoreIconButton(
     )
     val sizeData = size.toSizeData(shape = shape)
 
+    // `bgSubtle` backdrop is drawn BEFORE the disabled [Modifier.alpha] scope. Compose applies
+    // alpha as a graphics layer wrapping subsequent draws only — so when disabled, the 50% alpha
+    // blends the colored fill into the opaque backdrop instead of into whatever is behind the
+    // button. When enabled, the opaque colored fill fully covers the backdrop. Ghost buttons have
+    // no fill, so they skip the backdrop entirely and stay transparent when disabled.
+    val disabledModifier = if (!enabled) {
+        val backdrop = if (type == LemonadeButtonType.Ghost) {
+            Modifier
+        } else {
+            Modifier.background(color = LocalColors.current.background.bgSubtle)
+        }
+        backdrop.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+    } else {
+        Modifier
+    }
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .then(
-                other = if (!enabled) {
-                    Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                } else {
-                    Modifier
-                },
-            ).clip(shape = sizeData.shape)
+            .clip(shape = sizeData.shape)
+            .then(other = disabledModifier)
             .clickable(
                 onClick = onClick,
                 role = Role.Button,

--- a/swiftui/SampleApp/ButtonDisplayView.swift
+++ b/swiftui/SampleApp/ButtonDisplayView.swift
@@ -62,7 +62,7 @@ struct ButtonDisplayView: View {
                         LemonadeUi.Button(label: "Loading", onClick: {}, variant: .neutral, size: .medium, loading: true)
                     }
                 }
-                
+
                 // Neutral Ghost Variant
                 sectionView(title: "Neutral Ghost") {
                     VStack(spacing: 16) {

--- a/swiftui/SampleApp/ButtonDisplayView.swift
+++ b/swiftui/SampleApp/ButtonDisplayView.swift
@@ -62,6 +62,22 @@ struct ButtonDisplayView: View {
                         LemonadeUi.Button(label: "Loading", onClick: {}, variant: .neutral, size: .medium, loading: true)
                     }
                 }
+                
+                // Neutral Ghost Variant
+                sectionView(title: "Neutral Ghost") {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            LemonadeUi.Button(label: "XSmall", onClick: {}, variant: .neutral, type: .ghost, size: .xSmall)
+                            LemonadeUi.Button(label: "Small", onClick: {}, variant: .neutral, type: .ghost, size: .small)
+                            LemonadeUi.Button(label: "Medium", onClick: {}, variant: .neutral, type: .ghost, size: .medium)
+                            LemonadeUi.Button(label: "Large", onClick: {}, variant: .neutral, type: .ghost, size: .large)
+                        }
+
+                        LemonadeUi.Button(label: "Disabled", onClick: {}, variant: .neutral, type: .ghost, size: .medium, enabled: false)
+
+                        LemonadeUi.Button(label: "Loading", onClick: {}, variant: .neutral, type: .ghost, size: .medium, loading: true)
+                    }
+                }
 
                 // Critical Variant
                 sectionView(title: "Critical") {

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -375,10 +375,10 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
         // OUTSIDE the `.opacity` modifier applied to the SwiftUI.Button, so the disabled 50%
         // opacity blends the colored fill into the backdrop instead of into whatever happens to
         // be drawn behind (e.g. a scrolling list under a floating footer).
-        let pressedOpacity = isPressed ? 1.0 - LemonadeTheme.opacity.state.opacityPressed : LemonadeTheme.opacity.base.opacity100
+        let pressedOpacity = isPressed ? LemonadeTheme.opacity.state.opacityPressed : LemonadeTheme.opacity.base.opacity100
         let disabledOpacity = (enabled || loading) ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled
         ZStack {
-            if !enabled {
+            if !enabled, type != .ghost {
                 buttonShape.fill(LemonadeTheme.colors.background.bgSubtle)
             }
 
@@ -561,6 +561,14 @@ struct LemonadeButton_Previews: PreviewProvider {
                 label: "Neutral",
                 onClick: {},
                 variant: .neutral
+            )
+
+            LemonadeUi.Button(
+                label: "Ghost Disabled",
+                onClick: {},
+                variant: .neutral,
+                type: .ghost,
+                enabled: false
             )
 
             LemonadeUi.Button(

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -250,35 +250,45 @@ private struct LemonadeIconButtonView: View {
         let bgColor: Color = isHovering ? colors.backgroundHoverColor : colors.backgroundColor
         let buttonShape = RoundedRectangle(cornerRadius: cornerRadius)
 
-        SwiftUI.Button(action: onClick) {
-            Group {
-                if loading {
-                    LemonadeUi.Spinner(tint: colors.contentColor)
-                } else {
-                    LemonadeUi.Icon(
-                        icon: icon,
-                        contentDescription: contentDescription,
-                        size: size.iconButtonSizeData.iconSize,
-                        tint: colors.contentColor
-                    )
-                }
+        // The ZStack backdrop paints an opaque `bgSubtle` rectangle behind the button. It sits
+        // OUTSIDE the `.opacity` modifier applied to the SwiftUI.Button, so the disabled 50%
+        // opacity blends the colored fill into the backdrop instead of into whatever happens to
+        // be drawn behind. Ghost buttons have no fill, so they skip the backdrop entirely.
+        ZStack {
+            if !enabled, type != .ghost {
+                buttonShape.fill(LemonadeTheme.colors.background.bgSubtle)
             }
-            .padding(size.iconButtonSizeData.innerPadding)
-            .background(
-                buttonShape
-                    .fill(bgColor)
-                    .animation(.easeInOut(duration: 0.1), value: bgColor)
-            )
-            .clipShape(buttonShape)
+
+            SwiftUI.Button(action: onClick) {
+                Group {
+                    if loading {
+                        LemonadeUi.Spinner(tint: colors.contentColor)
+                    } else {
+                        LemonadeUi.Icon(
+                            icon: icon,
+                            contentDescription: contentDescription,
+                            size: size.iconButtonSizeData.iconSize,
+                            tint: colors.contentColor
+                        )
+                    }
+                }
+                .padding(size.iconButtonSizeData.innerPadding)
+                .background(
+                    buttonShape
+                        .fill(bgColor)
+                        .animation(.easeInOut(duration: 0.1), value: bgColor)
+                )
+                .clipShape(buttonShape)
+            }
+            .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+            .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)
+            .animation(.easeInOut(duration: 0.1), value: isPressed)
+            .onHover { hovering in
+                isHovering = hovering
+            }
+            .disabled(!enabled || loading)
+            .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
         }
-        .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
-        .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)
-        .animation(.easeInOut(duration: 0.1), value: isPressed)
-        .onHover { hovering in
-            isHovering = hovering
-        }
-        .disabled(!enabled || loading)
-        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
     }
 }
 


### PR DESCRIPTION
## Summary

Aligns `Button` and `IconButton` interaction feedback across **SwiftUI** and **KMP (Compose)**:

- **Pressed opacity (SwiftUI):** `LemonadeButton` dimmed to `0.2` on press (`1.0 - opacityPressed`) instead of the intended `0.8`. Now uses `opacityPressed` directly, matching the native button feel and the existing `IconButton`/`Tile` components.
- **Ghost disabled background:** ghost-type buttons no longer paint the opaque `bgSubtle` backdrop when disabled — they stay transparent. Solid/subtle types keep the backdrop so the disabled alpha blends against a known surface (avoids bleed-through over scrolling content).
- **IconButton parity:** the disabled-backdrop treatment was mirrored onto SwiftUI `IconButton` (wrapped in a `ZStack`) and KMP `CoreIconButton`, which previously had no backdrop.
- **Ghost detection:** both platforms now detect ghost via the `LemonadeButtonType` enum (`type == .ghost` / `!= .ghost`) instead of inferring it from a transparent fill color. `type` is now threaded into KMP `CoreButton` for this.

## Test plan

- KMP `:ui` module compiles (`compileDebugKotlinAndroid`); sample app built and run on a Pixel 10a emulator.
- SwiftUI `Lemonade` package builds (`swift build`).
- Previews / sample screens updated to cover the disabled ghost state.

## Screenshots
<img width="360" src="https://github.com/user-attachments/assets/c7789984-e3f7-466b-8ff5-dda0c5fb7df6" />

## API Dump

No public API changes.

Classifier verdict: **NO_CHANGES** — all edits are confined to private composables/views (`CoreButton`, `CoreIconButton`, `LemonadeCoreButtonView`, `LemonadeIconButtonView`). The `type` parameter added to KMP `CoreButton` is on a `private` function and does not appear in the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)