### PR TITLE
fix(swiftui): make the whole SelectField tappable, not just text and chevron

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSelectField.swift
@@ -135,6 +135,9 @@ private struct LemonadeSelectFieldView<LeadingContent: View>: View {
                 }
                 .padding(.horizontal, TextFieldConstants.horizontalPadding)
                 .padding(.vertical, TextFieldConstants.verticalPadding)
+                // Hit-test the whole field, not just the opaque text + chevron. Without this the
+                // empty space around the Spacer falls through and taps there don't register.
+                .contentShape(Rectangle())
             }
             .buttonStyle(PlainButtonStyle())
             .disabled(!enabled)


### PR DESCRIPTION
## Problem
On iOS, `LemonadeUi.SelectField` only responded to taps on its opaque content — the value/placeholder text and the chevron. The empty space around the internal `Spacer` fell through, so tapping the middle of the field did nothing. This contradicts the component's own doc ("the entire field is clickable") and users hit the dead gap on wide fields.

## Fix
Add `.contentShape(Rectangle())` to the Button's label so the whole padded field is hit-tested. One line, no API or layout change.

## Demo
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/e1585abf-a779-46aa-88e7-5a96fcbb7aed" /> | <video src="https://github.com/user-attachments/assets/983f35b2-e063-44ca-914d-bbc632ae545b" /> |
