### PR TITLE
feat(swiftui): add keyboardType support to text fields

### DIFF
--- a/swiftui/SampleApp/TextFieldDisplayView.swift
+++ b/swiftui/SampleApp/TextFieldDisplayView.swift
@@ -12,6 +12,10 @@ struct TextFieldDisplayView: View {
     @State private var selectedPrefix = "+1"
     @State private var passwordText = ""
     @State private var isPasswordVisible = false
+    @State private var emailText = ""
+    @State private var pinText = ""
+    @State private var amountValue = LemonadeTextFieldValue(text: "")
+    @State private var urlText = ""
 
     var body: some View {
         ScrollView {
@@ -117,6 +121,49 @@ struct TextFieldDisplayView: View {
                         .buttonStyle(.plain)
                     }
                     .secureTextEntry(!isPasswordVisible)
+                }
+
+                // Keyboard Type — email (via modifier, String binding)
+                sectionView(title: "Keyboard Type — Email") {
+                    LemonadeUi.TextField(
+                        input: $emailText,
+                        label: "Email Address",
+                        supportText: "Shows the email keyboard with @ and .",
+                        placeholderText: "you@example.com"
+                    )
+                    .lemonadeKeyboardType(.emailAddress)
+                }
+
+                // Keyboard Type — numeric PIN (via modifier, String binding)
+                sectionView(title: "Keyboard Type — Number Pad") {
+                    LemonadeUi.TextField(
+                        input: $pinText,
+                        label: "PIN",
+                        supportText: "Digits-only number pad",
+                        placeholderText: "0000"
+                    )
+                    .lemonadeKeyboardType(.numberPad)
+                }
+
+                // Keyboard Type — URL (via modifier, String binding)
+                sectionView(title: "Keyboard Type — URL") {
+                    LemonadeUi.TextField(
+                        input: $urlText,
+                        label: "Website",
+                        placeholderText: "https://example.com"
+                    )
+                    .lemonadeKeyboardType(.URL)
+                }
+
+                // Keyboard Type — decimal (via explicit parameter, value binding)
+                sectionView(title: "Keyboard Type — Decimal (parameter)") {
+                    LemonadeUi.TextField(
+                        value: $amountValue,
+                        label: "Amount",
+                        supportText: "Set via the keyboardType: parameter",
+                        placeholderText: "0.00",
+                        keyboardType: .decimalPad
+                    )
                 }
 
                 // With Selector

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -166,7 +166,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
-        keyboardType: UIKeyboardType = .default
+        keyboardType: UIKeyboardType? = nil
     ) -> some View {
         LemonadeTextFieldValueView<EmptyView, EmptyView>(
             value: value,
@@ -210,7 +210,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
-        keyboardType: UIKeyboardType = .default,
+        keyboardType: UIKeyboardType? = nil,
         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
         @ViewBuilder trailingContent: @escaping () -> TrailingContent
     ) -> some View {
@@ -403,7 +403,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
-        keyboardType: UIKeyboardType = .default
+        keyboardType: UIKeyboardType? = nil
     ) -> some View {
         LemonadeTextFieldWithSelectorValueView<LeadingContent, EmptyView>(
             value: value,
@@ -451,7 +451,7 @@ public extension LemonadeUi {
         errorMessage: String? = nil,
         error: Bool = false,
         enabled: Bool = true,
-        keyboardType: UIKeyboardType = .default,
+        keyboardType: UIKeyboardType? = nil,
         @ViewBuilder trailingContent: @escaping () -> TrailingContent
     ) -> some View {
         LemonadeTextFieldWithSelectorValueView(
@@ -492,6 +492,11 @@ private struct LemonadeTextInputField: View {
     @Binding var isFocused: Bool
     let onInputChanged: ((String) -> Void)?
 
+    // The String-binding overloads expose no `keyboardType:` parameter, so the
+    // `.lemonadeKeyboardType()` modifier (read from the environment here) is the
+    // only way to drive their keyboard.
+    @Environment(\.lemonadeKeyboardType) private var keyboardType
+
     // `input` (the public String binding) stays the source of truth; this local
     // value only carries the live cursor position that LemonadeUITextField needs.
     @State private var fieldValue: LemonadeTextFieldValue
@@ -518,6 +523,7 @@ private struct LemonadeTextInputField: View {
             isEnabled: enabled,
             textStyle: LemonadeTypography.shared.bodyMediumRegular,
             textColor: LemonadeTheme.colors.content.contentPrimary,
+            keyboardType: keyboardType,
             isSecure: isSecure,
             onValueChange: { newValue in
                 if newValue.text != input { input = newValue.text }
@@ -733,13 +739,19 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
     let errorMessage: String?
     let error: Bool
     let enabled: Bool
-    let keyboardType: UIKeyboardType
+    // An explicit per-call keyboard type; `nil` falls back to the environment value
+    // set by `.lemonadeKeyboardType()`.
+    let keyboardType: UIKeyboardType?
     let leadingContent: (() -> LeadingContent)?
     let trailingContent: (() -> TrailingContent)?
 
     @State private var isFocused = false
     @State private var isHovered = false
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
+    @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
+
+    // The explicit per-call type wins; otherwise fall back to the environment value.
+    private var resolvedKeyboardType: UIKeyboardType { keyboardType ?? environmentKeyboardType }
 
     var body: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing50) {
@@ -766,7 +778,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
                         isEnabled: enabled,
                         textStyle: LemonadeTypography.shared.bodyMediumRegular,
                         textColor: LemonadeTheme.colors.content.contentPrimary,
-                        keyboardType: keyboardType,
+                        keyboardType: resolvedKeyboardType,
                         isSecure: isSecure,
                         onValueChange: onValueChange
                     )
@@ -855,12 +867,18 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
     let errorMessage: String?
     let error: Bool
     let enabled: Bool
-    let keyboardType: UIKeyboardType
+    // An explicit per-call keyboard type; `nil` falls back to the environment value
+    // set by `.lemonadeKeyboardType()`.
+    let keyboardType: UIKeyboardType?
     let trailingContent: (() -> TrailingContent)?
 
     @State private var isFocused = false
     @State private var isHovered = false
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
+    @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
+
+    // The explicit per-call type wins; otherwise fall back to the environment value.
+    private var resolvedKeyboardType: UIKeyboardType { keyboardType ?? environmentKeyboardType }
 
     var body: some View {
         VStack(alignment: .leading, spacing: LemonadeTheme.spaces.spacing50) {
@@ -900,7 +918,7 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
                             isEnabled: enabled,
                             textStyle: LemonadeTypography.shared.bodyMediumRegular,
                             textColor: LemonadeTheme.colors.content.contentPrimary,
-                            keyboardType: keyboardType,
+                            keyboardType: resolvedKeyboardType,
                             isSecure: isSecure,
                             onValueChange: onValueChange
                         )

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeKeyboardType.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeKeyboardType.swift
@@ -27,8 +27,13 @@ public extension View {
     /// Backed by the platform: on iOS it maps to `UITextField.keyboardType`. The
     /// field reloads its input view if the keyboard type changes while the field
     /// is focused, so a dynamic switch takes effect without dropping focus. Has no
-    /// effect on views other than Lemonade text fields, and is a no-op on macOS
-    /// (which has no on-screen keyboard).
+    /// effect on views other than Lemonade text fields.
+    ///
+    /// Availability: this modifier (and `UIKeyboardType`) only exists where UIKit
+    /// does — iOS, iPadOS, and Mac Catalyst. It is not compiled for native macOS
+    /// (AppKit), where the Lemonade text fields fall back to a plain field with no
+    /// keyboard-type concept, so guard cross-platform call sites with
+    /// `#if canImport(UIKit)`.
     ///
     /// - Note: This is deliberately *not* named `keyboardType(_:)`. SwiftUI already
     ///   ships a `View.keyboardType(_:)` with the same signature; declaring another

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeKeyboardType.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeKeyboardType.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Environment
+
+private struct LemonadeKeyboardTypeKey: EnvironmentKey {
+    static let defaultValue: UIKeyboardType = .default
+}
+
+extension EnvironmentValues {
+    var lemonadeKeyboardType: UIKeyboardType {
+        get { self[LemonadeKeyboardTypeKey.self] }
+        set { self[LemonadeKeyboardTypeKey.self] = newValue }
+    }
+}
+
+// MARK: - View Modifier
+
+public extension View {
+    /// Sets the keyboard type for the Lemonade text fields in this hierarchy.
+    /// Applies to every variant — `LemonadeUi.TextField`, `TextFieldWithSelector`,
+    /// and their `LemonadeTextFieldValue`-based forms — including the plain
+    /// `String`-binding overloads, which take no `keyboardType` parameter.
+    ///
+    /// Backed by the platform: on iOS it maps to `UITextField.keyboardType`. The
+    /// field reloads its input view if the keyboard type changes while the field
+    /// is focused, so a dynamic switch takes effect without dropping focus. Has no
+    /// effect on views other than Lemonade text fields, and is a no-op on macOS
+    /// (which has no on-screen keyboard).
+    ///
+    /// - Note: This is deliberately *not* named `keyboardType(_:)`. SwiftUI already
+    ///   ships a `View.keyboardType(_:)` with the same signature; declaring another
+    ///   would make every call site ambiguous. Use this Lemonade-namespaced
+    ///   modifier to drive the Lemonade fields' UIKit-backed keyboard.
+    ///
+    /// Precedence: an explicit `keyboardType:` argument on a
+    /// `LemonadeTextFieldValue`-based overload wins over this modifier; this
+    /// modifier in turn wins over the `.default` fallback. For the `String`-binding
+    /// overloads (no parameter), this modifier is the only way to set the keyboard.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.TextField(
+    ///     input: $email,
+    ///     label: "Email",
+    ///     placeholderText: "you@example.com"
+    /// )
+    /// .lemonadeKeyboardType(.emailAddress)
+    /// ```
+    ///
+    /// - Parameter type: The `UIKeyboardType` the field should present.
+    /// - Returns: A view whose Lemonade text fields use the given keyboard type.
+    func lemonadeKeyboardType(_ type: UIKeyboardType) -> some View {
+        environment(\.lemonadeKeyboardType, type)
+    }
+}
+#endif


### PR DESCRIPTION
## What

Adds keyboard-type support to the SwiftUI Lemonade text fields.

- New `.lemonadeKeyboardType(_:)` view modifier, environment-backed, mirroring the existing `.secureTextEntry()` modifier pattern (`EnvironmentKey` + `@Environment` read). It applies to **every** variant — `LemonadeUi.TextField`, `TextFieldWithSelector`, and their `LemonadeTextFieldValue` forms — including the plain `String`-binding overloads, which expose no `keyboardType:` parameter and previously had no way to set the keyboard.
- The value-based overloads' `keyboardType:` parameter becomes optional (`UIKeyboardType? = nil`). Resolution precedence: an explicit `keyboardType:` argument wins → otherwise the `.lemonadeKeyboardType()` environment value → otherwise `.default`.
- Sample app gains sections demonstrating the email, number-pad, URL, and decimal keyboards (both the modifier and the explicit-parameter paths).

## Why

The `String`-binding text field overloads had no keyboard-type control at all. An environment-backed modifier brings them in line with how `secureTextEntry` is already configured, and keeps the API consistent across every field variant.

## Notes

- The shared `keyboardType ?? environmentKeyboardType` fallback is factored into a `resolvedKeyboardType` computed property on each value view.
- The modifier and `UIKeyboardType` are UIKit-only (iOS / iPadOS / Mac Catalyst); not compiled for native macOS/AppKit.

## API changes

**KMP binary-compatibility baseline:** No changes. This touches no KMP module (`core`, `tokens`, `ui`, `expressive`, `calendar`) or their `api/*.api` / `*.klib.api` files, so the API Stability Review job is not affected.

**SwiftUI public surface (not BCV-governed; source-distributed):**
- **Additive:** new `public func View.lemonadeKeyboardType(_:)` modifier.
- **Signature change:** `keyboardType:` on the four `LemonadeTextFieldValue`-based `TextField` / `TextFieldWithSelector` overloads goes from `UIKeyboardType = .default` to `UIKeyboardType? = nil`. Ordinary call sites are unaffected — passing a value still compiles (it promotes to the optional) and omitting it preserves the `.default` behavior (resolved via the environment fallback). The only theoretical break is code that captured a typed function reference to these initializers, which is not an expected usage. No runtime behavior change for existing callers.

## Testing

- Built and ran `LemonadeSampleApp` on a physical iPhone (iOS 26.6) — verified the email, number-pad, URL, and decimal keyboards appear for the respective fields.
- Verified the change compiles for the iOS Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)