### PR TITLE
feat(swiftui): ListItem .both priority, filler floor, and first-line alignment

### DIFF
--- a/swiftui/SampleApp/ListItemDisplayView.swift
+++ b/swiftui/SampleApp/ListItemDisplayView.swift
@@ -33,6 +33,15 @@ struct ListItemPriorityPreview: View {
         )
     }
 
+    @ViewBuilder
+    private func addressText() -> some View {
+        LemonadeUi.Text(
+            "Rua de Olivenca, 55, esq 2, Algés, OX20 1PP",
+            textAlign: .trailing,
+            color: LemonadeTheme.colors.content.contentSecondary
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: .space.spacing400) {
             LemonadeUi.Text("ListItem — Layout Priority", font: .headingXSmall)
@@ -41,10 +50,18 @@ struct ListItemPriorityPreview: View {
             LemonadeUi.Card(
                 contentPadding: .none,
                 header: CardHeaderConfig(
-                    title: "priority: .trailing (default)",
+                    title: "Priority: .trailing (default)",
                     subtitle: "Trailing keeps its full width; the label truncates to fit."
                 )
             ) {
+                LemonadeUi.ListItem(
+                    label: "Delivery to",
+                    showDivider: true,
+                    trailingAlignment: .top,
+                    labelMaxLines: 1,
+                    leadingSlot: { EmptyView() },
+                    trailingSlot: { addressText() }
+                )
                 LemonadeUi.ListItem(
                     label: label,
                     labelMaxLines: 1,
@@ -57,7 +74,7 @@ struct ListItemPriorityPreview: View {
             LemonadeUi.Card(
                 contentPadding: .none,
                 header: CardHeaderConfig(
-                    title: "priority: .label",
+                    title: "Priority: .label",
                     subtitle: "Label keeps its full width; the trailing content truncates to fit."
                 )
             ) {
@@ -79,6 +96,70 @@ struct ListItemPriorityPreview: View {
                     labelMaxLines: 1,
                     leadingSlot: { EmptyView() },
                     trailingSlot: { valueText() }
+                )
+            }
+
+            // MARK: - priority: .both
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "Priority: .both",
+                    subtitle: "Neither side wins — the width splits 50/50 and both truncate together."
+                )
+            ) {
+                LemonadeUi.ListItem(
+                    label: label,
+                    priority: .both,
+                    labelMaxLines: 1,
+                    leadingSlot: { EmptyView() },
+                    trailingSlot: { valueText() }
+                )
+            }
+
+            // MARK: - priority: .trailing — label keeps a minimum width
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "Priority: .trailing — label floor",
+                    subtitle: "Even with a very long trailing value, the label keeps a readable minimum width instead of collapsing to just an ellipsis."
+                )
+            ) {
+                LemonadeUi.ListItem(
+                    label: "Beneficiary",
+                    labelMaxLines: 1,
+                    leadingSlot: { EmptyView() },
+                    trailingSlot: {
+                        LemonadeUi.Text(
+                            "International Holdings Ltd Partnership and Subsidiaries",
+                            textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                            maxLines: 1
+                        )
+                    }
+                )
+            }
+
+            // MARK: - First-line (top) alignment
+            LemonadeUi.Card(
+                contentPadding: .none,
+                header: CardHeaderConfig(
+                    title: "First-line alignment",
+                    subtitle: "trailingAlignment: .top keeps the label aligned with the trailing's first line when it wraps; .center is the default."
+                )
+            ) {
+                LemonadeUi.ListItem(
+                    label: "Delivery to",
+                    showDivider: true,
+                    trailingAlignment: .top,
+                    priority: .label,
+                    leadingSlot: { EmptyView() },
+                    trailingSlot: { addressText() }
+                )
+                LemonadeUi.ListItem(
+                    label: "Delivery to",
+                    trailingAlignment: .center,
+                    priority: .label,
+                    leadingSlot: { EmptyView() },
+                    trailingSlot: { addressText() }
                 )
             }
         }

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -237,9 +237,15 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
         priority == .label ? nil : .infinity
     }
 
