### PR TITLE
feat(swiftui): add onSubmit (return key) to TextField

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTextField.swift
@@ -21,6 +21,8 @@ public extension LemonadeUi {
     /// - Parameters:
     ///   - input: The inputted text (Binding)
     ///   - onInputChanged: Callback when the user inputs content
+    ///   - onSubmit: Callback when the keyboard's return key is pressed. The field
+    ///     keeps focus (the keyboard stays up) so the caller decides what happens next.
     ///   - label: Label displayed above the text field
     ///   - optionalIndicator: Optional text displayed on the right of the label
     ///   - supportText: Support text displayed below the text field
@@ -33,6 +35,7 @@ public extension LemonadeUi {
     static func TextField(
         input: Binding<String>,
         onInputChanged: ((String) -> Void)? = nil,
+        onSubmit: (() -> Void)? = nil,
         label: String? = nil,
         optionalIndicator: String? = nil,
         supportText: String? = nil,
@@ -44,6 +47,7 @@ public extension LemonadeUi {
         LemonadeTextFieldView<EmptyView, EmptyView>(
             input: input,
             onInputChanged: onInputChanged,
+            onSubmit: onSubmit,
             label: label,
             optionalIndicator: optionalIndicator,
             supportText: supportText,
@@ -75,6 +79,8 @@ public extension LemonadeUi {
     /// - Parameters:
     ///   - input: The inputted text (Binding)
     ///   - onInputChanged: Callback when the user inputs content
+    ///   - onSubmit: Callback when the keyboard's return key is pressed. The field
+    ///     keeps focus (the keyboard stays up) so the caller decides what happens next.
     ///   - label: Label displayed above the text field
     ///   - optionalIndicator: Optional text displayed on the right of the label
     ///   - supportText: Support text displayed below the text field
@@ -89,6 +95,7 @@ public extension LemonadeUi {
     static func TextField<LeadingContent: View, TrailingContent: View>(
         input: Binding<String>,
         onInputChanged: ((String) -> Void)? = nil,
+        onSubmit: (() -> Void)? = nil,
         label: String? = nil,
         optionalIndicator: String? = nil,
         supportText: String? = nil,
@@ -102,6 +109,7 @@ public extension LemonadeUi {
         LemonadeTextFieldView(
             input: input,
             onInputChanged: onInputChanged,
+            onSubmit: onSubmit,
             label: label,
             optionalIndicator: optionalIndicator,
             supportText: supportText,
@@ -491,6 +499,7 @@ private struct LemonadeTextInputField: View {
     let enabled: Bool
     @Binding var isFocused: Bool
     let onInputChanged: ((String) -> Void)?
+    let onSubmit: (() -> Void)?
 
     // The String-binding overloads expose no `keyboardType:` parameter, so the
     // `.lemonadeKeyboardType()` modifier (read from the environment here) is the
@@ -510,13 +519,15 @@ private struct LemonadeTextInputField: View {
         isSecure: Bool,
         enabled: Bool,
         isFocused: Binding<Bool>,
-        onInputChanged: ((String) -> Void)?
+        onInputChanged: ((String) -> Void)?,
+        onSubmit: (() -> Void)?
     ) {
         _input = input
         self.isSecure = isSecure
         self.enabled = enabled
         _isFocused = isFocused
         self.onInputChanged = onInputChanged
+        self.onSubmit = onSubmit
         _fieldValue = State(initialValue: LemonadeTextFieldValue(text: input.wrappedValue))
     }
 
@@ -535,7 +546,8 @@ private struct LemonadeTextInputField: View {
             onValueChange: { newValue in
                 if newValue.text != input { input = newValue.text }
                 onInputChanged?(newValue.text)
-            }
+            },
+            onReturnKey: onSubmit
         )
         .onChange(of: input) { newText in
             // External text change (e.g. a programmatic reset): re-sync, cursor to end.
@@ -552,6 +564,7 @@ private struct LemonadeTextInputField: View {
     let enabled: Bool
     @Binding var isFocused: Bool
     let onInputChanged: ((String) -> Void)?
+    let onSubmit: (() -> Void)?
 
     @FocusState private var fieldFocused: Bool
 
@@ -568,6 +581,7 @@ private struct LemonadeTextInputField: View {
         .tint(LemonadeTheme.colors.content.contentPrimary)
         .focused($fieldFocused)
         .disabled(!enabled)
+        .onSubmit { onSubmit?() }
         .onChange(of: input) { newValue in
             onInputChanged?(newValue)
         }
@@ -582,6 +596,7 @@ private struct LemonadeTextInputField: View {
 private struct LemonadeTextFieldView<LeadingContent: View, TrailingContent: View>: View {
     @Binding var input: String
     let onInputChanged: ((String) -> Void)?
+    let onSubmit: (() -> Void)?
     let label: String?
     let optionalIndicator: String?
     let supportText: String?
@@ -620,7 +635,8 @@ private struct LemonadeTextFieldView<LeadingContent: View, TrailingContent: View
                         isSecure: isSecure,
                         enabled: enabled,
                         isFocused: $isFocused,
-                        onInputChanged: onInputChanged
+                        onInputChanged: onInputChanged,
+                        onSubmit: onSubmit
                     )
                 }
 
@@ -703,7 +719,8 @@ private struct LemonadeTextFieldWithSelectorView<LeadingContent: View, TrailingC
                             isSecure: isSecure,
                             enabled: enabled,
                             isFocused: $isFocused,
-                            onInputChanged: onInputChanged
+                            onInputChanged: onInputChanged,
+                            onSubmit: nil
                         )
                     }
 
@@ -848,6 +865,7 @@ private struct LemonadeTextFieldValueView<LeadingContent: View, TrailingContent:
         LemonadeTextFieldView(
             input: textBinding,
             onInputChanged: nil,
+            onSubmit: nil,
             label: label,
             optionalIndicator: optionalIndicator,
             supportText: supportText,

--- a/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeUITextField.swift
@@ -26,6 +26,10 @@ internal struct LemonadeUITextField: UIViewRepresentable {
     var isSecure: Bool = false
     var onValueChange: ((LemonadeTextFieldValue) -> Void)?
     var onEditingChanged: ((Bool) -> Void)?
+    /// Called when the keyboard's return key is pressed. When set, the field keeps
+    /// first responder (the keyboard stays up) so the caller drives what happens
+    /// next; when `nil`, the return key dismisses the keyboard as before.
+    var onReturnKey: (() -> Void)?
 
     /// Clamps cursor position to valid UTF-16 range for the given text
     private func clampedCursorPosition(_ position: Int, for text: String) -> Int {
@@ -229,7 +233,11 @@ internal struct LemonadeUITextField: UIViewRepresentable {
         }
 
         func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            textField.resignFirstResponder()
+            if let onReturnKey = parent.onReturnKey {
+                onReturnKey()
+            } else {
+                textField.resignFirstResponder()
+            }
             return true
         }
 


### PR DESCRIPTION
## What

Adds an `onSubmit` callback to the String-binding `LemonadeUi.TextField` overloads so callers can react to the keyboard's **return key** on iOS.

## Why

On iOS, `LemonadeUi.TextField` is backed by `LemonadeUITextField`, a `UIViewRepresentable` over `UITextField`. SwiftUI's `.onSubmit` modifier only fires for SwiftUI's own text-input views, so attaching it to `LemonadeUi.TextField` is a **silent no-op** — the return key never reaches the caller. The wrapper's `textFieldShouldReturn` previously just called `resignFirstResponder()` and swallowed the event, so there was no way at all to run an action on return.

This surfaced in the Teya app's "Email receipt" screen: typing an email and pressing return added a recipient chip on Android (`KeyboardActions.onDone`) but did nothing on iOS.

## How

- `LemonadeUITextField`: new `onReturnKey: (() -> Void)?`, fired inside `textFieldShouldReturn`.
- `LemonadeTextField`: new public `onSubmit: (() -> Void)?` on both String-binding overloads, plumbed through `LemonadeTextFieldView` → `LemonadeTextInputField` → `onReturnKey`. The macOS fallback wires it via native `.onSubmit`.

## Behaviour

- **When `onSubmit` is set:** the field **keeps first responder** (the keyboard stays up) and fires the callback, so the caller decides what happens next (e.g. add a chip and keep typing). This matches Android, where providing `KeyboardActions.onDone` overrides the default keyboard dismiss.
- **When `onSubmit` is nil (default):** the return key dismisses the keyboard exactly as before.

Fully backward compatible — every new parameter is optional/defaulted and existing behaviour is unchanged when `onSubmit` isn't provided.

## Testing

`swift build` clean. Verified end-to-end in the Teya app (SPM pointed at this branch locally): the app compiles against the new API and the recipient chip is now added when pressing return on the email-receipt screen.

## Usage

```swift
LemonadeUi.TextField(
    input: $email,
    onInputChanged: { email = $0 },
    onSubmit: { addRecipient() },   // fires on return; keyboard stays up
    placeholderText: "Add recipient"
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)