### PR TITLE
feat(swiftui): add AutoFill + capitalization support to text fields

### DIFF
--- a/swiftui/SampleApp/TextFieldDisplayView.swift
+++ b/swiftui/SampleApp/TextFieldDisplayView.swift
@@ -111,17 +111,7 @@ struct TextFieldDisplayView: View {
                             tint: .content.contentSecondary
                         )
                     } trailingContent: {
-                        Button {
-                            isPasswordVisible.toggle()
-                        } label: {
-                            LemonadeUi.Icon(
-                                icon: isPasswordVisible ? .eyeOpen : .eyeClosed,
-                                contentDescription: isPasswordVisible ? "Hide password" : "Show password",
-                                size: .medium,
-                                tint: .content.contentSecondary
-                            )
-                        }
-                        .buttonStyle(.plain)
+                        passwordVisibilityToggle($isPasswordVisible)
                     }
                     .secureTextEntry(!isPasswordVisible)
                 }
@@ -217,17 +207,7 @@ struct TextFieldDisplayView: View {
                     ) {
                         EmptyView()
                     } trailingContent: {
-                        Button {
-                            isAutofillPasswordVisible.toggle()
-                        } label: {
-                            LemonadeUi.Icon(
-                                icon: isAutofillPasswordVisible ? .eyeOpen : .eyeClosed,
-                                contentDescription: isAutofillPasswordVisible ? "Hide password" : "Show password",
-                                size: .medium,
-                                tint: LemonadeTheme.colors.content.contentSecondary
-                            )
-                        }
-                        .buttonStyle(.plain)
+                        passwordVisibilityToggle($isAutofillPasswordVisible)
                     }
                     .lemonadeTextContentType(.password)
                     .secureTextEntry(!isAutofillPasswordVisible)
@@ -256,6 +236,20 @@ struct TextFieldDisplayView: View {
 
             content()
         }
