### PR TITLE
feat(swiftui): add shape parameter to LemonadeUi.CountryFlag

### DIFF
--- a/swiftui/SampleApp/FlagsDisplayView.swift
+++ b/swiftui/SampleApp/FlagsDisplayView.swift
@@ -3,6 +3,7 @@ import Lemonade
 
 struct FlagsDisplayView: View {
     @State private var searchText = ""
+    @State private var shape: LemonadeCountryFlagShape = .circular
 
     private var filteredFlags: [LemonadeCountryFlag] {
         if searchText.isEmpty {
@@ -19,33 +20,88 @@ struct FlagsDisplayView: View {
         GridItem(.adaptive(minimum: 80), spacing: 12)
     ]
 
-    var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(filteredFlags, id: \.rawValue) { flag in
-                    VStack(spacing: 6) {
-                        LemonadeUi.CountryFlag(
-                            flag: flag,
-                            size: .xxLarge
-                        )
+    private let sizes: [(size: LemonadeCountryFlagSize, label: String)] = [
+        (.small, "S"),
+        (.medium, "M"),
+        (.large, "L"),
+        (.xLarge, "XL"),
+        (.xxLarge, "2XL"),
+        (.xxxLarge, "3XL"),
+        (.xxxxLarge, "4XL")
+    ]
 
-                        Text(flag.countryCode)
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(.primary)
+    private var allSizesRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("All sizes")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.content.contentSecondary)
 
-                        Text(flag.countryName)
-                            .font(.system(size: 8))
-                            .foregroundStyle(.content.contentSecondary)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.center)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .bottom, spacing: 12) {
+                    ForEach(sizes, id: \.size) { item in
+                        VStack(spacing: 4) {
+                            LemonadeUi.CountryFlag(
+                                flag: .gBUnitedKingdom,
+                                size: item.size,
+                                shape: shape
+                            )
+
+                            Text(item.label)
+                                .font(.system(size: 9))
+                                .foregroundStyle(.content.contentSecondary)
+                        }
                     }
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 90)
-                    .background(.bg.bgSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
             }
-            .padding()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.bg.bgSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Shape", selection: $shape) {
+                Text("Circular").tag(LemonadeCountryFlagShape.circular)
+                Text("Rounded").tag(LemonadeCountryFlagShape.rounded)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.top)
+
+            ScrollView {
+                allSizesRow
+                    .padding(.horizontal)
+                    .padding(.top)
+
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(filteredFlags, id: \.rawValue) { flag in
+                        VStack(spacing: 6) {
+                            LemonadeUi.CountryFlag(
+                                flag: flag,
+                                size: .xxLarge,
+                                shape: shape
+                            )
+
+                            Text(flag.countryCode)
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(.primary)
+
+                            Text(flag.countryName)
+                                .font(.system(size: 8))
+                                .foregroundStyle(.content.contentSecondary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 90)
+                        .background(.bg.bgSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+                .padding()
+            }
         }
         .searchable(text: $searchText, prompt: "Search by code or country name")
         .navigationTitle("Country Flags (\(filteredFlags.count))")

--- a/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
@@ -24,19 +24,6 @@ public enum LemonadeCountryFlagSize {
         case .xxxxLarge: return LemonadeTheme.sizes.size1400 // 56
         }
     }
-
-    /// Corner radius applied when the flag uses `LemonadeCountryFlagShape.rounded`.
-    var roundedRadius: CGFloat {
-        switch self {
-        case .small: return LemonadeTheme.radius.radius100      // 4
-        case .medium: return LemonadeTheme.radius.radius150     // 6
-        case .large: return LemonadeTheme.radius.radius200      // 8
-        case .xLarge: return LemonadeTheme.radius.radius250     // 10
-        case .xxLarge: return LemonadeTheme.radius.radius300    // 12
-        case .xxxLarge: return LemonadeTheme.radius.radius400   // 16
-        case .xxxxLarge: return LemonadeTheme.radius.radius500  // 20
-        }
-    }
 }
 
 // MARK: - Country Flag Shape
@@ -94,7 +81,7 @@ private struct LemonadeCountryFlagView: View {
         case .circular:
             styled(sized, with: Circle())
         case .rounded:
-            styled(sized, with: RoundedRectangle(cornerRadius: size.roundedRadius))
+            styled(sized, with: RoundedRectangle(cornerRadius: roundedRadius(for: size)))
         }
     }
 
