### PR TITLE
fix(pincode): keep caret pinned to end of PIN entry

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
@@ -437,9 +437,7 @@ private fun PinCodeHiddenField(
 
 // A [TextFieldValue] holding [text] with the cursor collapsed to its end — the state the hidden
 // field is always driven to, so rejected overflow never leaves the caret parked past the digits.
-private fun pinnedToEnd(text: String): TextFieldValue {
-    return TextFieldValue(text = text, selection = TextRange(index = text.length))
-}
+private fun pinnedToEnd(text: String): TextFieldValue = TextFieldValue(text = text, selection = TextRange(index = text.length))
 
 private const val FIELD_TEST_ID = "pin_code_field"
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDataType
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadePinCodeVariant
@@ -394,9 +396,27 @@ private fun PinCodeHiddenField(
         if (autoFocus && enabled) focusRequester.requestFocus()
     }
 
+    // Drive the field through a [TextFieldValue] rather than a raw String so the cursor stays
+    // pinned to the end of the clamped text. The String overload lets Compose's IME buffer keep
+    // the characters typed past [length]: focus then drifts off the last box and backspace has to
+    // chew through those invisible characters before it reaches a visible digit.
+    val clamped = value.take(n = length)
+    var fieldValue by remember { mutableStateOf(value = pinnedToEnd(text = clamped)) }
+    // Resync when the entry changes underneath us (external writes, or input we rejected as
+    // overflow so the buffer text is unchanged), always collapsing the cursor to the end.
+    if (fieldValue.text != clamped) {
+        fieldValue = pinnedToEnd(text = clamped)
+    }
+
     BasicTextField(
-        value = value.take(n = length),
-        onValueChange = { input -> onValueChange(input.take(n = length)) },
+        value = fieldValue,
+        onValueChange = { input ->
+            val next = input.text.take(n = length)
+            // Push the buffer back to the end even when [next] matches the current text (overflow
+            // typing), so the IME drops the extra characters instead of parking the cursor past them.
+            fieldValue = pinnedToEnd(text = next)
+            if (next != clamped) onValueChange(next)
+        },
         enabled = enabled,
         singleLine = true,
         cursorBrush = SolidColor(value = Color.Transparent),
@@ -411,6 +431,12 @@ private fun PinCodeHiddenField(
                 if (!oneTimeCodeAutofill) contentDataType = ContentDataType.None
             }.onFocusChanged { onFocusChanged(it.isFocused) },
     )
+}
+
+// A [TextFieldValue] holding [text] with the cursor collapsed to its end — the state the hidden
+// field is always driven to, so rejected overflow never leaves the caret parked past the digits.
+private fun pinnedToEnd(text: String): TextFieldValue {
+    return TextFieldValue(text = text, selection = TextRange(index = text.length))
 }
 
 private const val FIELD_TEST_ID = "pin_code_field"

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
@@ -402,10 +402,12 @@ private fun PinCodeHiddenField(
     // chew through those invisible characters before it reaches a visible digit.
     val clamped = value.take(n = length)
     var fieldValue by remember { mutableStateOf(value = pinnedToEnd(text = clamped)) }
-    // Resync when the entry changes underneath us (external writes, or input we rejected as
-    // overflow so the buffer text is unchanged), always collapsing the cursor to the end.
-    if (fieldValue.text != clamped) {
-        fieldValue = pinnedToEnd(text = clamped)
+    // Resync from an effect — not during composition — when the entry changes underneath us: an
+    // external write, or the parent clamping an oversized value. Overflow typing is already pinned
+    // in onValueChange below, so this only needs to track [clamped]. Mirrors the
+    // `LaunchedEffect(displayText)` idiom documented on LemonadeUi.TextFieldWithSelector.
+    LaunchedEffect(clamped) {
+        if (fieldValue.text != clamped) fieldValue = pinnedToEnd(text = clamped)
     }
 
     BasicTextField(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/PinCode.kt
@@ -437,7 +437,7 @@ private fun PinCodeHiddenField(
 
 // A [TextFieldValue] holding [text] with the cursor collapsed to its end — the state the hidden
 // field is always driven to, so rejected overflow never leaves the caret parked past the digits.
-private fun pinnedToEnd(text: String): TextFieldValue = TextFieldValue(text = text, selection = TextRange(index = text.length))
+private fun pinnedToEnd(text: String): TextFieldValue = TextFieldValue(text = text, selection = TextRange(text.length))
 
 private const val FIELD_TEST_ID = "pin_code_field"
 

--- a/swiftui/Sources/Lemonade/Components/LemonadePinCode.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadePinCode.swift
@@ -237,10 +237,19 @@ private struct PinCodeHiddenField: View {
     let oneTimeCodeAutofill: Bool
     @FocusState.Binding var focused: Bool
 
+    // Local mirror of the entry that the field edits directly. Binding a plain String whose setter
+    // clamps to `length` leaves the characters typed past the limit sitting in UIKit's (invisible,
+    // `.clear`) field buffer with the cursor parked beyond them — because clamping to the unchanged
+    // `value` never pushes an update back to the field. Focus then drifts off the last box and
+    // backspace has to chew through those ghosts before it reaches a visible digit. Reassigning this
+    // @State to the clamped text forces SwiftUI to push it back into the field, dropping the overflow
+    // and collapsing the cursor to the end — mirroring the KMP `TextFieldValue` fix.
+    @State private var text: String = ""
+
     var body: some View {
         // Full-bleed transparent field: a tap anywhere on the boxes lands here and focuses it
         // natively, so the keyboard opens on the first tap with no sync round-trip.
-        TextField("", text: clampedBinding)
+        TextField("", text: $text)
             .focused($focused)
             .autocorrectionDisabled(true)
             .foregroundColor(.clear)
@@ -251,13 +260,20 @@ private struct PinCodeHiddenField: View {
             .accessibilityIdentifier("pin_code_field")
             .modifier(OptionalAccessibilityLabel(label: accessibilityLabel))
             .modifier(SystemKeyboardTraits(variant: variant, oneTimeCodeAutofill: oneTimeCodeAutofill))
-    }
-
-    private var clampedBinding: Binding<String> {
-        Binding(
-            get: { value },
-            set: { value = String($0.prefix(length)) }
-        )
+            .onAppear { text = String(value.prefix(length)) }
+            .onChange(of: text) { newText in
+                let clamped = String(newText.prefix(length))
+                // Force the field back to the clamped text (drops overflow, collapses the cursor to
+                // the end) whenever raw input exceeded `length` — including typing while it is full.
+                if clamped != newText { text = clamped }
+                if clamped != value { value = clamped }
+            }
+            // Keep the field in sync when the entry changes from outside (external writes, or the
+            // parent clamping an oversized value).
+            .onChange(of: value) { newValue in
+                let clamped = String(newValue.prefix(length))
+                if text != clamped { text = clamped }
+            }
     }
 }
 


### PR DESCRIPTION
# Summary

Fixes a typing bug in `LemonadeUi.PinCode` (Compose + SwiftUI): once every box was filled, continuing to type left ghost characters in the hidden field's input buffer with the caret parked past the visible digits. Focus drifted off the last box, and deleting the last visible digit needed several backspaces before it took effect.

The hidden field is now driven through a value that carries its cursor, and the caret is pinned to the end of the clamped text on both platforms, so overflow keystrokes are dropped and backspace always deletes the last visible digit on the first press.

## Figma component

N/A — behavioural fix, no visual change.

## Screenshot

N/A — no visual change; behaviour only (caret/backspace handling).

## What was done

- **Compose** (`kmp/ui/.../PinCode.kt`): switched the hidden `BasicTextField` from the `String` overload to the `TextFieldValue` overload, reassigning it via a private `pinnedToEnd(...)` helper so the selection is always collapsed to the end of the clamped text.
- **SwiftUI** (`swiftui/.../LemonadePinCode.swift`): the hidden `TextField` now edits a local `@State` mirror reconciled in `onChange`/`onAppear`; reassigning the clamped text forces the field buffer back into sync (drops overflow, caret to end) — the direct analog of the Compose fix.

## API Dump

**Verdict:** NO_CHANGES

The fix and the new `pinnedToEnd` helper are entirely `private`; no `api/*.api` or `*.klib.api` baseline file changed. `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` reports `NO_CHANGES`.

**Genuine breaking changes (if any):** None.

## How to test

1. Open the sample app → **PinCode** screen (Android composeApp / iOS SampleApp).
2. Type until all boxes are filled, then keep typing more characters — focus should stay on the field and no extra characters should be accepted.
3. Press backspace once — the last visible digit should be deleted immediately (previously required several presses).
4. Verify normal typing, autofocus, error shake, and submitting states still behave as before.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added all necessary code documentation and specifications
- [ ] I have performed manual tests to ensure the system is working as expected
- [ ] I have considered if my changes affect E2E tests (the `pin_code_field` test tag/identifier is unchanged)