### PR TITLE
perf: reduce offscreen render passes (clip → fill-based rounding)

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -406,7 +406,6 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                 .frame(height: size.contentData.requiredHeight)
                 .frame(minWidth: size.contentData.minWidth)
                 .background(buttonShape.fill(colors.backgroundColor))
-                .clipShape(buttonShape)
             }
             .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
             .opacity(pressedOpacity * disabledOpacity)

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -406,6 +406,9 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                 .frame(height: size.contentData.requiredHeight)
                 .frame(minWidth: size.contentData.minWidth)
                 .background(buttonShape.fill(colors.backgroundColor))
+                // Keep the rounded hit target the removed .clipShape used to provide, without
+                // reintroducing its offscreen pass.
+                .contentShape(buttonShape)
             }
             .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
             .opacity(pressedOpacity * disabledOpacity)

--- a/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeChip.swift
@@ -257,8 +257,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
                     .foregroundStyle(LemonadeTheme.colors.content.contentOnBrandHigh)
                     .padding(.horizontal, LemonadeTheme.spaces.spacing100)
                     .frame(minWidth: .size.size450, minHeight: .size.size400)
-                    .background(.bg.bgBrand)
-                    .clipShape(Capsule())
+                    .background(Capsule().fill(.bg.bgBrand))
                     .padding(.trailing, .space.spacing50)
             }
 
@@ -274,8 +273,7 @@ private struct LemonadeChipView<LeadingContent: View, TrailingContent: View>: Vi
         }
         .padding(.space.spacing200)
         .frame(minWidth: minWidth, minHeight: minHeight)
-        .background(backgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: .radius.radiusFull))
+        .background(RoundedRectangle(cornerRadius: .radius.radiusFull).fill(backgroundColor))
         .overlay {
             if error {
                 RoundedRectangle(cornerRadius: .radius.radiusFull)

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -278,6 +278,9 @@ private struct LemonadeIconButtonView: View {
                         .fill(bgColor)
                         .animation(.easeInOut(duration: 0.1), value: bgColor)
                 )
+                // Keep the rounded hit target the removed .clipShape used to provide, without
+                // reintroducing its offscreen pass.
+                .contentShape(buttonShape)
             }
             .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
             .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -278,7 +278,6 @@ private struct LemonadeIconButtonView: View {
                         .fill(bgColor)
                         .animation(.easeInOut(duration: 0.1), value: bgColor)
                 )
-                .clipShape(buttonShape)
             }
             .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
             .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -328,11 +328,13 @@ struct ListItemButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .background(
-                configuration.isPressed
-                ? voice.interactionBackground
-                : Color.clear
+                RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
+                    .fill(
+                        configuration.isPressed
+                        ? voice.interactionBackground
+                        : Color.clear
+                    )
             )
-            .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
             .contentShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
             .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeNotice.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeNotice.swift
@@ -128,8 +128,7 @@ private struct LemonadeNoticeView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(LemonadeTheme.spaces.spacing400)
-        .background(voice.containerColor)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .background(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500).fill(voice.containerColor))
     }
 
     @ViewBuilder

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -118,8 +118,7 @@ private struct LemonadeSearchFieldView: View {
         }
         .padding(.horizontal, horizontalPadding)
         .frame(height: height)