@@ -106,12 +93,24 @@ private struct LemonadeCountryFlagView: View {
     private func styled<S: Shape>(_ view: some View, with shape: S) -> some View {
         view
             .clipShape(shape)
-            .overlay(
-                shape.stroke(
-                    LemonadeTheme.colors.border.borderNeutralMedium,
-                    lineWidth: LemonadeTheme.borderWidth.base.border25
-                )
+            .shadowBorder(
+                width: LemonadeTheme.borderWidth.base.border25,
+                color: LemonadeTheme.colors.border.borderNeutralMedium,
+                shape: shape
             )
+    }
+
+    /// Corner radius applied when the flag uses `LemonadeCountryFlagShape.rounded`.
+    private func roundedRadius(for size: LemonadeCountryFlagSize) -> CGFloat {
+        switch size {
+        case .small: return LemonadeTheme.radius.radius100      // 4
+        case .medium: return LemonadeTheme.radius.radius150     // 6
+        case .large: return LemonadeTheme.radius.radius200      // 8
+        case .xLarge: return LemonadeTheme.radius.radius250     // 10
+        case .xxLarge: return LemonadeTheme.radius.radius300    // 12
+        case .xxxLarge: return LemonadeTheme.radius.radius400   // 16
+        case .xxxxLarge: return LemonadeTheme.radius.radius500  // 20
+        }
     }
 
     private var flagImage: Image {

--- a/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCountryFlag.swift
@@ -24,32 +24,55 @@ public enum LemonadeCountryFlagSize {
         case .xxxxLarge: return LemonadeTheme.sizes.size1400 // 56
         }
     }
+
+    /// Corner radius applied when the flag uses `LemonadeCountryFlagShape.rounded`.
+    var roundedRadius: CGFloat {
+        switch self {
+        case .small: return LemonadeTheme.radius.radius100      // 4
+        case .medium: return LemonadeTheme.radius.radius150     // 6
+        case .large: return LemonadeTheme.radius.radius200      // 8
+        case .xLarge: return LemonadeTheme.radius.radius250     // 10
+        case .xxLarge: return LemonadeTheme.radius.radius300    // 12
+        case .xxxLarge: return LemonadeTheme.radius.radius400   // 16
+        case .xxxxLarge: return LemonadeTheme.radius.radius500  // 20
+        }
+    }
+}
+
+// MARK: - Country Flag Shape
+
+/// Shape variants for the Country Flag component.
+public enum LemonadeCountryFlagShape {
+    case circular
+    case rounded
 }
 
 // MARK: - Country Flag Component
 
 public extension LemonadeUi {
     /// Country Flags component, to display the available country flags in a standardized way.
-    /// The flag is displayed in a circular shape with a border.
     ///
     /// ## Usage
     /// ```swift
     /// LemonadeUi.CountryFlag(
     ///     flag: .pTPortugal,
-    ///     size: .medium
+    ///     size: .medium,
+    ///     shape: .rounded
     /// )
     /// ```
     ///
     /// - Parameters:
     ///   - flag: The `LemonadeCountryFlag` to be displayed
     ///   - size: The `LemonadeCountryFlagSize` to be applied. Defaults to `.medium`
-    /// - Returns: A styled circular flag view
+    ///   - shape: The `LemonadeCountryFlagShape` to be applied. Defaults to `.circular`
+    /// - Returns: A styled flag view
     @ViewBuilder
     static func CountryFlag(
         flag: LemonadeCountryFlag,
-        size: LemonadeCountryFlagSize = .medium
+        size: LemonadeCountryFlagSize = .medium,
+        shape: LemonadeCountryFlagShape = .circular
     ) -> some View {
-        LemonadeCountryFlagView(flag: flag, size: size)
+        LemonadeCountryFlagView(flag: flag, size: size, shape: shape)
     }
 }
 
@@ -58,19 +81,36 @@ public extension LemonadeUi {
 private struct LemonadeCountryFlagView: View {
     let flag: LemonadeCountryFlag
     let size: LemonadeCountryFlagSize
+    let shape: LemonadeCountryFlagShape
 
-    var body: some View {
-        flagImage
+    @ViewBuilder
+    private var flagView: some View {
+        let sized = flagImage
             .resizable()
             .aspectRatio(contentMode: .fill)
             .frame(width: size.value, height: size.value)
-            .clipShape(Circle())
+
+        switch shape {
+        case .circular:
+            styled(sized, with: Circle())
+        case .rounded:
+            styled(sized, with: RoundedRectangle(cornerRadius: size.roundedRadius))
+        }
+    }
+
+    var body: some View {
+        flagView
+    }
+
+    @ViewBuilder
+    private func styled<S: Shape>(_ view: some View, with shape: S) -> some View {
+        view
+            .clipShape(shape)
             .overlay(
-                Circle()
-                    .stroke(
-                        LemonadeTheme.colors.border.borderNeutralMedium,
-                        lineWidth: LemonadeTheme.borderWidth.base.border25
-                    )
+                shape.stroke(
+                    LemonadeTheme.colors.border.borderNeutralMedium,
+                    lineWidth: LemonadeTheme.borderWidth.base.border25
+                )
             )
     }
 
@@ -93,6 +133,14 @@ private struct LemonadeCountryFlagView: View {
             LemonadeUi.CountryFlag(flag: .pTPortugal, size: .xxLarge)
             LemonadeUi.CountryFlag(flag: .pTPortugal, size: .xxxLarge)
         }
+    }
+    .padding()
+}
+
+#Preview("Shapes") {
+    HStack(spacing: 16) {
+        LemonadeUi.CountryFlag(flag: .pTPortugal, size: .xxLarge, shape: .circular)
+        LemonadeUi.CountryFlag(flag: .pTPortugal, size: .xxLarge, shape: .rounded)
     }
     .padding()
 }


### PR DESCRIPTION
## What

Adds a `shape` parameter to the SwiftUI `LemonadeUi.CountryFlag`, mirroring the existing KMP `CountryFlag` API.

- New `LemonadeCountryFlagShape` enum: `.circular` / `.rounded`.
- Parameter defaults to `.circular`, so every existing call site is unchanged (source-compatible — `from:` consumers won't break).
- `.rounded` applies a per-size corner radius matching the KMP `resolveShape` mapping (small→radius100 … xxLarge→radius300 … xxxxLarge→radius500).
- Implementation follows the existing `LemonadeSymbolContainer` shape pattern (`@ViewBuilder` switch + generic `styled(_:with:)` helper). The border reuses the existing `shadowBorder` modifier, and the per-size radius mapping lives in a private helper on the view (not on the public size enum) — keeping the size enum's public surface minimal.

## Why

The Teya app's selection lists (e.g. the Select language bottom sheet) want rounded flag tiles in list leading slots rather than circular avatars. KMP `CountryFlag` already supports this via `CountryFlagShape`; this brings the SwiftUI component to parity so iOS can match.

## Screeshots
<img width="360" src="https://github.com/user-attachments/assets/936dc766-7fdb-488d-ad70-90d119c6ace6" />

## Test plan

- `swift build` passes.
- Added a "Shapes" preview showing circular vs rounded side by side.
- Sample app: the Flags screen has a Circular/Rounded segmented picker plus an "All sizes" showcase row (UK flag at every size), so the shape variants and per-size radius scaling are visible. Built and verified on a physical iPhone.

## API Dump

No public API changes to the KMP modules — this PR only touches the SwiftUI Swift package (`swiftui/`), which is not covered by the Binary Compatibility Validator (`kmp/*/api/*.api`). The KMP API Stability Review should report `NO_CHANGES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)