### PR TITLE
fix(swiftui): render compact-large top bar title in Figtree

### DIFF
--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -784,8 +784,7 @@ private struct LemonadeCompactLargeTitle: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             SwiftUI.Text(label)
-                .font(titleFont)
-                .fontWeight(.bold)
+                .font(.headingLarge)
                 .fixedSize(horizontal: true, vertical: false)
             if let subheading {
                 SwiftUI.Text(subheading)
@@ -795,15 +794,6 @@ private struct LemonadeCompactLargeTitle: View {
                     .padding(.bottom, LemonadeSpacing.spacing200.value)
             }
         }
-    }
-
-    private var titleFont: Font {
-        #if compiler(>=6.2)
-        if #available(iOS 26, *) {
-            return .largeTitle
-        }
-        #endif
-        return .title2
     }
 }
 


### PR DESCRIPTION
## Problem

The compact-large `lemonadeTopBar(label:subheading:)` variant (used by top-level tabs like **Sales** and **Money** in the Teya app) rendered its title in **San Francisco** instead of Figtree.

`LemonadeCompactLargeTitle` set the title font with the SwiftUI system text styles `.largeTitle` (iOS 26) / `.title2` (older):

```swift
SwiftUI.Text(label)
    .font(titleFont)      // .largeTitle / .title2 — system (SF)
    .fontWeight(.bold)
```

Because this title is a **custom `.topBarLeading` toolbar item**, not the native `.navigationTitle`, the host app's `UINavigationBarAppearance.largeTitleTextAttributes` (which is set to Figtree-SemiBold) never applied to it, and the app's default `.environment(\.font, Figtree)` was overridden by the explicit `.font`.

## Fix

Render the title with the `headingLarge` token (`Font.headingLarge` → `Figtree-SemiBold` at the large-title size) — the exact style the **native** large titles already resolve to. This unifies the compact-large title with every other large title in consuming apps. `headingLarge` is already SemiBold, so the redundant `.fontWeight(.bold)` and the unused `titleFont` helper are removed.

## Scope

- Single `private struct` (`LemonadeCompactLargeTitle`) — no public API surface touched.
- Affects every compact-large `lemonadeTopBar` title (the intended, correct behaviour).

## API Dump

No public API changes (Swift-only change to a `private struct`; KMP `*.api` baselines untouched).

## Verification

`xcodebuild -scheme Lemonade -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)