### PR TITLE
fix(swiftui): pin TextField to intrinsic height

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -46,6 +46,12 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
+        // Pin the field to its intrinsic (single-line) height. A UITextField defaults to low
+        // vertical hugging, so when SwiftUI offers unbounded height (e.g. inside a flexible
+        // VStack) the field grows to fill it. SwiftUI's own TextField never does this.
+        textField.setContentHuggingPriority(.required, for: .vertical)
+        textField.setContentCompressionResistancePriority(.required, for: .vertical)
+
         // Set initial cursor position (clamped to valid range)
         textField.setCaret(toUTF16Offset: clampedCursorPosition(value.cursorPosition, for: value.text))
 


### PR DESCRIPTION
## Problem

The string-based `LemonadeUi.TextField(input:)` expands to fill all available vertical space when placed in a flexible layout, instead of staying single-line. It renders as a tall empty box with the text vertically centered.

## Root cause

In #246 the string-based variant was rewritten to route its editable control through the UIKit-backed `LemonadeUITextField` (a `UIViewRepresentable` over `UITextField`) to support in-place secure-entry toggling.

SwiftUI's native `TextField` asserts a fixed single-line intrinsic height regardless of the space offered. The wrapped `UITextField` does not: it defaults to **low vertical content hugging**, and `makeUIView` only constrained the **horizontal** axis:

```swift
textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
```

So when the surrounding layout offers unbounded height (e.g. a flexible `VStack`), the field grows to fill it.

This affects every consumer of the string-based `LemonadeUi.TextField(input:)` / `TextFieldWithSelector` since 0.18.0.

## Fix

Pin the wrapped field's vertical content hugging and compression resistance to `.required` so it hugs its intrinsic single-line height — symmetric with the existing horizontal handling, and matching SwiftUI's native `TextField`.

```swift
textField.setContentHuggingPriority(.required, for: .vertical)
textField.setContentCompressionResistancePriority(.required, for: .vertical)
```

## Testing

- `swift build --target Lemonade` passes.
- Verified the field returns to single-line height in a flexible vertical container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)