### PR TITLE
feat(toast): add Loading variant for ongoing actions

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -50,6 +50,31 @@ internal fun ToastDisplay() {
             )
         }
 
+        ToastSection("Loading") {
+            LemonadeUi.Button(
+                label = "Loading Toast",
+                onClick = {
+                    toastState.show(
+                        label = "Downloading your document…",
+                        voice = ToastVoice.Loading,
+                    )
+                },
+            )
+            LemonadeUi.Button(
+                label = "Complete Loading (replace)",
+                onClick = {
+                    toastState.show(
+                        label = "Download complete",
+                        voice = ToastVoice.Success,
+                    )
+                },
+            )
+            LemonadeUi.Button(
+                label = "Dismiss Loading",
+                onClick = { toastState.dismiss() },
+            )
+        }
+
         ToastSection("With Action") {
             LemonadeUi.Button(
                 label = "Success Toast with Action",

--- a/kmp/ui/api/android/ui.api
+++ b/kmp/ui/api/android/ui.api
@@ -589,6 +589,7 @@ public final class com/teya/lemonade/ToastKt {
 
 public final class com/teya/lemonade/ToastVoice : java/lang/Enum {
 	public static final field Error Lcom/teya/lemonade/ToastVoice;
+	public static final field Loading Lcom/teya/lemonade/ToastVoice;
 	public static final field Neutral Lcom/teya/lemonade/ToastVoice;
 	public static final field Success Lcom/teya/lemonade/ToastVoice;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/ui/api/desktop/ui.api
+++ b/kmp/ui/api/desktop/ui.api
@@ -561,6 +561,7 @@ public final class com/teya/lemonade/ToastKt {
 
 public final class com/teya/lemonade/ToastVoice : java/lang/Enum {
 	public static final field Error Lcom/teya/lemonade/ToastVoice;
+	public static final field Loading Lcom/teya/lemonade/ToastVoice;
 	public static final field Neutral Lcom/teya/lemonade/ToastVoice;
 	public static final field Success Lcom/teya/lemonade/ToastVoice;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/ui/api/ui.klib.api
+++ b/kmp/ui/api/ui.klib.api
@@ -35,6 +35,7 @@ final enum class com.teya.lemonade/TextFieldSize : kotlin/Enum<com.teya.lemonade
 
 final enum class com.teya.lemonade/ToastVoice : kotlin/Enum<com.teya.lemonade/ToastVoice> { // com.teya.lemonade/ToastVoice|null[0]
     enum entry Error // com.teya.lemonade/ToastVoice.Error|null[0]
+    enum entry Loading // com.teya.lemonade/ToastVoice.Loading|null[0]
     enum entry Neutral // com.teya.lemonade/ToastVoice.Neutral|null[0]
     enum entry Success // com.teya.lemonade/ToastVoice.Success|null[0]
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -291,8 +291,7 @@ private fun CoreToast(
     val iconTint = when (voice) {
         ToastVoice.Success -> colors.content.contentPositiveOnColor
         ToastVoice.Error -> colors.content.contentCriticalOnColor
-        ToastVoice.Neutral -> colors.content.contentNeutralOnColor
-        ToastVoice.Loading -> colors.content.contentNeutralOnColor
+        ToastVoice.Neutral, ToastVoice.Loading -> colors.content.contentNeutralOnColor
     }
 
     Row(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -55,6 +55,13 @@ public enum class ToastVoice {
     Success,
     Error,
     Neutral,
+
+    /**
+     * Communicates an ongoing action (e.g. "Downloading your document…"). The leading element is an
+     * animated [LemonadeUi.Spinner] instead of a static icon. A loading toast persists until it is
+     * explicitly dismissed or replaced — it does not auto-dismiss and cannot be swiped away.
+     */
+    Loading,
 }
 
 /**
@@ -135,11 +142,17 @@ public class LemonadeToastState {
     /**
      * Show a toast with an optional action button. If a toast is already visible, it is replaced immediately.
      *
+     * Use [ToastVoice.Loading] to communicate an ongoing action (e.g. "Downloading your document…"). A
+     * loading toast shows a spinner and persists until you call [dismiss] or replace it with another
+     * [show] — [duration] and [dismissible] are ignored for it.
+     *
      * @param label The text message to display.
      * @param voice The tone of voice — determines icon and icon color. Defaults to [ToastVoice.Neutral].
      * @param icon Optional custom icon. Only used when [voice] is [ToastVoice.Neutral].
-     * @param duration How long the toast is displayed. Defaults to [ToastDuration.Short].
-     * @param dismissible Whether the user can swipe to dismiss. Defaults to `true`.
+     * @param duration How long the toast is displayed. Defaults to [ToastDuration.Short]. Ignored when
+     *   [voice] is [ToastVoice.Loading].
+     * @param dismissible Whether the user can swipe to dismiss. Defaults to `true`. Ignored (forced off)
+     *   when [voice] is [ToastVoice.Loading].
      * @param actionLabel Optional label for the action button shown at the trailing end of the toast.
      * @param onAction Optional callback invoked when the action button is tapped. The button is only shown
      *   when both [actionLabel] and [onAction] are non-null.
@@ -272,12 +285,14 @@ private fun CoreToast(
         ToastVoice.Success -> LemonadeIcons.CircleCheck
         ToastVoice.Error -> LemonadeIcons.CircleX
         ToastVoice.Neutral -> icon
+        ToastVoice.Loading -> null
     }
 
     val iconTint = when (voice) {
         ToastVoice.Success -> colors.content.contentPositiveOnColor
         ToastVoice.Error -> colors.content.contentCriticalOnColor
         ToastVoice.Neutral -> colors.content.contentNeutralOnColor
+        ToastVoice.Loading -> colors.content.contentNeutralOnColor
     }
 
     Row(
@@ -295,7 +310,12 @@ private fun CoreToast(
         horizontalArrangement = Arrangement.spacedBy(spaces.spacing200),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (resolvedIcon != null) {
+        if (voice == ToastVoice.Loading) {
+            LemonadeUi.Spinner(
+                size = LemonadeAssetSize.Medium,
+                tint = iconTint,
+            )
+        } else if (resolvedIcon != null) {
             LemonadeUi.Icon(
                 icon = resolvedIcon,
                 contentDescription = null,
@@ -369,14 +389,17 @@ public fun LemonadeToastHost(
             // Haptic feedback + auto-dismiss timer
             LaunchedEffect(toast?.id) {
                 if (toast != null) {
-                    val feedbackType = if (toast.voice == ToastVoice.Neutral) {
-                        HapticFeedbackType.TextHandleMove
-                    } else {
-                        HapticFeedbackType.LongPress
+                    val feedbackType = when (toast.voice) {
+                        ToastVoice.Neutral, ToastVoice.Loading -> HapticFeedbackType.TextHandleMove
+                        ToastVoice.Success, ToastVoice.Error -> HapticFeedbackType.LongPress
                     }
                     haptic.performHapticFeedback(feedbackType)
-                    delay(toast.duration.millis)
-                    toastState.dismiss()
+                    // A loading toast describes an ongoing action: it persists until explicitly
+                    // dismissed or replaced, so skip the auto-dismiss timer.
+                    if (toast.voice != ToastVoice.Loading) {
+                        delay(toast.duration.millis)
+                        toastState.dismiss()
+                    }
                 }
             }
 
@@ -410,7 +433,11 @@ public fun LemonadeToastHost(
                 if (animatedToast != null) {
                     var offsetY by remember(animatedToast.id) { mutableStateOf(0f) }
 
-                    val swipeModifier = if (animatedToast.dismissible) {
+                    // A loading toast cannot be swiped away — it stays until the action completes.
+                    val swipeDismissible = animatedToast.dismissible &&
+                        animatedToast.voice != ToastVoice.Loading
+
+                    val swipeModifier = if (swipeDismissible) {
                         Modifier.pointerInput(animatedToast.id) {
                             detectVerticalDragGestures(
                                 onDragEnd = {

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -37,6 +37,26 @@ struct ToastDisplayView: View {
                 }
             }
 
+            Section("Loading") {
+                Button("Show Loading Toast") {
+                    toastManager.show(
+                        label: "Downloading your document…",
+                        voice: .loading
+                    )
+                }
+
+                Button("Complete Loading (replace)") {
+                    toastManager.show(
+                        label: "Download complete",
+                        voice: .success
+                    )
+                }
+
+                Button("Dismiss Loading") {
+                    toastManager.dismiss()
+                }
+            }
+
             Section("With Action") {
                 Button("Success Toast with Action") {
                     toastManager.show(
@@ -167,6 +187,7 @@ struct ToastDisplayView: View {
                     LemonadeUi.Toast(label: "Error message", voice: .error)
                     LemonadeUi.Toast(label: "Neutral message", voice: .neutral)
                     LemonadeUi.Toast(label: "With custom icon", voice: .neutral, icon: .sparkles)
+                    LemonadeUi.Toast(label: "Downloading your document…", voice: .loading)
                     LemonadeUi.Toast(label: "Success message", voice: .success, actionLabel: "Undo") {}
                     LemonadeUi.Toast(label: "Error message", voice: .error, actionLabel: "Retry") {}
                     LemonadeUi.Toast(label: "Neutral message", voice: .neutral, actionLabel: "View") {}

--- a/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
@@ -20,8 +20,7 @@ public enum LemonadeToastVoice: Sendable {
         switch self {
         case .success: return .circleCheck
         case .error: return .circleX
-        case .neutral: return nil
-        case .loading: return nil
+        case .neutral, .loading: return nil
         }
     }
 
@@ -29,8 +28,7 @@ public enum LemonadeToastVoice: Sendable {
         switch self {
         case .success: return colors.content.contentPositiveAlwaysOnColor
         case .error: return colors.content.contentCriticalAlwaysOnColor
-        case .neutral: return colors.content.contentNeutralAlwaysOnColor
-        case .loading: return colors.content.contentNeutralAlwaysOnColor
+        case .neutral, .loading: return colors.content.contentNeutralAlwaysOnColor
         }
     }
 
@@ -42,9 +40,7 @@ public enum LemonadeToastVoice: Sendable {
             return .success
         case .error:
             return .error
-        case .neutral:
-            return .impact
-        case .loading:
+        case .neutral, .loading:
             return .impact
         }
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
@@ -11,12 +11,17 @@ public enum LemonadeToastVoice: Sendable {
     case error
     /// Neutral toast with a customizable icon.
     case neutral
+    /// Loading toast communicating an ongoing action. Shows an animated spinner as the leading
+    /// element and persists until it is explicitly dismissed or replaced (no auto-dismiss, not
+    /// swipe-dismissible).
+    case loading
 
     internal var icon: LemonadeIcon? {
         switch self {
         case .success: return .circleCheck
         case .error: return .circleX
         case .neutral: return nil
+        case .loading: return nil
         }
     }
 
@@ -25,6 +30,7 @@ public enum LemonadeToastVoice: Sendable {
         case .success: return colors.content.contentPositiveAlwaysOnColor
         case .error: return colors.content.contentCriticalAlwaysOnColor
         case .neutral: return colors.content.contentNeutralAlwaysOnColor
+        case .loading: return colors.content.contentNeutralAlwaysOnColor
         }
     }
 
@@ -37,6 +43,8 @@ public enum LemonadeToastVoice: Sendable {
         case .error:
             return .error
         case .neutral:
+            return .impact
+        case .loading:
             return .impact
         }
     }
@@ -101,6 +109,9 @@ private struct LemonadeToastView: View {
             return customIcon
         case .success, .error:
             return voice.icon
+        case .loading:
+            // The leading element is a spinner, not a static icon.
+            return nil
         }
     }
 
@@ -109,12 +120,17 @@ private struct LemonadeToastView: View {
         case .success: return "Success"
         case .error: return "Error"
         case .neutral: return "Notice"
+        case .loading: return "Loading"
         }
     }
 
     var body: some View {
         HStack(spacing: .space.spacing200) {
-            if let icon = displayIcon {
+            if voice == .loading {
+                LemonadeUi.Spinner(
+                    tint: voice.iconColor(colors: LemonadeTheme.colors)
+                )
+            } else if let icon = displayIcon {
                 LemonadeUi.Icon(
                     icon: icon,
                     contentDescription: nil,
@@ -208,6 +224,7 @@ struct LemonadeToast_Previews: PreviewProvider {
             LemonadeUi.Toast(label: "Your session will expire soon", voice: .neutral, icon: .circleAlert)
             LemonadeUi.Toast(label: "Added to favorites", voice: .neutral, icon: .heart)
             LemonadeUi.Toast(label: "Toast without an icon", voice: .neutral)
+            LemonadeUi.Toast(label: "Downloading your document…", voice: .loading)
             LemonadeUi.Toast(label: "Changes saved", voice: .success, actionLabel: "Undo") {}
             LemonadeUi.Toast(label: "Something went wrong", voice: .error, actionLabel: "Retry") {}
             LemonadeUi.Toast(label: "Added to favorites", voice: .neutral, icon: .heart, actionLabel: "View") {}

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
@@ -147,12 +147,15 @@ public final class LemonadeToastManager: ObservableObject {
     ///
     /// - Parameters:
     ///   - label: The message to display.
-    ///   - voice: The toast variant (success, error, neutral).
+    ///   - voice: The toast variant (success, error, neutral, loading).
     ///   - icon: Custom icon for neutral toasts only.
-    ///   - duration: How long the toast should be visible.
-    ///   - dismissible: Whether the toast can be dismissed by swiping.
+    ///   - duration: How long the toast should be visible. Ignored when `voice` is `.loading`.
+    ///   - dismissible: Whether the toast can be dismissed by swiping. Ignored (forced off) when `voice` is `.loading`.
     ///   - actionLabel: Optional label for the action button shown at the trailing end of the toast.
     ///   - onAction: Optional callback invoked when the action button is tapped. The button is only shown when both `actionLabel` and `onAction` are non-nil.
+    ///
+    /// Use `.loading` to communicate an ongoing action (e.g. "Downloading your document…"). A loading
+    /// toast shows a spinner and persists until you call ``dismiss()`` or replace it with another `show`.
     public func show(
         label: String,
         voice: LemonadeToastVoice = .neutral,
@@ -167,7 +170,8 @@ public final class LemonadeToastManager: ObservableObject {
             voice: voice,
             icon: icon,
             duration: duration,
-            isDismissible: dismissible,
+            // A loading toast describes an ongoing action: it cannot be swiped away.
+            isDismissible: voice == .loading ? false : dismissible,
             actionLabel: actionLabel,
             onAction: onAction
         )
@@ -200,6 +204,9 @@ public final class LemonadeToastManager: ObservableObject {
     private func displayToast(_ toast: LemonadeToastItem) {
         dismissTask?.cancel()
         currentToast = toast
+
+        // A loading toast persists until explicitly dismissed or replaced — skip the auto-dismiss timer.
+        guard toast.voice != .loading else { return }
 
         // Wait for entry animation to complete, then start visibility timer
         let totalDelay = ToastAnimationConfig.duration + toast.duration.timeInterval


### PR DESCRIPTION
## What

Adds a **loading** Toast variant to communicate an ongoing action, e.g. *"Downloading your document…"*. Implemented across both ports:

- **KMP** — new `ToastVoice.Loading` (`kmp/ui/.../Toast.kt`)
- **SwiftUI** — new `LemonadeToastVoice.loading` (`LemonadeToast.swift`, `LemonadeToastManager.swift`)

## Behavior

- The leading element renders an animated **`Spinner`** (reuses the existing `LemonadeUi.Spinner`) instead of a static icon.
- A loading toast **persists until explicitly dismissed or replaced**:
  - the auto-dismiss timer is skipped, and
  - swipe-to-dismiss is disabled.
  - `duration` / `dismissible` are ignored for this voice.
- Dev flow: `show(label, voice = Loading)` while the action runs, then `dismiss()` or `show(..., voice = Success/Error)` to replace it when it finishes.

## Evidences
<img width="360" src="https://github.com/user-attachments/assets/b940b2f8-04be-40b4-a2b1-f6720cfef066" />
https://github.com/user-attachments/assets/961f122b-5a2f-47b5-8878-36cb13df4edf

## Usage

```kotlin
// KMP
val toast = LocalLemonadeToastState.current
toast.show(label = "Downloading your document…", voice = ToastVoice.Loading)
// …later
toast.show(label = "Download complete", voice = ToastVoice.Success)
```
```swift
// SwiftUI
toastManager.show(label: "Downloading your document…", voice: .loading)
// …later
toastManager.show(label: "Download complete", voice: .success)
```

## Verification

- KMP `:ui` compiles (via `:ui:apiDump`); all `when (voice)` blocks handle the new entry.
- SwiftUI package `swift build` succeeds; all `switch` over the voice are exhaustive.

## API Dump

**Verdict: `ADDITIONS_ONLY`** (CI auto-passes).

The only baseline change is one new enum entry on the published `ui` module:

```
+ public static final field Loading Lcom/teya/lemonade/ToastVoice;   (android + desktop)
+ enum entry Loading // com.teya.lemonade/ToastVoice.Loading         (klib)
```

`ToastVoice` is a config enum the component switches on internally, and every internal `when` now handles `Loading`, so the addition is ABI-safe and not consumer-breaking. Baseline regenerated via `./gradlew :ui:apiDump`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)