### PR TITLE
fix(swiftui): stop value-based TextField from overflowing screen width

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -36,6 +36,11 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.keyboardType = keyboardType
         textField.text = value.text
 
+        // Let SwiftUI compress the field to the available width instead of growing it to the
+        // text's intrinsic width. Without this, long input pushes the layout past the screen edge.
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
         // Set initial cursor position (clamped to valid range)
         let clampedPosition = clampedCursorPosition(value.cursorPosition, for: value.text)
         if let position = textField.position(


### PR DESCRIPTION
## Problem

The `LemonadeUi.TextField(value:)` overload (the cursor-control variant) renders a `UITextField` through a `UIViewRepresentable` (`LemonadeUITextField`). `UITextField` defaults to a **high horizontal content compression resistance (750)**, so SwiftUI sizes it to the text's intrinsic width instead of compressing it to the available width.

With short input it's invisible, but with long input (e.g. a recipient **address** in the Teya business app's add-recipient screen) the field grows past the screen edge, dragging the surrounding `ZStack`/`HStack`/`Card` wider than the viewport. The `input:` overload (native `SwiftUI.TextField`) and the Compose `singleLine = true` field don't have this problem.

## Fix

Lower the `UITextField`'s horizontal content compression resistance and hugging priorities in `makeUIView` so the field is bounded to its container and scrolls its text internally:

```swift
textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
```

This brings the value-based field in line with the native `SwiftUI.TextField` overload and the Compose single-line behaviour. It's still single-line (scrolls horizontally inside the field) — not multiline — matching the design across both platforms.

## Scope

Affects every `TextField(value:)` / `TextFieldWithSelector(value:)` usage app-wide (recipient fields, phone fields, any formatted input), not just the address field that surfaced it.

## Test

`xcodebuild -scheme Lemonade -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)