-    // When the trailing slot is prioritized, the content becomes the filler.
+    // When the trailing slot is prioritized, the content becomes the filler and
+    // keeps a readable floor so a long trailing value can't squeeze it to an
+    // ellipsis. Only applies when there's actually a trailing slot competing for
+    // width — otherwise a label-only row would be forced wider than a narrow
+    // container and overflow.
     private var contentMinWidth: CGFloat? {
-        priority == .trailing ? minReadableSlotWidth : nil
+        priority == .trailing && (hasTrailing || navigationIndicator)
+            ? minReadableSlotWidth
+            : nil
     }
 
     private var contentLayoutPriority: Double {

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -262,6 +262,18 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
         priority == .trailing ? 1 : 0
     }
 
+    // `.top` is documented as "keep the label and trailing slot on the same
+    // first line when one wraps". Frame-top alignment can't deliver that:
+    // `LemonadeUi.Text` pads a single line to its line-height box and centers
+    // the glyphs within it, while a wrapping slot lays its first line flush to
+    // the top — so the two first lines end up offset by the half-leading
+    // (~2-3pt). Aligning on the first text baseline lines the glyphs up exactly,
+    // regardless of how many lines each slot wraps to. Other alignments pass
+    // through unchanged so `.center`/`.bottom` keep their literal meaning.
+    private var contentRowAlignment: VerticalAlignment {
+        trailingAlignment == .top ? .firstTextBaseline : trailingAlignment
+    }
+
     var body: some View {
         ListItemSafeArea(showDivider: showDivider) {
             if let onClick = onListItemClick, enabled {
@@ -286,7 +298,7 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                     .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
             }
             
-            HStack(alignment: trailingAlignment, spacing: 0) {
+            HStack(alignment: contentRowAlignment, spacing: 0) {
                 // The non-prioritized slot becomes the flexible filler: it expands to
                 // claim the remaining width and truncates first, pinning the prioritized
                 // (intrinsically-sized) slot to its edge.

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -54,9 +54,12 @@ public enum LemonadeListItemVoice {
 ///   trailing slot compresses or truncates to fit.
 /// - `trailing`: The trailing slot claims its intrinsic width first; the label
 ///   compresses or truncates to fit. This is the default.
+/// - `both`: Neither slot is prioritized; the available width is split evenly so
+///   the label and trailing content each occupy half, truncating together.
 public enum LemonadeListItemPriority {
     case label
     case trailing
+    case both
 }
 
 // MARK: - ListItem
@@ -75,8 +78,8 @@ public extension LemonadeUi {
     ///   - enabled: Flag to define if component is enabled
     ///   - showDivider: Flag to show a divider below the list item
     ///   - leadingAlignment: Vertical alignment of the leading slot. Defaults to `.top`.
-    ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
-    ///   - priority: Which slot claims layout space first when label and trailing content compete for width. Defaults to `.trailing`.
+    ///   - trailingAlignment: Vertical alignment of the content row — both the label/content and the trailing slot align to it (e.g. `.top` keeps them on the same first line when one wraps). Defaults to `.center`.
+    ///   - priority: Which slot claims layout space first when label and trailing content compete for width. Use `.both` to split the width evenly. Defaults to `.trailing`.
     ///   - labelMaxLines: Maximum number of lines for the label before it truncates. Defaults to `nil` (no limit).
     ///   - labelOverflow: Truncation mode applied to the label when it exceeds `labelMaxLines`. Defaults to `.tail`.
     ///   - supportTextMaxLines: Maximum number of lines for the support text before it truncates. Defaults to `nil` (no limit).
@@ -165,8 +168,8 @@ public extension LemonadeUi {
     ///   - enabled: Flag to define if component is enabled
     ///   - showDivider: Flag to show a divider below the list item
     ///   - leadingAlignment: Vertical alignment of the leading slot. Defaults to `.top`.
-    ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
-    ///   - priority: Which slot claims layout space first when content and trailing slots compete for width. Defaults to `.trailing`.
+    ///   - trailingAlignment: Vertical alignment of the content row — both the label/content and the trailing slot align to it (e.g. `.top` keeps them on the same first line when one wraps). Defaults to `.center`.
+    ///   - priority: Which slot claims layout space first when content and trailing slots compete for width. Use `.both` to split the width evenly. Defaults to `.trailing`.
     ///   - onListItemClick: Optional callback triggered on click interaction
     ///   - leadingSlot: Slot content to be placed in leading position
     ///   - trailingSlot: Slot content to be placed in trailing position
@@ -223,7 +226,42 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
     private var hasTrailing: Bool {
         TrailingContent.self != EmptyView.self
     }
-    
+
+    // The minimum width the filler (non-prioritized) slot keeps so a long
+    // prioritized slot can't squeeze it down to just an ellipsis.
+    private var minReadableSlotWidth: CGFloat { LemonadeTheme.sizes.size2000 }
+
+    // The content slot is intrinsically sized only when the label is prioritized;
+    // otherwise it expands to fill (and, for `.both`, shares the fill equally).
+    private var contentMaxWidth: CGFloat? {
+        priority == .label ? nil : .infinity
+    }
+
+    // When the trailing slot is prioritized, the content becomes the filler.
+    private var contentMinWidth: CGFloat? {
+        priority == .trailing ? minReadableSlotWidth : nil
+    }
+
+    private var contentLayoutPriority: Double {
+        priority == .label ? 1 : 0
+    }
+
+    // The trailing slot is intrinsically sized only when it is prioritized;
+    // otherwise it expands to fill (and, for `.both`, shares the fill equally).
+    private var trailingMinWidth: CGFloat? {
+        priority == .label && (hasTrailing || navigationIndicator)
+            ? minReadableSlotWidth
+            : nil
+    }
+
+    private var trailingMaxWidth: CGFloat? {
+        priority == .trailing ? nil : .infinity
+    }
+
+    private var trailingLayoutPriority: Double {
+        priority == .trailing ? 1 : 0
+    }
+
     var body: some View {
         ListItemSafeArea(showDivider: showDivider) {
             if let onClick = onListItemClick, enabled {
@@ -256,12 +294,13 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                     contentSlot()
                 }
                 .frame(
-                    maxWidth: priority == .label ? nil : .infinity,
+                    minWidth: contentMinWidth,
+                    maxWidth: contentMaxWidth,
                     maxHeight: .infinity,
-                    alignment: .leading
+                    alignment: Alignment(horizontal: .leading, vertical: trailingAlignment)
                 )
                 .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
-                .layoutPriority(priority == .label ? 1 : 0)
+                .layoutPriority(contentLayoutPriority)
 
                 HStack(spacing: 0) {
                     if hasTrailing {
@@ -280,17 +319,15 @@ struct LemonadeCoreListItemView<ContentSlot: View, LeadingContent: View, Trailin
                     }
                 }
                 .frame(
-                    minWidth: priority == .label && (hasTrailing || navigationIndicator)
-                        ? LemonadeTheme.sizes.size2000
-                        : nil,
-                    maxWidth: priority == .label ? .infinity : nil,
+                    minWidth: trailingMinWidth,
+                    maxWidth: trailingMaxWidth,
                     alignment: .trailing
                 )
                 .padding(
                     .leading,
                     hasTrailing || navigationIndicator ? LemonadeTheme.spaces.spacing300 : 0
                 )
-                .layoutPriority(priority == .trailing ? 1 : 0)
+                .layoutPriority(trailingLayoutPriority)
             }
         }
         .padding(.horizontal, LemonadeTheme.spaces.spacing300)
@@ -405,6 +442,38 @@ struct LemonadeListItem_Previews: PreviewProvider {
                         "International Holdings Ltd Partnership",
                         textStyle: LemonadeTypography.shared.bodyMediumMedium,
                         maxLines: 1
+                    )
+                }
+            )
+
+            // Priority .both — label and trailing each take half, truncating together
+            LemonadeUi.ListItem(
+                label: "Beneficiary account holder",
+                showDivider: true,
+                priority: .both,
+                labelMaxLines: 1,
+                leadingSlot: { EmptyView() },
+                trailingSlot: {
+                    LemonadeUi.Text(
+                        "International Holdings Ltd Partnership",
+                        textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                        maxLines: 1
+                    )
+                }
+            )
+
+            // Top alignment — label keeps first-line alignment when trailing wraps
+            LemonadeUi.ListItem(
+                label: "Delivery to",
+                showDivider: true,
+                trailingAlignment: .top,
+                priority: .label,
+                leadingSlot: { EmptyView() },
+                trailingSlot: {
+                    LemonadeUi.Text(
+                        "Rua de Olivenca, 55, esq 2, Algés, OX20 1PP",
+                        textStyle: LemonadeTypography.shared.bodyMediumRegular,
+                        textAlign: .trailing
                     )
                 }
             )


### PR DESCRIPTION
## What

Extends the SwiftUI `ListItem` layout-priority feature with three improvements:

- **`priority: .both`** — a new case that splits the available width 50/50 between the label and trailing slots, so both truncate together. It falls out of the existing filler mechanism (both slots get `maxWidth: .infinity` + equal `layoutPriority`).
- **Filler min-width floor** — the non-prioritized (filler) slot now keeps a minimum readable width (`size2000`) so a long prioritized slot can't squeeze it down to just an ellipsis. The floor already existed for the trailing slot under `.label`; this makes it symmetric so the label no longer collapses to "…" under the default `.trailing` priority. The content-side floor only applies when there's actually a trailing slot (or nav indicator) competing for width, so a label-only row isn't forced wider than a narrow container.
- **First-line alignment** — `trailingAlignment: .top` now keeps the label and trailing content on the same first line when one wraps. Frame-top alignment couldn't deliver this (`LemonadeUi.Text` centers a single line within its line-height box while a wrapping slot lays its first line flush to the top, leaving a ~2–3pt half-leading offset), so `.top` is resolved to `.firstTextBaseline` for the content row. `.center`/`.bottom` and other values pass through unchanged.

## Why

Real layouts hit two issues: a long trailing value (e.g. an address) would collapse the label to a bare ellipsis, and a wrapping trailing value would leave the label vertically offset from the trailing's first line. `.both` covers the common "two competing values, share the row" case.

## Screenshots
<img width="360" src="https://github.com/user-attachments/assets/28cf916e-4af5-4cd5-a080-b735d778325b" />

## Notes

- Internals refactored from inline `priority == ...` ternaries into named computed properties (`contentMaxWidth`, `contentMinWidth`, `*LayoutPriority`, etc.) — cost-neutral, just readable. The `size2000` floor is centralized in one `minReadableSlotWidth` property.
- Sample app (`ListItemDisplayView`) gains cards for `.both`, the filler floor, and first-line alignment (`.top` vs `.center`).
- `trailingAlignment` doc comment clarified to note it governs the whole content row, not just the trailing slot.
- Verified in the simulator: under `.top`, label and trailing first lines share the exact same top/baseline; `.center` still centers; `ResourceListItem` row heights unchanged.

## API Dump

No KMP public API changes — this is a SwiftUI-package-only change (`Sources/Lemonade` + `SampleApp`); no published KMP module (`core`/`tokens`/`ui`/`expressive`/`calendar`) baseline files were touched, so the Binary Compatibility Validator is not involved.

One **additive SwiftUI API change**: a new `.both` case on the public `LemonadeListItemPriority` enum. It's source- and binary-additive, but downstream exhaustive `switch`es over the enum will need a new branch (and `CaseIterable` consumers, if any, see an extra case).

## Follow-up

The Compose/KMP `ListItem` is missing the `.both` case and the content-side floor; a separate PR will mirror these for parity. (The alignment change is already present on the Compose side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
