### PR TITLE
fix(swiftui): avoid offscreen render pass on Badge

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
@@ -102,6 +102,11 @@ private struct LemonadeBadgeView: View {
             .padding(.vertical, size.textVerticalPadding)
             .padding(.horizontal, size.horizontalPadding)
             .frame(height: size.height)
+            // The two Capsule fills already define the pill, and the label is inset by padding
+            // so it never reaches the ends. A clipShape over this gradient background only adds
+            // an offscreen render pass (the composited subtree can't fold into a layer corner
+            // radius), so the shaped fills do the rounding instead. Badges render densely
+            // (one per notification dot/count), so the per-instance pass adds up while scrolling.
             .background(
                 ZStack {
                     Capsule()
@@ -117,7 +122,6 @@ private struct LemonadeBadgeView: View {
                         )
                 }
             )
-            .clipShape(Capsule())
     }
 }
 


### PR DESCRIPTION
## What

Drops the redundant `.clipShape(Capsule())` on `LemonadeBadge`. Its background is a composited `ZStack` (a solid `Capsule` + a gradient `Capsule`), so clipping it forced the subtree into an **offscreen render pass** to apply the mask — one pass per badge. The two `Capsule` fills already define the pill and the label is inset by padding, so the clip never changed a pixel. Removing it eliminates the pass with an identical result.

This is the same fix as `SymbolContainer` / `Tag` in #236. Badge was missed there because its yellow brand fill is the **same hue** as the Simulator's *Color Off-Screen Rendered* overlay, so the pass was invisible in light mode.

## How it was found

Audited the DS in the sample app with **Color Off-Screen Rendered** on, driving navigation via Maestro. Validated six components (Badge, Chip, Tile, Button, Notice, SearchField + ListItem) in **both light and dark**:

| Component | Clip | Offscreen? |
|---|---|---|
| **Badge** | `Capsule()` over **gradient ZStack** | ✅ **yes — fixed here** |
| Chip (container + counter) | `RoundedRectangle` / `Capsule` over **solid** fill | clean |
| Tile | `RoundedRectangle` over solid | clean |
| Button / IconButton | `buttonShape` over solid | clean |
| Notice | `RoundedRectangle` over solid | clean |
| SearchField | `Capsule` over solid | clean |
| ListItem (at rest) | — | clean |

The confound: the Teya brand colour **is** yellow, so brand-filled elements (Badge, Primary buttons, selected chips) read "yellow" regardless. Dark mode broke the tie — a real offscreen pass shows a yellow halo/double-composite against dark surfaces; the solid-fill clips showed none, Badge's gradient-clip is the only structural offender.

**The rule it confirms:** `clipShape` over a **solid** fill folds into a cheap layer `cornerRadius` (no offscreen); `clipShape` over a **gradient/composited** background can't, so it forces an offscreen pass. Badge was the only such case in the DS (Tabs' gradient is the intentional alpha-fade `.mask`; Skeleton's gradient is a plain `.fill` with no clip).

## Verification

`LemonadeSampleApp` rebuilt and re-captured on the simulator — Badge is **pixel-identical** in light and dark (gradient, pill shape, text all unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)