### PR TITLE
fix(badge): align gradient highlight with design on both platforms

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Badge.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Badge.kt
@@ -1,6 +1,5 @@
 package com.teya.lemonade
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -11,8 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.layout.Layout
@@ -55,7 +56,7 @@ public fun LemonadeUi.Badge(
     CoreBadge(
         text = text,
         modifier = modifier,
-        size = size,
+        badgeSize = size,
     )
 }
 
@@ -63,16 +64,35 @@ public fun LemonadeUi.Badge(
 private fun CoreBadge(
     text: String,
     modifier: Modifier,
-    size: LemonadeBadgeSize,
+    badgeSize: LemonadeBadgeSize,
 ) {
-    val props = size.badgeProps
+    val props = badgeSize.badgeProps
+    val brandColor = LocalColors.current.background.bgBrand
+    val overlayColor = LocalColors.current.background.bgDefault
     Row(
         modifier = modifier
             .height(props.height)
             .clip(LocalShapes.current.radiusFull)
-            .background(LocalColors.current.background.bgBrand)
-            .background(gradientOverlay)
-            .padding(horizontal = props.horizontalPadding),
+            .drawWithCache {
+                // Per design: a bg-default → transparent highlight composited over the brand
+                // fill in Overlay blend mode. The design specifies a ~106.6° sweep; a
+                // corner-to-corner gradient approximates that closely on the badge's short,
+                // wide shape without size-dependent angle math. drawWithCache rebuilds the
+                // brush only when the size changes, not every frame.
+                val overlay = Brush.linearGradient(
+                    0f to overlayColor,
+                    1f to overlayColor.copy(alpha = 0f),
+                    start = Offset.Zero,
+                    end = Offset(x = size.width, y = size.height),
+                )
+                onDrawBehind {
+                    drawRect(color = brandColor)
+                    drawRect(
+                        brush = overlay,
+                        blendMode = BlendMode.Overlay,
+                    )
+                }
+            }.padding(horizontal = props.horizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         LemonadeUi.Text(
@@ -85,17 +105,6 @@ private fun CoreBadge(
         )
     }
 }
-
-// todo can we replace with themed colors? ask designer
-private val gradientOverlay: Brush
-    get() {
-        return Brush.linearGradient(
-            colors = listOf(
-                Color(0xFFD6F25A),
-                Color(0xD6F25A00).copy(alpha = 0.0f),
-            ),
-        )
-    }
 
 private data class BadgeProps(
     val height: Dp,

--- a/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeBadge.swift
@@ -85,12 +85,18 @@ private struct LemonadeBadgeView: View {
     let text: String
     let size: LemonadeBadgeSize
 
-    private var gradientColors: [Color] {
-        let brandHighlight = LemonadeTheme.colors.background.bgBrandHigh
-        return [
-            brandHighlight,
-            brandHighlight.opacity(0)
-        ]
+    private var overlayGradient: LinearGradient {
+        let highlight = LemonadeTheme.colors.background.bgDefault
+        return LinearGradient(
+            stops: [
+                .init(color: highlight, location: 0),
+                .init(color: highlight.opacity(0), location: 1)
+            ],
+            // The design specifies a ~106.6° sweep; topLeading→bottomTrailing approximates
+            // that on the badge's short, wide shape without size-dependent angle math.
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
 
     var body: some View {
@@ -108,19 +114,20 @@ private struct LemonadeBadgeView: View {
             // radius), so the shaped fills do the rounding instead. Badges render densely
             // (one per notification dot/count), so the per-instance pass adds up while scrolling.
             .background(
+                // Per design: brand fill with a bg-default → transparent highlight composited
+                // in `.overlay` blend mode. compositingGroup() isolates the blend so the gradient
+                // reacts to the brand fill below it, not whatever sits behind the badge. This is a
+                // bounded compositing pass over two coincident capsules — much cheaper than the
+                // clipShape avoided above, which would composite the whole shaped subtree.
                 ZStack {
                     Capsule()
                         .fill(LemonadeTheme.colors.background.bgBrand)
 
                     Capsule()
-                        .fill(
-                            LinearGradient(
-                                colors: gradientColors,
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
+                        .fill(overlayGradient)
+                        .blendMode(.overlay)
                 }
+                .compositingGroup()
             )
     }
 }


### PR DESCRIPTION
## What

The Badge highlight overlay didn't match the Figma design ([node 2203-639](https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---New-App-Components?node-id=2203-639)) and rendered differently on each platform. The spec is a **`bg-default` → transparent gradient composited over the `bg-brand` pill in `Overlay` blend mode**, along a ~106.6° diagonal.

| | Before | After |
|---|---|---|
| **Compose** | hardcoded lime `Color(0xFFD6F25A)`, normal blend, diagonal | `bg-default` → transparent, `BlendMode.Overlay`, diagonal |
| **SwiftUI** | `bgBrandHigh` (dark olive in light mode → the "odd" smear), no blend mode, horizontal | `bg-default` → transparent, `.blendMode(.overlay)`, diagonal |

### Why it looked odd on iOS
`bgBrandHigh` resolves to `yellowLime800` (a dark olive) in light mode, so the overlay painted a dark smear over the left of the lime pill. Both platforms now pull the gradient from the `bg-default` token and apply the `overlay` blend mode the design calls for, so the highlight is theme-aware and consistent.

## Changes
- **`kmp/ui/.../Badge.kt`** — draw `bg-brand` then the `bg-default` → transparent gradient with `BlendMode.Overlay` in a `drawWithCache`/`onDrawBehind` (brush rebuilt only when size changes). Removed the hardcoded `gradientOverlay` brush and its `// todo ask designer`. Renamed `CoreBadge`'s `size` param to `badgeSize` to avoid shadowing `CacheDrawScope.size`.
- **`swiftui/.../LemonadeBadge.swift`** — gradient now uses `bgDefault` → transparent with `.blendMode(.overlay)`, isolated by `.compositingGroup()`. Kept the existing no-`clipShape` capsule-fill perf optimization.

## Screenshots
| Before | After |
| ------ | ----- |
| <img width="300" src="https://github.com/user-attachments/assets/77b1213c-e8de-415f-9bc7-1f1c6d5fccb2" /> | <img width="300" src="https://github.com/user-attachments/assets/e9336084-e314-4d1e-9b32-197a54512b86" /> |
### Notes
- Gradient direction is a corner-to-corner approximation of the spec's ~106.6° (documented inline) — close on the badge's short/wide shape without size-dependent angle math.
- `/simplify` run over the diff: reuse/simplification/efficiency/altitude all came back clean (colors are now token-driven, no shared gradient helper exists to reuse, duplication across platforms is unavoidable).

## Testing
- Compose: builds clean; **verified running on a Pixel 10a** — badges render the correct lime pill with a subtle white sheen, no dark smear.
- SwiftUI: changed code uses only standard APIs. **On-device iOS verification is pending** — blocked by local Xcode signing setup (no Apple ID account configured), not by the change.

## API Dump
**No public API changes.** Classifier verdict: `NO_CHANGES`. The `Badge(...)` signature is unchanged; all edits are private (renamed a private parameter, swapped private draw modifiers, removed a private brush property). No `api/*.api` / `*.klib.api` baseline files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)