### PR TITLE
fix(compose): match shadow weight to iOS using shadowDefault token

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeShadowsExtension.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeShadowsExtension.kt
@@ -39,15 +39,13 @@ public fun Modifier.animateLemonadeShadow(
     shape: Shape,
 ): Modifier {
     var modifier = this
+    val shadowColor = LocalColors.current.shadow.shadowDefault
     val animatedColor by animateColorAsState(
-        targetValue = Color(21, 34, 21)
-            .copy(
-                alpha = if (shadow == LemonadeShadow.None) {
-                    LocalOpacities.current.base.opacity0
-                } else {
-                    LocalOpacities.current.base.opacity20
-                },
-            ),
+        targetValue = if (shadow == LemonadeShadow.None) {
+            shadowColor.copy(alpha = LocalOpacities.current.base.opacity0)
+        } else {
+            shadowColor
+        },
     )
     val animatedShadows = remember {
         mutableListOf<State<LemonadeShadowData>>()
@@ -72,13 +70,13 @@ public fun Modifier.animateLemonadeShadow(
 private fun Modifier.dropShadow(
     lemonadeShadow: LemonadeShadowData,
     shape: Shape,
-    shadowColor: Color = Color(21, 34, 21).copy(alpha = 0.18f),
+    shadowColor: Color? = null,
 ): Modifier =
     composed {
         dropShadow(
             shape = shape,
             shadow = Shadow(
-                color = shadowColor,
+                color = shadowColor ?: LocalColors.current.shadow.shadowDefault,
                 radius = lemonadeShadow.blur.dp,
                 spread = lemonadeShadow.spread.dp,
                 offset = DpOffset(


### PR DESCRIPTION
## Summary

iOS and Android rendered the same shadow tokens differently — Android shadows were noticeably **heavier and tinted**. The Compose code hardcoded `Color(21, 34, 21)` (a dark green) at **18%/20% opacity** instead of using the design token, while iOS uses the `shadow-default` token = `rgba(0, 0, 0, 0.05)` (black @ 5%).

iOS is the source of truth here. This routes both Compose shadow paths through the existing semantic token `LocalColors.current.shadow.shadowDefault`, which resolves to `black50` = `rgba(0, 0, 0, 0.05)` in light theme — matching iOS exactly. As a bonus, dark theme now gets the correct `black500` token instead of the hardcoded color too.

The shadow geometry (blur/spread/offset) was already identical across platforms and is unchanged. The iOS-specific `blur / 2` is a SwiftUI Gaussian-blur correction and is intentionally not mirrored — Compose's `Shadow.radius` already maps to the token blur directly.

## Changes

- `animateLemonadeShadow`: animate between `shadow.shadowDefault` and transparent (for `None`) instead of the hardcoded green.
- `dropShadow`: default the color to `shadow.shadowDefault` instead of `Color(21, 34, 21).copy(alpha = 0.18f)`.

## Evidences
| Before | After |
| ------ | ----- |
| <img width="300" src="https://github.com/user-attachments/assets/d6e65b2b-7540-4dc5-ba4e-50adc6cb0c55" /> | <img width="300" src="https://github.com/user-attachments/assets/b0dbda90-8755-4cbd-8bb9-1264f8c2ae10" /> |

## Testing

Built and launched the sample app on a Pixel 10a — shadows (Xsmall → Xlarge) now read as soft black @ 5%, matching the iOS baseline.

## API Dump

No public API changes. All edits are in `private` function bodies/signatures; `bcv-check.sh --ci` reports `NO_CHANGES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)