### PR TITLE
feat(listitem): mirror SwiftUI .both priority and content floor on Compose

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ActionListItemDisplay.kt
@@ -96,6 +96,29 @@ internal fun ActionListItemDisplay() {
             )
         }
 
+        // ListItem - Layout Priority (priority = Both)
+        LemonadeUi.Card(
+            header = CardHeaderConfig(
+                title = "priority: Both",
+                subtitle = "Neither side wins — the width splits 50/50 and both truncate together.",
+            ),
+        ) {
+            LemonadeUi.ListItem(
+                label = "Beneficiary account holder",
+                priority = LemonadeListItemPriority.Both,
+                labelMaxLines = 1,
+                labelOverflow = TextOverflow.Ellipsis,
+                trailingSlot = {
+                    LemonadeUi.Text(
+                        text = "International Holdings Ltd Partnership",
+                        textStyle = LemonadeTheme.typography.bodyMediumMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+            )
+        }
+
         // ActionListItem - Truncation
         LemonadeUi.Card(
             header = CardHeaderConfig(title = "ActionListItem - Truncation"),

--- a/kmp/core/api/android/core.api
+++ b/kmp/core/api/android/core.api
@@ -796,6 +796,7 @@ public final class com/teya/lemonade/core/LemonadeLineHeights : java/lang/Enum {
 }
 
 public final class com/teya/lemonade/core/LemonadeListItemPriority : java/lang/Enum {
+	public static final field Both Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static final field Label Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static final field Trailing Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/core/api/core.klib.api
+++ b/kmp/core/api/core.klib.api
@@ -872,6 +872,7 @@ final enum class com.teya.lemonade.core/LemonadeLineHeights : kotlin/Enum<com.te
 }
 
 final enum class com.teya.lemonade.core/LemonadeListItemPriority : kotlin/Enum<com.teya.lemonade.core/LemonadeListItemPriority> { // com.teya.lemonade.core/LemonadeListItemPriority|null[0]
+    enum entry Both // com.teya.lemonade.core/LemonadeListItemPriority.Both|null[0]
     enum entry Label // com.teya.lemonade.core/LemonadeListItemPriority.Label|null[0]
     enum entry Trailing // com.teya.lemonade.core/LemonadeListItemPriority.Trailing|null[0]
 

--- a/kmp/core/api/desktop/core.api
+++ b/kmp/core/api/desktop/core.api
@@ -796,6 +796,7 @@ public final class com/teya/lemonade/core/LemonadeLineHeights : java/lang/Enum {
 }
 
 public final class com/teya/lemonade/core/LemonadeListItemPriority : java/lang/Enum {
+	public static final field Both Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static final field Label Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static final field Trailing Lcom/teya/lemonade/core/LemonadeListItemPriority;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeListItemPriority.kt
+++ b/kmp/core/src/commonMain/kotlin/com/teya/lemonade/core/LemonadeListItemPriority.kt
@@ -7,9 +7,12 @@ package com.teya.lemonade.core
  * - [Label]: the content slot keeps its full width; the trailing slot truncates to fit
  *   (down to a readable minimum width).
  * - [Trailing]: the trailing slot keeps its full width; the content slot truncates to
- *   fit. This is the default.
+ *   fit (down to a readable minimum width). This is the default.
+ * - [Both]: neither slot is prioritized; the available width is split evenly so the
+ *   content and trailing slots each occupy half, truncating together.
  */
 public enum class LemonadeListItemPriority {
     Label,
     Trailing,
+    Both,
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -599,7 +599,8 @@ public fun LemonadeUi.ListItem(
  * @param supportTextOverflow - [TextOverflow] strategy applied to the [supportText] when it exceeds
  *  [supportTextMaxLines]. Defaults to [TextOverflow.Clip].
  * @param priority - [LemonadeListItemPriority] deciding which slot claims layout space first when
- *  the label and trailing slots compete for width. Defaults to [LemonadeListItemPriority.Trailing].
+ *  the label and trailing slots compete for width. Use [LemonadeListItemPriority.Both] to split the
+ *  width evenly. Defaults to [LemonadeListItemPriority.Trailing].
  */
 @Composable
 public fun LemonadeUi.ListItem(
@@ -787,7 +788,8 @@ public fun LemonadeUi.ListItem(
  * @param leadingVerticalAlignment - Vertical alignment of the leading slot against the
  *  content slot. Defaults to [Alignment.Top].
  * @param priority - [LemonadeListItemPriority] deciding which slot claims layout space first when
- *  the content and trailing slots compete for width. Defaults to [LemonadeListItemPriority.Trailing].
+ *  the content and trailing slots compete for width. Use [LemonadeListItemPriority.Both] to split the
+ *  width evenly. Defaults to [LemonadeListItemPriority.Trailing].
  */
 @Composable
 public fun LemonadeUi.ListItem(
@@ -887,25 +889,91 @@ private fun CoreListItem(
                 Modifier
             }
 
-            if (priority == LemonadeListItemPriority.Label) {
-                // Content keeps its width; the trailing slot yields and truncates. The content is
-                // capped so the trailing slot always retains a readable floor instead of vanishing —
-                // but only when there is trailing content to keep visible.
-                val hasTrailingContent = trailingSlot != null || navigationIndicator
-                BoxWithConstraints(modifier = Modifier.weight(weight = 1f)) {
-                    val trailingFloor = LocalSizes.current.size2000
-                    val gap = LocalSpaces.current.spacing300
-                    val contentMaxWidth = if (hasTrailingContent) {
-                        (maxWidth - trailingFloor - gap).coerceAtLeast(0.dp)
-                    } else {
-                        maxWidth
-                    }
+            val hasTrailingContent = trailingSlot != null || navigationIndicator
+            val slotFloor = LocalSizes.current.size2000
+            val gap = LocalSpaces.current.spacing300
 
-                    Row(verticalAlignment = trailingVerticalAlignment) {
+            when (priority) {
+                LemonadeListItemPriority.Label -> {
+                    // Content keeps its width; the trailing slot yields and truncates. The content is
+                    // capped so the trailing slot always retains a readable floor instead of vanishing —
+                    // but only when there is trailing content to keep visible.
+                    BoxWithConstraints(modifier = Modifier.weight(weight = 1f)) {
+                        val contentMaxWidth = if (hasTrailingContent) {
+                            (maxWidth - slotFloor - gap).coerceAtLeast(0.dp)
+                        } else {
+                            maxWidth
+                        }
+
+                        Row(verticalAlignment = trailingVerticalAlignment) {
+                            Column(
+                                content = contentSlot,
+                                modifier = Modifier
+                                    .widthIn(max = contentMaxWidth)
+                                    .then(other = contentAlpha),
+                            )
+
+                            if (hasTrailingContent) {
+                                Row(
+                                    horizontalArrangement = Arrangement.End,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .weight(weight = 1f)
+                                        .padding(start = gap),
+                                ) {
+                                    ListItemTrailingContent(
+                                        trailingSlot = trailingSlot,
+                                        navigationIndicator = navigationIndicator,
+                                        enabled = enabled,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                LemonadeListItemPriority.Trailing -> {
+                    // Default: the trailing slot keeps its width; the content column yields and
+                    // truncates. The trailing slot is capped so the content always retains a readable
+                    // floor instead of collapsing to a bare ellipsis.
+                    BoxWithConstraints(modifier = Modifier.weight(weight = 1f)) {
+                        val trailingMaxWidth = (maxWidth - slotFloor).coerceAtLeast(0.dp)
+
+                        Row(verticalAlignment = trailingVerticalAlignment) {
+                            Column(
+                                content = contentSlot,
+                                modifier = Modifier
+                                    .weight(weight = 1f)
+                                    .then(other = contentAlpha),
+                            )
+
+                            if (hasTrailingContent) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.widthIn(max = trailingMaxWidth),
+                                ) {
+                                    ListItemTrailingContent(
+                                        trailingSlot = trailingSlot,
+                                        navigationIndicator = navigationIndicator,
+                                        enabled = enabled,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                LemonadeListItemPriority.Both -> {
+                    // Neither slot is prioritized: split the available width evenly so the content
+                    // and trailing slots each occupy half and truncate together.
+                    Row(
+                        modifier = Modifier.weight(weight = 1f),
+                        verticalAlignment = trailingVerticalAlignment,
+                    ) {
                         Column(
                             content = contentSlot,
                             modifier = Modifier
-                                .widthIn(max = contentMaxWidth)
+                                .weight(weight = 1f)
                                 .then(other = contentAlpha),
                         )
 
@@ -923,31 +991,6 @@ private fun CoreListItem(
                                     enabled = enabled,
                                 )
                             }
-                        }
-                    }
-                }
-            } else {
-                // Default: the trailing slot keeps its width; the content column truncates to fit.
-                Row(
-                    modifier = Modifier.weight(weight = 1f),
-                    verticalAlignment = trailingVerticalAlignment,
-                ) {
-                    Column(
-                        content = contentSlot,
-                        modifier = Modifier
-                            .weight(weight = 1f)
-                            .then(other = contentAlpha),
-                    )
-
-                    if (trailingSlot != null || navigationIndicator) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            ListItemTrailingContent(
-                                trailingSlot = trailingSlot,
-                                navigationIndicator = navigationIndicator,
-                                enabled = enabled,
-                            )
                         }
                     }
                 }


### PR DESCRIPTION
## What

Brings the Compose/KMP `ListItem` to parity with the SwiftUI changes in #253:

- **`LemonadeListItemPriority.Both`** — a new enum case that splits the available width 50/50 between the content and trailing slots, so both truncate together (implemented as two equal `Modifier.weight(1f)` columns).
- **Content min-width floor under `Trailing`** — the default `Trailing` priority gave the content column `weight(1f)` with no floor, so a long trailing value could squeeze the label down to a bare ellipsis. The trailing slot is now capped to `maxWidth - size2000` so the content always keeps a readable minimum. This mirrors the floor the `Label` path already had for the trailing slot, making it symmetric.
- **Exhaustive `when (priority)`** — replaced the `if/else` priority branch with an exhaustive `when`, so adding a future case is a compile error rather than a silent fall-through into default behavior.

The cross-axis / first-line alignment was **already** correct on Compose (`trailingVerticalAlignment` wraps both content and trailing in one `Row`), so unlike SwiftUI there was no alignment change to make here.

## Why

Mirrors the iOS work so the design system behaves identically across platforms: the `Both` option for the "two competing values share the row" case, and the floor so the label never collapses to "…" under the default priority.

## Notes

- Sample app (`ActionListItemDisplay`) gains a `priority: Both` card alongside the existing `Trailing` / `Label` cards.
- Compiles clean: `:core`, `:ui`, and `:composeApp` (Android) all build.
- Minor cross-platform spacing note: the Compose `Trailing` path intentionally keeps its existing no-gap spacing between content and trailing (only the floor was added), whereas SwiftUI applies a leading gap on the trailing slot for all priorities. Not reconciled here to avoid shifting every existing default `ListItem`'s spacing; flagging for awareness.

## API Dump

**Verdict: ADDITIONS_ONLY.**

The only baseline change is a new `Both` enum entry in `LemonadeListItemPriority` (`core/api/android/core.api`, `core/api/desktop/core.api`, `core/api/core.klib.api`):

```
+	public static final field Both Lcom/teya/lemonade/core/LemonadeListItemPriority;
```

This is the additive enum-entry case from the binary-compatibility skill: `LemonadeListItemPriority` is a config enum the component owns the `when` over, the internal `when (priority)` is exhaustive and handles the new entry, and no existing symbol changed. No public function signatures changed, so the `ui` baseline is unchanged. ABI-safe, no maintainer sign-off required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)