### PR TITLE
chore: add publish-version skill for releasing the SDK

### DIFF
--- a/.claude/skills/publish-version/SKILL.md
+++ b/.claude/skills/publish-version/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: publish-version
+description: >
+  Publish a new version of the Lemonade SDK — KMP and/or SwiftUI. Use when the
+  user wants to cut a release, ship a new version, tag a release, or "publish the
+  SDK". Syncs to latest origin/main, analyzes what changed per platform since the
+  last release, suggests a version bump (confirmed with the user), then cuts and
+  pushes the tags and creates the KMP GitHub release.
+---
+
+# Publish a Lemonade SDK version
+
+Cuts a new release for the two published SDKs. They version **independently** and
+their versions are **purely tag-driven** — there are no version files to bump on
+either side.
+
+| SDK | Release tag | What the tag does | GitHub Release |
+|-----|-------------|-------------------|----------------|
+| **KMP** | `lemonade-kmp-X.Y.Z` | `kmp_release.yml` publishes to Maven Central | **You create it** (KMP CI does *not*) — holds the **Latest** badge |
+| **SwiftUI** | `lemonade-swiftui-X.Y.Z` **and** plain `X.Y.Z` | `swiftui_release.yml` (on the prefixed tag) builds the XCFramework + creates the GH release. The plain `X.Y.Z` tag is the **SPM resolution tag** consumers actually pin to (root `Package.swift` builds from source). | **CI creates it** — do *not* create it yourself |
+
+Both SwiftUI tags point at the same commit. The XCFramework path is legacy ("we
+consume SwiftUI purely via SPM from source"), but the prefixed tag still drives
+the GH release + Slack notification, so keep pushing it.
+
+**Version bump rule (suggestion only, always confirmed):**
+- changes on **one** side only → **patch** bump for that SDK
+- changes on **both** sides → **minor** bump for both
+
+A "new icons" / token PR generates into *both* `kmp/` and `swiftui/Sources/`, so it
+lands on both sides and warrants a release on both.
+
+---
+
+## Procedure
+
+### 1. Pre-flight
+
+Confirm tooling and remote, from anywhere in the repo:
+
+```bash
+gh auth status            # gh must be authenticated
+git remote get-url origin # expect …saltpay/lemonade-design-system
+```
+
+### 2. Gather release status (syncs to latest origin/main)
+
+```bash
+.claude/skills/publish-version/scripts/release-status.sh
+```
+
+This fetches `origin/main` + tags, resolves `RELEASE_SHA` (the exact origin/main
+HEAD all tags will point at — the worktree-safe equivalent of "checkout
+origin/main"), finds the latest released KMP and SwiftUI versions, lists what
+changed in each SDK's *shipped* source since its last release, and prints
+patch/minor candidates plus a suggested bump. **Capture `RELEASE_SHA` and each
+`*_PREV_TAG` / `*_PREV_VERSION` from this output — you need them below.**
+
+The script's path filters (`kmp/` minus the `composeApp` sample; `swiftui/Sources/`)
+decide whether each side *has* changes. They are a first pass — the next step makes
+the real call.
+
+### 3. Decide "is there code to release?" — one analysis subagent per SDK
+
+For each SDK the script reports as `HAS_CHANGES=true` (and, if the user is unsure,
+even for `false`), spawn an **Explore** subagent — run the two in parallel. Hand
+each the range from the script and have it read the actual diff and judge whether
+the change is **consumer-facing** and worth a release, vs. noise that is not
+(only the sample app, tests, docs, CI, or a pure `api/*.api` baseline reformat).
+
+Prompt template (fill in the range from the script):
+
+> Read the diff `git diff <PREV_TAG>..origin/main -- <paths>` and the commit list
+> `git log --no-merges <PREV_TAG>..origin/main -- <paths>`.
+> - For **KMP** use paths: `kmp/ ':(exclude)kmp/composeApp/'`
+> - For **SwiftUI** use paths: `swiftui/Sources/`
+> Decide: does this contain a real, consumer-facing change to the published SDK
+> (new/changed component, new icon or token, bug fix in shipped code, public API
+> change)? Answer `RELEASE` or `SKIP`, then 2–4 bullets summarizing what changed
+> (call out new icons/tokens, new components, and any public API additions — an
+> `api/*.api` diff means the public surface changed). Read only; do not edit.
+
+Use both verdicts to settle which SDKs to release. A reliable signal of a real KMP
+release is a changed `kmp/<module>/api/*.api` or `*.klib.api` baseline.
+
+### 4. Confirm versions with the user — **always** via AskUserQuestion
+
+Apply the bump rule to form the suggestion, then confirm with `AskUserQuestion`.
+**Never tag without this confirmation.** Ask one question per SDK that has changes
+(at most two questions). Put the rule-suggested version first, marked
+"(Recommended)", and always include a "Don't release this SDK" option.
+
+Example, when KMP has changes and SwiftUI doesn't (KMP-only → patch):
+
+- **Question** "KMP version to release? (currently `0.20.0`)"
+  - `0.20.1 — patch (Recommended)` — KMP-only change
+  - `0.21.0 — minor` — if these are significant/breaking-ish additions
+  - `Don't release KMP`
+
+When **both** sides changed, suggest **minor** for both (e.g. KMP `0.20.0 → 0.21.0`,
+SwiftUI `0.16.2 → 0.17.0`) and ask one question each. Respect the user's choice
+even if it differs from the rule.
+
+### 5. Execute — only after confirmation
+
+Use `RELEASE_SHA` from step 2 so tags point at the exact origin/main commit.
+Before tagging, make sure the chosen tag does not already exist
+(`git tag -l <tag>`). Run the SDKs the user confirmed.
+
+**KMP** — tag → push (triggers Maven Central publish) → create the GitHub release
+(KMP CI does *not* create it). Mark it `--latest` and base its notes on the
+previous KMP tag so the auto-generated "What's Changed" + "Full Changelog" compare
+link are correct:
+
+```bash
+NEW=0.20.1                       # confirmed version
+PREV=lemonade-kmp-0.20.0         # KMP_PREV_TAG from the script
+SHA=<RELEASE_SHA>
+
+git tag "lemonade-kmp-${NEW}" "$SHA"
+git push origin "lemonade-kmp-${NEW}"
+
+gh release create "lemonade-kmp-${NEW}" \
+  --title "Lemonade Release ${NEW}" \
+  --generate-notes \
+  --notes-start-tag "$PREV" \
+  --latest
+```
+
+**SwiftUI** — push **both** tags at the same commit. The prefixed tag triggers
+`swiftui_release.yml` (XCFramework build + GH release + Slack); the plain tag is
+what SPM consumers resolve. **Do not** create a GitHub release yourself — CI does.
+
+```bash
+NEW=0.17.0                       # confirmed version
+SHA=<RELEASE_SHA>
+
+git tag "${NEW}" "$SHA"                      # SPM resolution tag
+git tag "lemonade-swiftui-${NEW}" "$SHA"     # triggers CI (XCFramework + GH release)
+git push origin "${NEW}" "lemonade-swiftui-${NEW}"
+```
+
+### 6. Report back
+
+Summarize what shipped, with links:
+- KMP: the GH release URL (`gh release view lemonade-kmp-${NEW} --web` to confirm)
+  and the Maven publish run (`gh run list --workflow kmp_release.yml --limit 1`).
+- SwiftUI: the CI run that will build + publish the release
+  (`gh run list --workflow swiftui_release.yml --limit 1`), and remind the user the
+  SPM consumer version is the plain `${NEW}` tag.
+- Both post to the Slack release channel from CI.
+
+---
+
+## Guardrails
+
+- **Never tag without the AskUserQuestion confirmation** of versions (step 4).
+- Tag the resolved `RELEASE_SHA` (origin/main HEAD), never the local worktree HEAD —
+  this skill releases what is on origin/main, not local work in progress.
+- Pushing a tag is effectively irreversible (it triggers a public Maven/CI publish).
+  Only push the tags for the SDKs the user explicitly confirmed.
+- Don't create the SwiftUI GitHub release — `swiftui_release.yml` already does, and
+  doubling it up fights the CI-managed release.
+- These are public, outward-facing actions. Do the analysis and version
+  confirmation, then execute the push/release for the confirmed SDKs in the same run.
+```

--- a/.claude/skills/publish-version/scripts/release-status.sh
+++ b/.claude/skills/publish-version/scripts/release-status.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# release-status.sh — gather everything the publish-version skill needs to
+# propose a Lemonade SDK release. Read-only except for the `git fetch`.
+#
+# What it does:
+#   1. Refreshes origin/main and tags (so we always reason about the freshest tree).
+#   2. Resolves RELEASE_SHA = the exact origin/main HEAD that tags will point at.
+#      (Tagging this SHA is the worktree-safe equivalent of "checkout origin/main":
+#       the release always reflects the latest origin/main, no branch switch needed.)
+#   3. Finds the latest released KMP and SwiftUI versions. Both are purely
+#      tag-driven — there are no version files to bump.
+#         KMP     -> tag  lemonade-kmp-X.Y.Z
+#         SwiftUI -> tag  lemonade-swiftui-X.Y.Z  (CI) + plain X.Y.Z (SPM resolution)
+#   4. Lists what changed in each SDK's *shipped* source since its last release and
+#      prints patch/minor candidates plus a suggested bump per the project rule.
+#
+# Version bump rule (suggestion only — always confirmed with the user):
+#   - changes on ONE side only -> PATCH bump for that SDK
+#   - changes on BOTH sides     -> MINOR bump for both
+#
+# Usage:
+#   release-status.sh             # fetch + full report
+#   release-status.sh --no-fetch  # skip the network fetch, use local refs
+#
+set -euo pipefail
+
+# Resolve paths against the repo root so the kmp/ and swiftui/ pathspecs are
+# correct no matter where this is invoked from.
+cd "$(git rev-parse --show-toplevel)"
+
+FETCH=1
+[ "${1:-}" = "--no-fetch" ] && FETCH=0
+
+if [ "$FETCH" = "1" ]; then
+  echo "Fetching origin/main and tags..." >&2
+  git fetch origin main --tags --prune --quiet
+fi
+
+if ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "ERROR: origin/main not found. Is 'origin' the saltpay/lemonade-design-system remote?" >&2
+  exit 1
+fi
+
+RELEASE_SHA=$(git rev-parse origin/main)
+RELEASE_SHORT=$(git rev-parse --short origin/main)
+RELEASE_SUBJECT=$(git log -1 --format='%s' "$RELEASE_SHA")
+
+latest_tag() { git tag -l "$1" --sort=-version:refname | head -n1; }
+
+KMP_PREV_TAG=$(latest_tag 'lemonade-kmp-*')
+SWIFT_PREV_TAG=$(latest_tag 'lemonade-swiftui-*')
+KMP_PREV_VER=${KMP_PREV_TAG#lemonade-kmp-}
+SWIFT_PREV_VER=${SWIFT_PREV_TAG#lemonade-swiftui-}
+
+bump() { # $1=version (X.Y.Z)  $2=part (major|minor|patch)
+  local v=$1 part=$2 MA MI PA
+  IFS=. read -r MA MI PA <<<"$v"
+  case "$part" in
+    major) echo "$((MA + 1)).0.0" ;;
+    minor) echo "${MA}.$((MI + 1)).0" ;;
+    patch) echo "${MA}.${MI}.$((PA + 1))" ;;
+  esac
+}
+
+# Shipped-source path filters. Everything else (the composeApp sample, the SwiftUI
+# SampleApp/Tests, docs, CI) does NOT warrant a consumer release on its own — the
+# analysis subagent makes the final call, but these filters drive the suggestion.
+KMP_PATHS=(kmp/ ':(exclude)kmp/composeApp/')
+SWIFT_PATHS=(swiftui/Sources/)
+
+# Returns commit count touching the given paths in <prev_tag>..RELEASE_SHA.
+shipped_count() {
+  local prev_tag=$1; shift
+  [ -z "$prev_tag" ] && { echo 0; return; }
+  git rev-list --count --no-merges "${prev_tag}..${RELEASE_SHA}" -- "$@"
+}
+
+KMP_COUNT=$(shipped_count "$KMP_PREV_TAG" "${KMP_PATHS[@]}")
+SWIFT_COUNT=$(shipped_count "$SWIFT_PREV_TAG" "${SWIFT_PATHS[@]}")
+[ "$KMP_COUNT" -gt 0 ] && KMP_HAS=true || KMP_HAS=false
+[ "$SWIFT_COUNT" -gt 0 ] && SWIFT_HAS=true || SWIFT_HAS=false
+
+# Apply the bump rule.
+KMP_SUGGEST="none"
+SWIFT_SUGGEST="none"
+if [ "$KMP_HAS" = true ] && [ "$SWIFT_HAS" = true ]; then
+  KMP_SUGGEST="minor"; SWIFT_SUGGEST="minor"
+elif [ "$KMP_HAS" = true ]; then
+  KMP_SUGGEST="patch"
+elif [ "$SWIFT_HAS" = true ]; then
+  SWIFT_SUGGEST="patch"
+fi
+
+suggested_version() { # $1=prev_ver $2=suggest-part
+  [ "$2" = "none" ] && { echo "-"; return; }
+  bump "$1" "$2"
+}
+
+print_sdk() { # $1=NAME $2=prev_tag $3=prev_ver $4=count $5=has $6=suggest ; then paths...
+  local name=$1 prev_tag=$2 prev_ver=$3 count=$4 has=$5 suggest=$6; shift 6
+  echo "## ${name}"
+  echo "${name}_PREV_TAG=${prev_tag:-<none>}"
+  echo "${name}_PREV_VERSION=${prev_ver:-<none>}"
+  echo "${name}_SHIPPED_COMMITS=${count}"
+  echo "${name}_HAS_CHANGES=${has}"
+  echo "${name}_NEXT_PATCH=$(bump "$prev_ver" patch)"
+  echo "${name}_NEXT_MINOR=$(bump "$prev_ver" minor)"
+  echo "${name}_NEXT_MAJOR=$(bump "$prev_ver" major)"
+  echo "${name}_SUGGESTED_BUMP=${suggest}"
+  echo "${name}_SUGGESTED_VERSION=$(suggested_version "$prev_ver" "$suggest")"
+  echo "${name}_RANGE=${prev_tag}..${RELEASE_SHORT}"
+  echo
+  if [ "$count" -gt 0 ]; then
+    echo "Commits touching shipped source (${prev_tag}..origin/main):"
+    git log --no-merges --format='  %h %s' "${prev_tag}..${RELEASE_SHA}" -- "$@"
+    echo
+    echo "Files changed:"
+    git diff --stat "$prev_tag" "$RELEASE_SHA" -- "$@" | sed 's/^/  /'
+  else
+    echo "No changes to shipped source since ${prev_tag:-<none>}."
+  fi
+  echo
+}
+
+echo "=================================================================="
+echo " Lemonade SDK — release status"
+echo "=================================================================="
+echo "RELEASE_SHA=${RELEASE_SHA}"
+echo "RELEASE_SHORT=${RELEASE_SHORT}"
+echo "RELEASE_SUBJECT=${RELEASE_SUBJECT}"
+echo
+print_sdk KMP   "$KMP_PREV_TAG"   "$KMP_PREV_VER"   "$KMP_COUNT"   "$KMP_HAS"   "$KMP_SUGGEST"   "${KMP_PATHS[@]}"
+print_sdk SWIFT "$SWIFT_PREV_TAG" "$SWIFT_PREV_VER" "$SWIFT_COUNT" "$SWIFT_HAS" "$SWIFT_SUGGEST" "${SWIFT_PATHS[@]}"
+
+echo "## SUGGESTION (rule: one side -> patch, both sides -> minor)"
+if [ "$KMP_SUGGEST" != none ]; then
+  echo "  KMP     ${KMP_PREV_VER} -> $(bump "$KMP_PREV_VER" "$KMP_SUGGEST")   (${KMP_SUGGEST})   tag: lemonade-kmp-$(bump "$KMP_PREV_VER" "$KMP_SUGGEST")"
+else
+  echo "  KMP     no shipped changes -> skip"
+fi
+if [ "$SWIFT_SUGGEST" != none ]; then
+  V=$(bump "$SWIFT_PREV_VER" "$SWIFT_SUGGEST")
+  echo "  SwiftUI ${SWIFT_PREV_VER} -> ${V}   (${SWIFT_SUGGEST})   tags: ${V} + lemonade-swiftui-${V}"
+else
+  echo "  SwiftUI no shipped changes -> skip"
+fi
+echo
+echo "Note: suggestion only. Confirm exact versions with the user before tagging."


### PR DESCRIPTION
## What

Adds a Claude Code skill — `publish-version` — that publishes a new Lemonade SDK version (KMP and/or SwiftUI) with one command.

## Why

Releases are tag-driven and split across two SDKs with different mechanics (KMP → manual GitHub release + Maven Central CI; SwiftUI → plain `X.Y.Z` SPM tag + `lemonade-swiftui-X.Y.Z` CI tag). The skill encodes that model so a release is consistent and low-effort.

## How it works

1. **Pre-flight** — checks `gh auth` and the `origin` remote.
2. **`scripts/release-status.sh`** (read-only except `git fetch`) — syncs to latest `origin/main`, resolves the exact `RELEASE_SHA` to tag, finds the last released version per SDK, and lists shipped-source changes since then (`kmp/` minus the sample app; `swiftui/Sources/`), with patch/minor candidates.
3. **Per-SDK analysis subagent** (Explore, run in parallel) reads the diff and rules `RELEASE` vs `SKIP` — catching the "new icons land on both sides → release both" case, using `api/*.api` baseline diffs as the signal of a real public KMP change.
4. **Version confirmation via `AskUserQuestion`** — rule: one side → **patch**, both → **minor**; suggestion only, never tags without confirmation.
5. **Execute** — tags `RELEASE_SHA`, pushes, creates the KMP GitHub release (`--generate-notes`, `--latest`). SwiftUI's GH release is left to CI.

## Files

- `.claude/skills/publish-version/SKILL.md` — orchestration guide + exact tag/release commands
- `.claude/skills/publish-version/scripts/release-status.sh` — deterministic status gatherer

## Testing

Validated against live repo state: all `gh`/`git` commands and flags verified, exclude-pathspec works, `bash -n` clean, script runs from any subdirectory. A live run correctly reports KMP `0.20.0 → 0.20.1` (patch, 5 unreleased commits) and SwiftUI skip (nothing new since `0.16.2`).

## API Dump

No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)