### PR TITLE
feat(BottomTabBar): add optional badge on tab items

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/BottomTabBarDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/BottomTabBarDisplay.kt
@@ -59,6 +59,7 @@ private fun LazyListScope.defaultBottomTabBarSection() {
                     label = "Teya AI",
                     icon = LemonadeIcons.SparklesSoft,
                     selectedIcon = LemonadeIcons.SparklesSoftSolid,
+                    badge = "Soon",
                 ),
             ),
             selectedIndex = 0,

--- a/kmp/expressive/api/android/expressive.api
+++ b/kmp/expressive/api/android/expressive.api
@@ -10,13 +10,17 @@ public final class com/teya/lemonade/BottomSheet_androidKt {
 
 public final class com/teya/lemonade/BottomTabBarItem {
 	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component3 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component4 ()Ljava/lang/String;
+	public final synthetic fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)Lcom/teya/lemonade/BottomTabBarItem;
 	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)Lcom/teya/lemonade/BottomTabBarItem;
+	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBadge ()Ljava/lang/String;

--- a/kmp/expressive/api/android/expressive.api
+++ b/kmp/expressive/api/android/expressive.api
@@ -10,14 +10,16 @@ public final class com/teya/lemonade/BottomSheet_androidKt {
 
 public final class com/teya/lemonade/BottomTabBarItem {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component3 ()Lcom/teya/lemonade/core/LemonadeIcons;
-	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)Lcom/teya/lemonade/BottomTabBarItem;
-	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)Lcom/teya/lemonade/BottomTabBarItem;
+	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBadge ()Ljava/lang/String;
 	public final fun getIcon ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getSelectedIcon ()Lcom/teya/lemonade/core/LemonadeIcons;