+    }
+
+    private func passwordVisibilityToggle(_ isVisible: Binding<Bool>) -> some View {
+        Button {
+            isVisible.wrappedValue.toggle()
+        } label: {
+            LemonadeUi.Icon(
+                icon: isVisible.wrappedValue ? .eyeOpen : .eyeClosed,
+                contentDescription: isVisible.wrappedValue ? "Hide password" : "Show password",
+                size: .medium,
+                tint: .content.contentSecondary
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/swiftui/SampleApp/TextFieldDisplayView.swift
+++ b/swiftui/SampleApp/TextFieldDisplayView.swift
@@ -16,6 +16,9 @@ struct TextFieldDisplayView: View {
     @State private var pinText = ""
     @State private var amountValue = LemonadeTextFieldValue(text: "")
     @State private var urlText = ""
+    @State private var usernameText = ""
+    @State private var autofillPasswordText = ""
+    @State private var isAutofillPasswordVisible = false
 
     var body: some View {
         ScrollView {
@@ -189,6 +192,45 @@ struct TextFieldDisplayView: View {
                         label: "Phone Number",
                         placeholderText: "Enter phone number"
                     )
+                }
+
+                // AutoFill + capitalization — username (String binding, via modifiers)
+                sectionView(title: "AutoFill — Username") {
+                    LemonadeUi.TextField(
+                        input: $usernameText,
+                        label: "Username",
+                        supportText: "AutoFill, no capitalization, no autocorrect",
+                        placeholderText: "you@example.com"
+                    )
+                    .lemonadeTextContentType(.username)
+                    .lemonadeKeyboardType(.emailAddress)
+                    .lemonadeTextInputAutocapitalization(.none)
+                    .lemonadeAutocorrectionDisabled()
+                }
+
+                // AutoFill — password with show/hide toggle
+                sectionView(title: "AutoFill — Password") {
+                    LemonadeUi.TextField(
+                        input: $autofillPasswordText,
+                        label: "Password",
+                        placeholderText: "Enter password"
+                    ) {
+                        EmptyView()
+                    } trailingContent: {
+                        Button {
+                            isAutofillPasswordVisible.toggle()
+                        } label: {
+                            LemonadeUi.Icon(
+                                icon: isAutofillPasswordVisible ? .eyeOpen : .eyeClosed,
+                                contentDescription: isAutofillPasswordVisible ? "Hide password" : "Show password",
+                                size: .medium,
+                                tint: LemonadeTheme.colors.content.contentSecondary
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .lemonadeTextContentType(.password)
+                    .secureTextEntry(!isAutofillPasswordVisible)
                 }
 
                 // Disabled

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -494,8 +494,12 @@ private struct LemonadeTextInputField: View {
 
     // The String-binding overloads expose no `keyboardType:` parameter, so the
     // `.lemonadeKeyboardType()` modifier (read from the environment here) is the
-    // only way to drive their keyboard.
+    // only way to drive their keyboard. The same applies to the text-input traits
+    // below.
     @Environment(\.lemonadeKeyboardType) private var keyboardType
+    @Environment(\.lemonadeTextContentType) private var textContentType
+    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // `input` (the public String binding) stays the source of truth; this local
     // value only carries the live cursor position that LemonadeUITextField needs.
@@ -524,6 +528,9 @@ private struct LemonadeTextInputField: View {
             textStyle: LemonadeTypography.shared.bodyMediumRegular,
             textColor: LemonadeTheme.colors.content.contentPrimary,
             keyboardType: keyboardType,
+            textContentType: textContentType,
+            autocapitalizationType: autocapitalization,
+            autocorrectionType: autocorrectionType,
             isSecure: isSecure,
             onValueChange: { newValue in
                 if newValue.text != input { input = newValue.text }
@@ -749,6 +756,9 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
     @State private var isHovered = false
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
     @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
+    @Environment(\.lemonadeTextContentType) private var textContentType
+    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // The explicit per-call type wins; otherwise fall back to the environment value.
     private var resolvedKeyboardType: UIKeyboardType { keyboardType ?? environmentKeyboardType }
@@ -779,6 +789,9 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
                         textStyle: LemonadeTypography.shared.bodyMediumRegular,
                         textColor: LemonadeTheme.colors.content.contentPrimary,
                         keyboardType: resolvedKeyboardType,
+                        textContentType: textContentType,
+                        autocapitalizationType: autocapitalization,
+                        autocorrectionType: autocorrectionType,
                         isSecure: isSecure,
                         onValueChange: onValueChange
                     )
@@ -876,6 +889,9 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
     @State private var isHovered = false
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
     @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
+    @Environment(\.lemonadeTextContentType) private var textContentType
+    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // The explicit per-call type wins; otherwise fall back to the environment value.
     private var resolvedKeyboardType: UIKeyboardType { keyboardType ?? environmentKeyboardType }
@@ -919,6 +935,9 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
                             textStyle: LemonadeTypography.shared.bodyMediumRegular,
                             textColor: LemonadeTheme.colors.content.contentPrimary,
                             keyboardType: resolvedKeyboardType,
+                            textContentType: textContentType,
+                            autocapitalizationType: autocapitalization,
+                            autocorrectionType: autocorrectionType,
                             isSecure: isSecure,
                             onValueChange: onValueChange
                         )

--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -498,7 +498,7 @@ private struct LemonadeTextInputField: View {
     // below.
     @Environment(\.lemonadeKeyboardType) private var keyboardType
     @Environment(\.lemonadeTextContentType) private var textContentType
-    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocapitalizationType) private var autocapitalizationType
     @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // `input` (the public String binding) stays the source of truth; this local
@@ -529,7 +529,7 @@ private struct LemonadeTextInputField: View {
             textColor: LemonadeTheme.colors.content.contentPrimary,
             keyboardType: keyboardType,
             textContentType: textContentType,
-            autocapitalizationType: autocapitalization,
+            autocapitalizationType: autocapitalizationType,
             autocorrectionType: autocorrectionType,
             isSecure: isSecure,
             onValueChange: { newValue in
@@ -757,7 +757,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
     @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
     @Environment(\.lemonadeTextContentType) private var textContentType
-    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocapitalizationType) private var autocapitalizationType
     @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // The explicit per-call type wins; otherwise fall back to the environment value.
@@ -790,7 +790,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
                         textColor: LemonadeTheme.colors.content.contentPrimary,
                         keyboardType: resolvedKeyboardType,
                         textContentType: textContentType,
-                        autocapitalizationType: autocapitalization,
+                        autocapitalizationType: autocapitalizationType,
                         autocorrectionType: autocorrectionType,
                         isSecure: isSecure,
                         onValueChange: onValueChange
@@ -890,7 +890,7 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
     @Environment(\.lemonadeSecureTextEntry) private var isSecure
     @Environment(\.lemonadeKeyboardType) private var environmentKeyboardType
     @Environment(\.lemonadeTextContentType) private var textContentType
-    @Environment(\.lemonadeAutocapitalization) private var autocapitalization
+    @Environment(\.lemonadeAutocapitalizationType) private var autocapitalizationType
     @Environment(\.lemonadeAutocorrectionType) private var autocorrectionType
 
     // The explicit per-call type wins; otherwise fall back to the environment value.
@@ -936,7 +936,7 @@ private struct LemonadeTextFieldWithSelectorValueView<LeadingContent: View, Trai
                             textColor: LemonadeTheme.colors.content.contentPrimary,
                             keyboardType: resolvedKeyboardType,
                             textContentType: textContentType,
-                            autocapitalizationType: autocapitalization,
+                            autocapitalizationType: autocapitalizationType,
                             autocorrectionType: autocorrectionType,
                             isSecure: isSecure,
                             onValueChange: onValueChange

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -120,9 +120,19 @@ internal struct LemonadeUITextField: UIViewRepresentable {
             }
         }
 
-        textField.textContentType = textContentType
-        textField.autocapitalizationType = autocapitalizationType
-        textField.autocorrectionType = autocorrectionType
+        // Match the guarded keyboardType update above: only reassign when the
+        // value actually changed to avoid needless per-keystroke trait churn on
+        // the focused field. Unlike keyboardType, these traits take effect
+        // without reloadInputViews().
+        if textField.textContentType != textContentType {
+            textField.textContentType = textContentType
+        }
+        if textField.autocapitalizationType != autocapitalizationType {
+            textField.autocapitalizationType = autocapitalizationType
+        }
+        if textField.autocorrectionType != autocorrectionType {
+            textField.autocorrectionType = autocorrectionType
+        }
 
         // Handle focus state
         updateFocus(textField)

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -15,6 +15,11 @@ internal struct LemonadeUITextField: UIViewRepresentable {
     var textStyle: LemonadeTextStyle
     var textColor: Color
     var keyboardType: UIKeyboardType = .default
+    /// Drives iOS AutoFill (username/password/one-time-code/…) via
+    /// `UITextField.textContentType`. `nil` leaves it unset.
+    var textContentType: UITextContentType?
+    var autocapitalizationType: UITextAutocapitalizationType = .sentences
+    var autocorrectionType: UITextAutocorrectionType = .default
     /// Enables native secure text entry (character masking). Note: UIKit clears
     /// the field's text and selection when this flips, so `updateUIView` applies
     /// it before re-synchronizing text and cursor to keep them stable on toggle.
@@ -38,6 +43,9 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         textField.tintColor = UIColor(textColor)
         textField.isEnabled = isEnabled
         textField.keyboardType = keyboardType
+        textField.textContentType = textContentType
+        textField.autocapitalizationType = autocapitalizationType
+        textField.autocorrectionType = autocorrectionType
         textField.isSecureTextEntry = isSecure
         textField.text = value.text
 
@@ -111,6 +119,10 @@ internal struct LemonadeUITextField: UIViewRepresentable {
                 textField.reloadInputViews()
             }
         }
+
+        textField.textContentType = textContentType
+        textField.autocapitalizationType = autocapitalizationType
+        textField.autocorrectionType = autocorrectionType
 
         // Handle focus state
         updateFocus(textField)

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeAutocorrection.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeAutocorrection.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Environment
+
+private struct LemonadeAutocorrectionTypeKey: EnvironmentKey {
+    // Matches UITextField's own default so an un-modified field behaves identically.
+    static let defaultValue: UITextAutocorrectionType = .default
+}
+
+extension EnvironmentValues {
+    var lemonadeAutocorrectionType: UITextAutocorrectionType {
+        get { self[LemonadeAutocorrectionTypeKey.self] }
+        set { self[LemonadeAutocorrectionTypeKey.self] = newValue }
+    }
+}
+
+// MARK: - View Modifier
+
+public extension View {
+    /// Enables or disables autocorrection for the Lemonade text fields in this
+    /// hierarchy. Applies to every variant — `LemonadeUi.TextField`,
+    /// `TextFieldWithSelector`, and their `LemonadeTextFieldValue`-based forms —
+    /// including the plain `String`-binding overloads.
+    ///
+    /// Backed by the platform: on iOS it maps to
+    /// `UITextField.autocorrectionType` (`.no` when disabled, `.default`
+    /// otherwise). Disable it for input that must not be "corrected", such as
+    /// emails, usernames, or codes. Has no effect on views other than Lemonade
+    /// text fields.
+    ///
+    /// Availability: this modifier only exists where UIKit does — iOS, iPadOS,
+    /// and Mac Catalyst. It is not compiled for native macOS (AppKit), so guard
+    /// cross-platform call sites with `#if canImport(UIKit)`.
+    ///
+    /// - Note: This is deliberately *not* named `autocorrectionDisabled(_:)`.
+    ///   SwiftUI ships a `View.autocorrectionDisabled(_:)` that configures only
+    ///   its own native fields and has no effect on the UIKit-backed Lemonade
+    ///   field. Use this Lemonade-namespaced modifier instead.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.TextField(
+    ///     input: $email,
+    ///     label: "Email",
+    ///     placeholderText: "you@example.com"
+    /// )
+    /// .lemonadeAutocorrectionDisabled()
+    /// ```
+    ///
+    /// - Parameter disabled: Whether autocorrection should be turned off. Defaults
+    ///   to `true`, matching SwiftUI's `autocorrectionDisabled(_:)` ergonomics.
+    /// - Returns: A view whose Lemonade text fields use the given autocorrection
+    ///   setting.
+    func lemonadeAutocorrectionDisabled(_ disabled: Bool = true) -> some View {
+        environment(\.lemonadeAutocorrectionType, disabled ? .no : .default)
+    }
+}
+#endif

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTextContentType.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTextContentType.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Environment
+
+private struct LemonadeTextContentTypeKey: EnvironmentKey {
+    static let defaultValue: UITextContentType? = nil
+}
+
+extension EnvironmentValues {
+    var lemonadeTextContentType: UITextContentType? {
+        get { self[LemonadeTextContentTypeKey.self] }
+        set { self[LemonadeTextContentTypeKey.self] = newValue }
+    }
+}
+
+// MARK: - View Modifier
+
+public extension View {
+    /// Sets the text content type for the Lemonade text fields in this hierarchy,
+    /// driving iOS AutoFill (e.g. `.username`, `.password`, `.newPassword`,
+    /// `.oneTimeCode`, `.emailAddress`) and the QuickType bar's contextual
+    /// suggestions. Applies to every variant — `LemonadeUi.TextField`,
+    /// `TextFieldWithSelector`, and their `LemonadeTextFieldValue`-based forms —
+    /// including the plain `String`-binding overloads.
+    ///
+    /// Backed by the platform: on iOS it maps to `UITextField.textContentType`.
+    /// Has no effect on views other than Lemonade text fields.
+    ///
+    /// Availability: this modifier (and `UITextContentType`) only exists where
+    /// UIKit does — iOS, iPadOS, and Mac Catalyst. It is not compiled for native
+    /// macOS (AppKit), where the Lemonade text fields fall back to a plain field
+    /// with no content-type concept, so guard cross-platform call sites with
+    /// `#if canImport(UIKit)`.
+    ///
+    /// - Note: This is deliberately *not* named `textContentType(_:)`. SwiftUI
+    ///   already ships a `View.textContentType(_:)`, but it configures only
+    ///   SwiftUI's own native fields and has no effect on the UIKit-backed
+    ///   Lemonade field. Use this Lemonade-namespaced modifier to drive AutoFill
+    ///   on the Lemonade fields.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.TextField(
+    ///     input: $email,
+    ///     label: "Email",
+    ///     placeholderText: "you@example.com"
+    /// )
+    /// .lemonadeTextContentType(.username)
+    /// ```
+    ///
+    /// - Parameter type: The `UITextContentType` the field should advertise, or
+    ///   `nil` to clear it.
+    /// - Returns: A view whose Lemonade text fields use the given content type.
+    func lemonadeTextContentType(_ type: UITextContentType?) -> some View {
+        environment(\.lemonadeTextContentType, type)
+    }
+}
+#endif

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTextInputAutocapitalization.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTextInputAutocapitalization.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+
+// MARK: - Environment
+
+private struct LemonadeAutocapitalizationKey: EnvironmentKey {
+    // Matches UITextField's own default so an un-modified field behaves identically.
+    static let defaultValue: UITextAutocapitalizationType = .sentences
+}
+
+extension EnvironmentValues {
+    var lemonadeAutocapitalization: UITextAutocapitalizationType {
+        get { self[LemonadeAutocapitalizationKey.self] }
+        set { self[LemonadeAutocapitalizationKey.self] = newValue }
+    }
+}
+
+// MARK: - View Modifier
+
+public extension View {
+    /// Sets the autocapitalization behaviour for the Lemonade text fields in this
+    /// hierarchy. Applies to every variant — `LemonadeUi.TextField`,
+    /// `TextFieldWithSelector`, and their `LemonadeTextFieldValue`-based forms —
+    /// including the plain `String`-binding overloads.
+    ///
+    /// Backed by the platform: on iOS it maps to
+    /// `UITextField.autocapitalizationType`. Defaults to `.sentences` (UIKit's
+    /// default) when unset, so an un-modified field is unchanged. Pass `.none` for
+    /// case-sensitive input such as emails or usernames. Has no effect on views
+    /// other than Lemonade text fields.
+    ///
+    /// Availability: this modifier (and `UITextAutocapitalizationType`) only
+    /// exists where UIKit does — iOS, iPadOS, and Mac Catalyst. It is not compiled
+    /// for native macOS (AppKit), so guard cross-platform call sites with
+    /// `#if canImport(UIKit)`.
+    ///
+    /// - Note: This is deliberately *not* named `textInputAutocapitalization(_:)`.
+    ///   SwiftUI ships a `View.textInputAutocapitalization(_:)` that configures
+    ///   only its own native fields and has no effect on the UIKit-backed Lemonade
+    ///   field. Use this Lemonade-namespaced modifier instead.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// LemonadeUi.TextField(
+    ///     input: $email,
+    ///     label: "Email",
+    ///     placeholderText: "you@example.com"
+    /// )
+    /// .lemonadeTextInputAutocapitalization(.none)
+    /// ```
+    ///
+    /// - Parameter type: The `UITextAutocapitalizationType` the field should use.
+    /// - Returns: A view whose Lemonade text fields use the given
+    ///   autocapitalization.
+    func lemonadeTextInputAutocapitalization(_ type: UITextAutocapitalizationType) -> some View {
+        environment(\.lemonadeAutocapitalization, type)
+    }
+}
+#endif

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTextInputAutocapitalization.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTextInputAutocapitalization.swift
@@ -5,15 +5,15 @@ import UIKit
 
 // MARK: - Environment
 
-private struct LemonadeAutocapitalizationKey: EnvironmentKey {
+private struct LemonadeAutocapitalizationTypeKey: EnvironmentKey {
     // Matches UITextField's own default so an un-modified field behaves identically.
     static let defaultValue: UITextAutocapitalizationType = .sentences
 }
 
 extension EnvironmentValues {
-    var lemonadeAutocapitalization: UITextAutocapitalizationType {
-        get { self[LemonadeAutocapitalizationKey.self] }
-        set { self[LemonadeAutocapitalizationKey.self] = newValue }
+    var lemonadeAutocapitalizationType: UITextAutocapitalizationType {
+        get { self[LemonadeAutocapitalizationTypeKey.self] }
+        set { self[LemonadeAutocapitalizationTypeKey.self] = newValue }
     }
 }
 
@@ -55,7 +55,7 @@ public extension View {
     /// - Returns: A view whose Lemonade text fields use the given
     ///   autocapitalization.
     func lemonadeTextInputAutocapitalization(_ type: UITextAutocapitalizationType) -> some View {
-        environment(\.lemonadeAutocapitalization, type)
+        environment(\.lemonadeAutocapitalizationType, type)
     }
 }
 #endif


### PR DESCRIPTION
## What

Adds three environment-backed view modifiers to the SwiftUI text fields, mirroring the existing `.lemonadeKeyboardType()` (#255) and `.secureTextEntry()` pattern:

| Modifier | Backed by | Purpose |
|---|---|---|
| `.lemonadeTextContentType(_:)` | `UITextField.textContentType` | iOS **AutoFill** (`.username`, `.password`, `.newPassword`, `.oneTimeCode`, …) + QuickType suggestions |
| `.lemonadeTextInputAutocapitalization(_:)` | `UITextField.autocapitalizationType` | Capitalization (pass `.none` for emails/usernames) |
| `.lemonadeAutocorrectionDisabled(_:)` | `UITextField.autocorrectionType` | Turn autocorrect off for emails/usernames/codes |

They apply to **every** variant — `LemonadeUi.TextField`, `TextFieldWithSelector`, and their `LemonadeTextFieldValue`-based forms — including the plain `String`-binding overloads that expose no parameter for these traits.

## Why

The Lemonade fields are backed by a `UITextField` (`LemonadeUITextField`), so SwiftUI's own `.textContentType` / `.textInputAutocapitalization` / `.autocorrectionDisabled` **don't reach them** — they only configure SwiftUI-native fields. Before this PR the only way to get AutoFill or disable capitalization on a Lemonade field was to drop back to a custom `UITextField` wrapper. This is the blocker for migrating the Teya app's auth (login/sign-up) screens off their local `DSTextField` onto `LemonadeUi.TextField`: keyboard type and secure entry already had modifiers, but AutoFill and capitalization control did not.

## How

- New env keys + `public` modifiers under `#if canImport(UIKit)`, named `lemonade*` to avoid colliding with SwiftUI's same-named modifiers (same convention as `.lemonadeKeyboardType`).
- `LemonadeUITextField` gains `textContentType` / `autocapitalizationType` / `autocorrectionType` stored properties, applied in `makeUIView` + `updateUIView`.
- The three UIKit view structs (`LemonadeTextInputField`, `LemonadeTextFieldValueView`, `LemonadeTextFieldWithSelectorValueView`) read the env values and forward them.
- **Defaults match `UITextField`'s own** (content type unset, `.sentences`, autocorrect `.default`), so an un-modified field renders exactly as before — no behavior change for existing call sites.
- macOS (non-UIKit) is unchanged, consistent with how `.lemonadeKeyboardType` is UIKit-only.

## Usage

```swift
LemonadeUi.TextField(input: $email, label: "Email")
    .lemonadeTextContentType(.username)
    .lemonadeKeyboardType(.emailAddress)
    .lemonadeTextInputAutocapitalization(.none)
    .lemonadeAutocorrectionDisabled()
```

## Testing

- `xcodebuild -scheme Lemonade -destination 'generic/platform=iOS Simulator'` — **BUILD SUCCEEDED**
- `xcodebuild -scheme LemonadeSampleApp -destination 'generic/platform=iOS Simulator'` — **BUILD SUCCEEDED**
- Sample app gains **AutoFill — Username** and **AutoFill — Password** sections in `TextFieldDisplayView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)