-        .background(backgroundColor)
-        .clipShape(Capsule())
+        .background(Capsule().fill(backgroundColor))
         .overlay(
             Capsule()
                 .stroke(borderColor, lineWidth: LemonadeTheme.borderWidth.state.borderSelected)

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
@@ -164,8 +164,7 @@ struct TextFieldContainerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(minHeight: TextFieldConstants.minHeight)
-            .background(backgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .background(RoundedRectangle(cornerRadius: cornerRadius).fill(backgroundColor))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .stroke(borderColor, lineWidth: LemonadeTheme.borderWidth.base.border25)
@@ -195,8 +194,7 @@ struct SelectFieldContainerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .frame(minHeight: TextFieldConstants.minHeight)
-            .background(backgroundColor)
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .background(RoundedRectangle(cornerRadius: cornerRadius).fill(backgroundColor))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .stroke(borderColor, lineWidth: LemonadeTheme.borderWidth.base.border25)

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextFieldShared.swift
@@ -150,7 +150,7 @@ struct TextFieldSupportText: View {
 
 // MARK: - Container Decoration Modifier
 
-/// Applies the standard text field container styling: background, clip, border overlay,
+/// Applies the standard text field container styling: rounded fill background, border overlay,
 /// focus ring overlay, opacity, and hover tracking.
 struct TextFieldContainerModifier: ViewModifier {
     let backgroundColor: Color

--- a/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTile.swift
@@ -405,8 +405,7 @@ private struct LemonadeTileView<TopAccessory: View>: View {
         .applyIf(orientation == .horizontal) {
             $0.frame(minHeight: minHeightHorizontal)
         }
-        .background(tileStyle.backgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .background(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500).fill(tileStyle.backgroundColor))
         .overlay(
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(tileStyle.borderColor, lineWidth: tileStyle.borderWidth)
@@ -517,8 +516,7 @@ private struct LemonadeTileSlotView<LeadingContent: View, TopAccessory: View>: V
         .applyIf(orientation == .horizontal) {
             $0.frame(minHeight: minHeightHorizontal)
         }
-        .background(tileStyle.backgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500))
+        .background(RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500).fill(tileStyle.backgroundColor))
         .overlay(
             RoundedRectangle(cornerRadius: LemonadeTheme.radius.radius500)
                 .stroke(tileStyle.borderColor, lineWidth: tileStyle.borderWidth)

--- a/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToast.swift
@@ -183,8 +183,7 @@ private struct ToastBackgroundModifier: ViewModifier {
                 )
         } else {
             content
-                .background(.bg.bgAlwaysDark)
-                .clipShape(RoundedRectangle(cornerRadius: .radius.radiusFull))
+                .background(RoundedRectangle(cornerRadius: .radius.radiusFull).fill(.bg.bgAlwaysDark))
         }
         #else
         content


### PR DESCRIPTION
## Rationale

Each `.clipShape(Shape)` / `.cornerRadius(_)` in SwiftUI allocates a **GPU offscreen mask layer** — one offscreen render pass per use. In the consuming app, with many list rows on screen (ListItem, Chip, SearchField, SymbolContainer, Tile and friends each clipping), this produced **200-300 offscreen passes per scroll frame**, the direct cause of severe scroll jank. This was confirmed on-device with the **"Color Off-screen Rendered"** debug overlay, which lit up these components yellow during scrolling.

When a component rounds a **solid-color background** and the child content stays **inside** the rounded area (normal padding, never reaching the edge), the clip mask is doing nothing the renderer can't do for free. Replacing `.background(Color.X).clipShape(RoundedRectangle(...))` with `.background(RoundedRectangle(...).fill(Color.X))` draws the rounded fill directly — **appearance-identical, zero offscreen pass**.

No public API, colors, corner radii, spacing, fonts, or layout changed — only the rendering technique. Builds clean (`swift build`).

## Per-component summary

| Component | Action | Detail |
|---|---|---|
| **LemonadeNotice** | ✅ Convert | Solid `voice.containerColor` bg, content padded inside → rounded fill |
| **LemonadeToast** | ✅ Convert (×2) | Solid `bgAlwaysDark` bg (both pre-iOS26 branches) → rounded fill |
| **LemonadeIconButton** | ✅ Convert | Background was already `buttonShape.fill(bgColor)`; removed the now-redundant `.clipShape(buttonShape)` |
| **LemonadeButton** | ✅ Convert | Same — background already filled; removed redundant `.clipShape(buttonShape)` |
| **LemonadeListItem** (`ListItemButtonStyle`) | ✅ Convert | Solid pressed/clear bg → rounded fill; kept `.contentShape(...)` |
| **LemonadeTile** | ✅ Convert (×2) | Solid `tileStyle.backgroundColor`, border via overlay → rounded fill |
| **LemonadeTextFieldShared** | ✅ Convert (×2) | Both container modifiers: solid `backgroundColor`, content inset → rounded fill |
| **LemonadeSearchField** | ✅ Convert | Solid `backgroundColor`, content padded → `Capsule().fill(...)` |
| **LemonadeChip** | ✅ Convert (×2) | Counter badge (`Capsule`) + chip body (`radiusFull`) solid bg → fill |
| **LemonadeChip** (leading image) | ⛔️ Keep | `.clipShape(Circle())` clips a resizable scaledToFill **image** — must clip |
| **LemonadeCountryFlag** | ⛔️ Keep | `.clipShape(Circle())` clips the flag **image** — must clip |
| **LemonadeSymbolContainer** | ⛔️ Keep (already optimal) | Already uses `.background(color, in: shape)`; the remaining `.clipShape` is conditional (`clipsContent`) and only for fill-**image** content that overflows |
| **LemonadeSelectListItem** | ⛔️ N/A (already optimal) | Already uses `RoundedRectangle(...).fill(backgroundColor)` — no clip |
| **LemonadeCard** | ⛔️ Keep | Container slot component — `header`/`footer`/`content()` can render edge-to-edge (full-bleed images/headers). Removing the clip would let child content poke past the rounded corners. Left as-is per the safety rule. |
| **LemonadeTabs** | ⛔️ Keep | `.mask(LinearGradient(black→clear))` is a genuine soft alpha **gradient fade** on the scroll edge — not a shape fill, not safely convertible |
| LemonadeContentListItem / ResourceListItem / ActionListItem | — | No own background/clip; delegate to ListItem |

## Review asks

1. **Verify appearance is unchanged** across the converted components (light/dark, selected/pressed/error/focused states) — the look should be pixel-identical.
2. **Re-check the "Color Off-screen Rendered" overlay** while scrolling a list in the consuming app — the converted components should no longer render offscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)