@@ -39,7 +41,7 @@ public final class com/teya/lemonade/ComposableSingletons$BottomSheetKt {
 public final class com/teya/lemonade/ComposableSingletons$BottomTabBarKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$BottomTabBarKt;
 	public fun <init> ()V
-	public final fun getLambda$-692955140$expressive_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1638718786$expressive_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/teya/lemonade/DialogKt {

--- a/kmp/expressive/api/desktop/expressive.api
+++ b/kmp/expressive/api/desktop/expressive.api
@@ -5,14 +5,16 @@ public final class com/teya/lemonade/BottomSheetKt {
 
 public final class com/teya/lemonade/BottomTabBarItem {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component3 ()Lcom/teya/lemonade/core/LemonadeIcons;
-	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)Lcom/teya/lemonade/BottomTabBarItem;
-	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)Lcom/teya/lemonade/BottomTabBarItem;
+	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBadge ()Ljava/lang/String;
 	public final fun getIcon ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun getLabel ()Ljava/lang/String;
 	public final fun getSelectedIcon ()Lcom/teya/lemonade/core/LemonadeIcons;
@@ -34,7 +36,7 @@ public final class com/teya/lemonade/ComposableSingletons$BottomSheetKt {
 public final class com/teya/lemonade/ComposableSingletons$BottomTabBarKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$BottomTabBarKt;
 	public fun <init> ()V
-	public final fun getLambda$-692955140$expressive ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1638718786$expressive ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/teya/lemonade/DialogKt {

--- a/kmp/expressive/api/desktop/expressive.api
+++ b/kmp/expressive/api/desktop/expressive.api
@@ -5,13 +5,17 @@ public final class com/teya/lemonade/BottomSheetKt {
 
 public final class com/teya/lemonade/BottomTabBarItem {
 	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component3 ()Lcom/teya/lemonade/core/LemonadeIcons;
 	public final fun component4 ()Ljava/lang/String;
+	public final synthetic fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;)Lcom/teya/lemonade/BottomTabBarItem;
 	public final fun copy (Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;)Lcom/teya/lemonade/BottomTabBarItem;
+	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public static synthetic fun copy$default (Lcom/teya/lemonade/BottomTabBarItem;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/core/LemonadeIcons;Ljava/lang/String;ILjava/lang/Object;)Lcom/teya/lemonade/BottomTabBarItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBadge ()Ljava/lang/String;

--- a/kmp/expressive/api/expressive.klib.api
+++ b/kmp/expressive/api/expressive.klib.api
@@ -7,8 +7,10 @@
 
 // Library unique name: <Lemonade:expressive>
 final class com.teya.lemonade/BottomTabBarItem { // com.teya.lemonade/BottomTabBarItem|null[0]
-    constructor <init>(kotlin/String, com.teya.lemonade.core/LemonadeIcons, com.teya.lemonade.core/LemonadeIcons? = ...) // com.teya.lemonade/BottomTabBarItem.<init>|<init>(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?){}[0]
+    constructor <init>(kotlin/String, com.teya.lemonade.core/LemonadeIcons, com.teya.lemonade.core/LemonadeIcons? = ..., kotlin/String? = ...) // com.teya.lemonade/BottomTabBarItem.<init>|<init>(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?;kotlin.String?){}[0]
 
+    final val badge // com.teya.lemonade/BottomTabBarItem.badge|{}badge[0]
+        final fun <get-badge>(): kotlin/String? // com.teya.lemonade/BottomTabBarItem.badge.<get-badge>|<get-badge>(){}[0]
     final val icon // com.teya.lemonade/BottomTabBarItem.icon|{}icon[0]
         final fun <get-icon>(): com.teya.lemonade.core/LemonadeIcons // com.teya.lemonade/BottomTabBarItem.icon.<get-icon>|<get-icon>(){}[0]
     final val label // com.teya.lemonade/BottomTabBarItem.label|{}label[0]
@@ -19,7 +21,8 @@ final class com.teya.lemonade/BottomTabBarItem { // com.teya.lemonade/BottomTabB
     final fun component1(): kotlin/String // com.teya.lemonade/BottomTabBarItem.component1|component1(){}[0]
     final fun component2(): com.teya.lemonade.core/LemonadeIcons // com.teya.lemonade/BottomTabBarItem.component2|component2(){}[0]
     final fun component3(): com.teya.lemonade.core/LemonadeIcons? // com.teya.lemonade/BottomTabBarItem.component3|component3(){}[0]
-    final fun copy(kotlin/String = ..., com.teya.lemonade.core/LemonadeIcons = ..., com.teya.lemonade.core/LemonadeIcons? = ...): com.teya.lemonade/BottomTabBarItem // com.teya.lemonade/BottomTabBarItem.copy|copy(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?){}[0]
+    final fun component4(): kotlin/String? // com.teya.lemonade/BottomTabBarItem.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., com.teya.lemonade.core/LemonadeIcons = ..., com.teya.lemonade.core/LemonadeIcons? = ..., kotlin/String? = ...): com.teya.lemonade/BottomTabBarItem // com.teya.lemonade/BottomTabBarItem.copy|copy(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?;kotlin.String?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.teya.lemonade/BottomTabBarItem.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.teya.lemonade/BottomTabBarItem.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.teya.lemonade/BottomTabBarItem.toString|toString(){}[0]

--- a/kmp/expressive/api/expressive.klib.api
+++ b/kmp/expressive/api/expressive.klib.api
@@ -7,6 +7,7 @@
 
 // Library unique name: <Lemonade:expressive>
 final class com.teya.lemonade/BottomTabBarItem { // com.teya.lemonade/BottomTabBarItem|null[0]
+    constructor <init>(kotlin/String, com.teya.lemonade.core/LemonadeIcons, com.teya.lemonade.core/LemonadeIcons? = ...) // com.teya.lemonade/BottomTabBarItem.<init>|<init>(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?){}[0]
     constructor <init>(kotlin/String, com.teya.lemonade.core/LemonadeIcons, com.teya.lemonade.core/LemonadeIcons? = ..., kotlin/String? = ...) // com.teya.lemonade/BottomTabBarItem.<init>|<init>(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?;kotlin.String?){}[0]
 
     final val badge // com.teya.lemonade/BottomTabBarItem.badge|{}badge[0]
@@ -22,6 +23,7 @@ final class com.teya.lemonade/BottomTabBarItem { // com.teya.lemonade/BottomTabB
     final fun component2(): com.teya.lemonade.core/LemonadeIcons // com.teya.lemonade/BottomTabBarItem.component2|component2(){}[0]
     final fun component3(): com.teya.lemonade.core/LemonadeIcons? // com.teya.lemonade/BottomTabBarItem.component3|component3(){}[0]
     final fun component4(): kotlin/String? // com.teya.lemonade/BottomTabBarItem.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., com.teya.lemonade.core/LemonadeIcons = ..., com.teya.lemonade.core/LemonadeIcons? = ...): com.teya.lemonade/BottomTabBarItem // com.teya.lemonade/BottomTabBarItem.copy|copy(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?){}[0]
     final fun copy(kotlin/String = ..., com.teya.lemonade.core/LemonadeIcons = ..., com.teya.lemonade.core/LemonadeIcons? = ..., kotlin/String? = ...): com.teya.lemonade/BottomTabBarItem // com.teya.lemonade/BottomTabBarItem.copy|copy(kotlin.String;com.teya.lemonade.core.LemonadeIcons;com.teya.lemonade.core.LemonadeIcons?;kotlin.String?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.teya.lemonade/BottomTabBarItem.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.teya.lemonade/BottomTabBarItem.hashCode|hashCode(){}[0]

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeShadow
-import com.teya.lemonade.core.TagVoice
 import kotlin.math.roundToInt
 
 /**
@@ -309,7 +308,7 @@ private fun BottomTabBarItemContent(
         BadgedBox(
             badge = {
                 item.badge?.let { badge ->
-                    LemonadeUi.Tag(label = badge, voice = TagVoice.Neutral)
+                    LemonadeUi.Badge(text = badge)
                 }
             },
         ) {

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
@@ -70,7 +70,26 @@ public data class BottomTabBarItem(
     val icon: LemonadeIcons,
     val selectedIcon: LemonadeIcons? = null,
     val badge: String? = null,
-)
+) {
+    // Binary-compat shim: restores the pre-badge constructor symbols
+    // `<init>(String, LemonadeIcons, LemonadeIcons)` and its `$default` variant, so already
+    // compiled consumers keep linking. HIDDEN keeps the bytecode while hiding it from source.
+    @Deprecated("kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        label: String,
+        icon: LemonadeIcons,
+        selectedIcon: LemonadeIcons? = null,
+    ) : this(label, icon, selectedIcon, badge = null)
+
+    // Binary-compat shim: restores the pre-badge `copy(...)` and `copy$default(...)` symbols.
+    // The defaults are required — they are what regenerate the old `copy$default`.
+    @Deprecated("kept for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public fun copy(
+        label: String = this.label,
+        icon: LemonadeIcons = this.icon,
+        selectedIcon: LemonadeIcons? = this.selectedIcon,
+    ): BottomTabBarItem = copy(label = label, icon = icon, selectedIcon = selectedIcon, badge = this.badge)
+}
 
 /**
  * A floating, pill-shaped bottom navigation bar for top-level destinations.

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
@@ -50,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 import com.teya.lemonade.core.LemonadeShadow
+import com.teya.lemonade.core.TagVoice
 import kotlin.math.roundToInt
 
 /**
@@ -60,11 +62,14 @@ import kotlin.math.roundToInt
  * @param selectedIcon Optional [LemonadeIcons] rendered while the item is selected. A common
  *   pattern is to pair an outline `icon` with its solid variant here (e.g. `Wallet` /
  *   `WalletSolid`). When `null`, [icon] is used for both states.
+ * @param badge Optional short text rendered as a small [LemonadeUi.Tag] over the icon's
+ *   top-trailing corner (e.g. "Soon" / "New"). When `null`, no badge is shown.
  */
 public data class BottomTabBarItem(
     val label: String,
     val icon: LemonadeIcons,
     val selectedIcon: LemonadeIcons? = null,
+    val badge: String? = null,
 )
 
 /**
@@ -282,23 +287,31 @@ private fun BottomTabBarItemContent(
             label = "tabIconScale",
         )
 
-        Box(
-            modifier = Modifier.graphicsLayer {
-                scaleX = iconScale
-                scaleY = iconScale
+        BadgedBox(
+            badge = {
+                item.badge?.let { badge ->
+                    LemonadeUi.Tag(label = badge, voice = TagVoice.Neutral)
+                }
             },
         ) {
-            Crossfade(
-                targetState = displayedIcon,
-                animationSpec = tween(durationMillis = ICON_CROSSFADE_MS),
-                label = "tabIcon",
-            ) { icon ->
-                LemonadeUi.Icon(
-                    icon = icon,
-                    contentDescription = null,
-                    size = LemonadeAssetSize.Medium,
-                    tint = LemonadeTheme.colors.content.contentPrimary,
-                )
+            Box(
+                modifier = Modifier.graphicsLayer {
+                    scaleX = iconScale
+                    scaleY = iconScale
+                },
+            ) {
+                Crossfade(
+                    targetState = displayedIcon,
+                    animationSpec = tween(durationMillis = ICON_CROSSFADE_MS),
+                    label = "tabIcon",
+                ) { icon ->
+                    LemonadeUi.Icon(
+                        icon = icon,
+                        contentDescription = null,
+                        size = LemonadeAssetSize.Medium,
+                        tint = LemonadeTheme.colors.content.contentPrimary,
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## What

`BottomTabBarItem` gains an optional `badge: String?`. When set, a small `LemonadeUi.Tag` renders over the icon's top-trailing corner via Material3 `BadgedBox` — so a tab can flag a **"Soon" / "New"** state without shifting the icon or label. `null` keeps the current icon-only layout (no behavior change for existing call sites — the param is defaulted).

Driven by the app needing a "Soon" badge on the **Teya AI** tab while the feature is behind a flag.

## Changes

- `BottomTabBarItem.badge: String? = null` (+ KDoc).
- `BottomTabBarItemContent` wraps the icon in `BadgedBox`, rendering `LemonadeUi.Tag(label = badge, voice = .Neutral)` when present.
- Binary-compat `.api` dumps regenerated (`apiDump`): android / desktop / klib.
- Demo (`BottomTabBarDisplay`) shows the badge on the "Teya AI" item.

## Design notes / for review

- **Voice:** used `TagVoice.Neutral` (gray pill). The app's reference design (web) shows a **lime/brand** "Soon" pill — there's no brand `TagVoice` today, so the exact color needs a design/token call. Happy to switch to whichever voice (or a new brand voice) you prefer.
- **Positioning:** `BadgedBox` default top-end placement; a text Tag is wider than a dot badge, so on very narrow slots it can sit close to the edge. Open to a tighter/size-capped badge variant if preferred.

## Verify

- `:expressive:compileDebugKotlinAndroid` ✅
- `:expressive:apiDump` ✅ (committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)