### PR TITLE
feat(button): match Figma button disabled state with group opacity

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -70,10 +70,9 @@ public fun LemonadeUi.Button(
     val colors = resolveButtonColors(
         variant = variant,
         type = type,
-    )
+    ).adjustedForDisabledFill(enabled = enabled, variant = variant, type = type)
     CoreButton(
         colors = colors,
-        type = type,
         size = size,
         modifier = modifier,
         enabled = enabled,
@@ -151,10 +150,9 @@ public fun LemonadeUi.Button(
     val colors = resolveButtonColors(
         variant = variant,
         type = type,
-    )
+    ).adjustedForDisabledFill(enabled = enabled, variant = variant, type = type)
     CoreButton(
         colors = colors,
-        type = type,
         size = size,
         enabled = enabled,
         interactionSource = interactionSource,
@@ -254,6 +252,30 @@ private fun resolveButtonColors(
         LemonadeButtonVariant.Critical -> resolveCriticalButtonColors(type = type)
     }
 
+// Secondary Solid's fill is an opaque dark inverse. Figma dims it to `opacity40` when disabled,
+// while every other variant — and all content — dims to `opacityDisabled`. The disabled
+// [Modifier.alpha] in [CoreButton] already multiplies the whole button by `opacityDisabled`, so
+// pre-scale just this fill by the ratio of the two, letting them multiply out to `opacity40`.
+@Composable
+private fun LemonadeButtonColors.adjustedForDisabledFill(
+    enabled: Boolean,
+    variant: LemonadeButtonVariant,
+    type: LemonadeButtonType,
+): LemonadeButtonColors {
+    val isSecondarySolid = variant == LemonadeButtonVariant.Secondary &&
+        type == LemonadeButtonType.Solid
+    if (enabled || !isSecondarySolid) return this
+    val opacities = LocalOpacities.current
+    val fillScale = opacities.base.opacity40 / opacities.state.opacityDisabled
+    return LemonadeButtonColors(
+        contentColor = contentColor,
+        solidBackgroundColor = solidBackgroundColor.copy(
+            alpha = solidBackgroundColor.alpha * fillScale,
+        ),
+        pressedBackgroundColor = pressedBackgroundColor,
+    )
+}
+
 @Composable
 private fun resolvePrimaryButtonColors(type: LemonadeButtonType): LemonadeButtonColors =
     when (type) {
@@ -349,7 +371,6 @@ private fun CoreButton(
     trailingSlot: (@Composable RowScope.(LemonadeButtonColors) -> Unit)?,
     onClick: () -> Unit,
     colors: LemonadeButtonColors,
-    type: LemonadeButtonType,
     size: LemonadeButtonSize,
     expandContents: Boolean,
     enabled: Boolean,
@@ -365,18 +386,11 @@ private fun CoreButton(
             colors.solidBackgroundColor
         },
     )
-    // `bgSubtle` backdrop is drawn BEFORE the disabled [Modifier.alpha] scope. Compose applies
-    // alpha as a graphics layer wrapping subsequent draws only — so when disabled, the 50% alpha
-    // blends the colored fill into the opaque backdrop instead of into whatever is behind the
-    // button. When enabled, the opaque colored fill fully covers the backdrop. Ghost buttons have
-    // no fill, so they skip the backdrop entirely and stay transparent when disabled.
+    // When disabled, wrap the fill and content in a single alpha graphics layer so the whole
+    // button — container and content together — dims to 50% as one group, matching the Figma
+    // disabled treatment (group opacity, letting the underlying surface show through).
     val disabledModifier = if (!enabled) {
-        val backdrop = if (type == LemonadeButtonType.Ghost) {
-            Modifier
-        } else {
-            Modifier.background(color = LocalColors.current.background.bgSubtle)
-        }
-        backdrop.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+        Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
     } else {
         Modifier
     }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
@@ -101,7 +101,7 @@ private fun CoreIconButton(
     val colors = resolveColors(
         variant = variant,
         type = type,
-    )
+    ).adjustedForDisabledFill(enabled = enabled, variant = variant, type = type)
     val animatedBackgroundColor by animateColorAsState(
         targetValue = when {
             isPressed -> colors.backgroundPressedColor
@@ -111,18 +111,11 @@ private fun CoreIconButton(
     )
     val sizeData = size.toSizeData(shape = shape)
 
-    // `bgSubtle` backdrop is drawn BEFORE the disabled [Modifier.alpha] scope. Compose applies
-    // alpha as a graphics layer wrapping subsequent draws only — so when disabled, the 50% alpha
-    // blends the colored fill into the opaque backdrop instead of into whatever is behind the
-    // button. When enabled, the opaque colored fill fully covers the backdrop. Ghost buttons have
-    // no fill, so they skip the backdrop entirely and stay transparent when disabled.
+    // When disabled, wrap the fill and content in a single alpha graphics layer so the whole
+    // button — container and content together — dims to 50% as one group, matching the Figma
+    // disabled treatment (group opacity, letting the underlying surface show through).
     val disabledModifier = if (!enabled) {
-        val backdrop = if (type == LemonadeButtonType.Ghost) {
-            Modifier
-        } else {
-            Modifier.background(color = LocalColors.current.background.bgSubtle)
-        }
-        backdrop.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+        Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
     } else {
         Modifier
     }
@@ -177,6 +170,26 @@ private fun resolveColors(
         LemonadeButtonVariant.Neutral -> resolveNeutralColors(type = type)
         LemonadeButtonVariant.Critical -> resolveCriticalColors(type = type)
     }
+
+// Secondary Solid's fill is an opaque dark inverse. Figma dims it to `opacity40` when disabled,
+// while every other variant — and all content — dims to `opacityDisabled`. The disabled
+// [Modifier.alpha] in [CoreIconButton] already multiplies the whole button by `opacityDisabled`,
+// so pre-scale just this fill by the ratio of the two, letting them multiply out to `opacity40`.
+@Composable
+private fun IconButtonColorData.adjustedForDisabledFill(
+    enabled: Boolean,
+    variant: LemonadeButtonVariant,
+    type: LemonadeButtonType,
+): IconButtonColorData {
+    val isSecondarySolid = variant == LemonadeButtonVariant.Secondary &&
+        type == LemonadeButtonType.Solid
+    if (enabled || !isSecondarySolid) return this
+    val opacities = LocalOpacities.current
+    val fillScale = opacities.base.opacity40 / opacities.state.opacityDisabled
+    return copy(
+        backgroundColor = backgroundColor.copy(alpha = backgroundColor.alpha * fillScale),
+    )
+}
 
 @Composable
 private fun resolvePrimaryColors(type: LemonadeButtonType): IconButtonColorData =

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -371,63 +371,63 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
         let colors = resolveButtonColors(variant: variant, type: type)
         let buttonShape = RoundedRectangle(cornerRadius: cornerRadius)
 
-        // The ZStack backdrop paints an opaque `bgSubtle` rectangle behind the button. It sits
-        // OUTSIDE the `.opacity` modifier applied to the SwiftUI.Button, so the disabled 50%
-        // opacity blends the colored fill into the backdrop instead of into whatever happens to
-        // be drawn behind (e.g. a scrolling list under a floating footer).
+        // When disabled, the whole button — fill and content together — dims to 50% via a single
+        // `.opacity` modifier on the SwiftUI.Button, matching the Figma disabled treatment (group
+        // opacity, letting the underlying surface show through).
         let pressedOpacity = isPressed ? LemonadeTheme.opacity.state.opacityPressed : LemonadeTheme.opacity.base.opacity100
         let disabledOpacity = (enabled || loading) ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled
-        ZStack {
-            if !enabled, type != .ghost {
-                buttonShape.fill(LemonadeTheme.colors.background.bgSubtle)
-            }
-
-            SwiftUI.Button(action: onClick) {
-                HStack(spacing: 0) {
-                    if !loading, let leadingSlot = leadingSlot {
-                        leadingSlot(colors)
-                    }
-
-                    HStack(spacing: 0) {
-                        Spacer(minLength: 0)
-                        ZStack {
-                            // Hide the content with opacity while loading instead of removing it
-                            // from the hierarchy. A removed view fades out at its old absolute
-                            // position, so if the button's frame animates at the same time the
-                            // content detaches and fades mid-screen while the spinner rides the
-                            // button to its new position. Kept in the layout, it moves with the
-                            // button.
-                            contentSlot(colors)
-                                .opacity(loading ? 0 : 1)
-
-                            if loading {
-                                LemonadeUi.Spinner(tint: colors.contentColor)
-                            }
-                        }
-                        Spacer(minLength: 0)
-                    }
-                    .padding(.vertical, size.contentData.verticalPadding)
-                    .padding(.horizontal, size.contentData.horizontalPadding)
-                    .if(expandContents) { view in
-                        view.frame(maxWidth: .infinity)
-                    }
-
-                    if !loading, let trailingSlot = trailingSlot {
-                        trailingSlot(colors)
-                    }
+        // Secondary Solid's opaque inverse fill dims to `opacity40` when disabled, not
+        // `opacityDisabled`. The `.opacity(… disabledOpacity)` below already dims the whole button
+        // by `opacityDisabled`, so pre-scale just the fill by the ratio so they multiply out to
+        // `opacity40`.
+        let disabledFillScale = (!enabled && variant == .secondary && type == .solid)
+            ? LemonadeTheme.opacity.base.opacity40 / LemonadeTheme.opacity.state.opacityDisabled
+            : 1.0
+        SwiftUI.Button(action: onClick) {
+            HStack(spacing: 0) {
+                if !loading, let leadingSlot = leadingSlot {
+                    leadingSlot(colors)
                 }
-                .frame(height: size.contentData.requiredHeight)
-                .frame(minWidth: size.contentData.minWidth)
-                .background(buttonShape.fill(colors.backgroundColor))
-                // Keep the rounded hit target the removed .clipShape used to provide, without
-                // reintroducing its offscreen pass.
-                .contentShape(buttonShape)
+
+                HStack(spacing: 0) {
+                    Spacer(minLength: 0)
+                    ZStack {
+                        // Hide the content with opacity while loading instead of removing it
+                        // from the hierarchy. A removed view fades out at its old absolute
+                        // position, so if the button's frame animates at the same time the
+                        // content detaches and fades mid-screen while the spinner rides the
+                        // button to its new position. Kept in the layout, it moves with the
+                        // button.
+                        contentSlot(colors)
+                            .opacity(loading ? 0 : 1)
+
+                        if loading {
+                            LemonadeUi.Spinner(tint: colors.contentColor)
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+                .padding(.vertical, size.contentData.verticalPadding)
+                .padding(.horizontal, size.contentData.horizontalPadding)
+                .if(expandContents) { view in
+                    view.frame(maxWidth: .infinity)
+                }
+
+                if !loading, let trailingSlot = trailingSlot {
+                    trailingSlot(colors)
+                }
             }
-            .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
-            .opacity(pressedOpacity * disabledOpacity)
-            .animation(.easeInOut(duration: 0.1), value: isPressed)
-            .disabled(!enabled || loading)
+            .frame(height: size.contentData.requiredHeight)
+            .frame(minWidth: size.contentData.minWidth)
+            .background(buttonShape.fill(colors.backgroundColor.opacity(disabledFillScale)))
+            // Keep the rounded hit target the removed .clipShape used to provide, without
+            // reintroducing its offscreen pass.
+            .contentShape(buttonShape)
         }
+        .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+        .opacity(pressedOpacity * disabledOpacity)
+        .animation(.easeInOut(duration: 0.1), value: isPressed)
+        .disabled(!enabled || loading)
         .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -375,7 +375,7 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
         // `.opacity` modifier on the SwiftUI.Button, matching the Figma disabled treatment (group
         // opacity, letting the underlying surface show through).
         let pressedOpacity = isPressed ? LemonadeTheme.opacity.state.opacityPressed : LemonadeTheme.opacity.base.opacity100
-        let disabledOpacity = (enabled || loading) ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled
+        let disabledOpacity = enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled
         // Secondary Solid's opaque inverse fill dims to `opacity40` when disabled, not
         // `opacityDisabled`. The `.opacity(… disabledOpacity)` below already dims the whole button
         // by `opacityDisabled`, so pre-scale just the fill by the ratio so they multiply out to

--- a/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIconButton.swift
@@ -250,47 +250,46 @@ private struct LemonadeIconButtonView: View {
         let bgColor: Color = isHovering ? colors.backgroundHoverColor : colors.backgroundColor
         let buttonShape = RoundedRectangle(cornerRadius: cornerRadius)
 
-        // The ZStack backdrop paints an opaque `bgSubtle` rectangle behind the button. It sits
-        // OUTSIDE the `.opacity` modifier applied to the SwiftUI.Button, so the disabled 50%
-        // opacity blends the colored fill into the backdrop instead of into whatever happens to
-        // be drawn behind. Ghost buttons have no fill, so they skip the backdrop entirely.
-        ZStack {
-            if !enabled, type != .ghost {
-                buttonShape.fill(LemonadeTheme.colors.background.bgSubtle)
-            }
-
-            SwiftUI.Button(action: onClick) {
-                Group {
-                    if loading {
-                        LemonadeUi.Spinner(tint: colors.contentColor)
-                    } else {
-                        LemonadeUi.Icon(
-                            icon: icon,
-                            contentDescription: contentDescription,
-                            size: size.iconButtonSizeData.iconSize,
-                            tint: colors.contentColor
-                        )
-                    }
+        // When disabled, the whole button — fill and content together — dims to 50% via a single
+        // `.opacity` modifier on the SwiftUI.Button, matching the Figma disabled treatment (group
+        // opacity, letting the underlying surface show through).
+        // Secondary Solid's opaque inverse fill dims to `opacity40` when disabled, not
+        // `opacityDisabled`. The `.opacity(… opacityDisabled)` below already dims the whole button,
+        // so pre-scale just the fill by the ratio so they multiply out to `opacity40`.
+        let disabledFillScale = (!enabled && variant == .secondary && type == .solid)
+            ? LemonadeTheme.opacity.base.opacity40 / LemonadeTheme.opacity.state.opacityDisabled
+            : 1.0
+        SwiftUI.Button(action: onClick) {
+            Group {
+                if loading {
+                    LemonadeUi.Spinner(tint: colors.contentColor)
+                } else {
+                    LemonadeUi.Icon(
+                        icon: icon,
+                        contentDescription: contentDescription,
+                        size: size.iconButtonSizeData.iconSize,
+                        tint: colors.contentColor
+                    )
                 }
-                .padding(size.iconButtonSizeData.innerPadding)
-                .background(
-                    buttonShape
-                        .fill(bgColor)
-                        .animation(.easeInOut(duration: 0.1), value: bgColor)
-                )
-                // Keep the rounded hit target the removed .clipShape used to provide, without
-                // reintroducing its offscreen pass.
-                .contentShape(buttonShape)
             }
-            .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
-            .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)
-            .animation(.easeInOut(duration: 0.1), value: isPressed)
-            .onHover { hovering in
-                isHovering = hovering
-            }
-            .disabled(!enabled || loading)
-            .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
+            .padding(size.iconButtonSizeData.innerPadding)
+            .background(
+                buttonShape
+                    .fill(bgColor.opacity(disabledFillScale))
+                    .animation(.easeInOut(duration: 0.1), value: bgColor)
+            )
+            // Keep the rounded hit target the removed .clipShape used to provide, without
+            // reintroducing its offscreen pass.
+            .contentShape(buttonShape)
         }
+        .buttonStyle(LemonadePressTrackingButtonStyle(isPressed: $isPressed))
+        .opacity(isPressed ? .opacity.opacityPressed : .opacity.opacity100)
+        .animation(.easeInOut(duration: 0.1), value: isPressed)
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .disabled(!enabled || loading)
+        .opacity(enabled ? 1.0 : LemonadeTheme.opacity.state.opacityDisabled)
     }
 }
 


### PR DESCRIPTION
## Overview

Reworks the disabled state of `Button` and `IconButton` (KMP + SwiftUI) to match the Figma design: the whole button dims via a single group opacity, and Secondary Solid gets its distinct 40% fill.

## What we have done

- Removed the opaque `bgSubtle` backdrop from the disabled path and replaced it with a single group opacity (`Modifier.alpha` on KMP, `.opacity` on SwiftUI), so fill + content dim together to 50% and the underlying surface shows through — matching Figma's group-opacity treatment on any surface.
- Special-cased **Secondary Solid**: its opaque dark inverse fill dims to `opacity40` (40%) while content stays at `opacityDisabled` (50%), verified against Figma's rendered pixels. The fill is pre-scaled by `opacity40 / opacityDisabled` so it multiplies out to 40% inside the group alpha; the ratio is token-derived, so it stays correct if the disabled token ever changes.
- Added a small `adjustedForDisabledFill(...)` helper (KMP, per color model) / `disabledFillScale` local (SwiftUI) to localize that special case.
- Removed the now-unused `type` parameter from the private `CoreButton`.

## Screenshot
<img width="300" src="https://github.com/user-attachments/assets/9aaca8e7-aa7e-4bba-8efc-60269de4d059" />

## How to test

1. Open the KMP sample app (`composeApp`) or the SwiftUI `SampleApp`.
2. Go to the Button and IconButton displays and look at the disabled rows across all variants (Primary, Secondary, Neutral, Critical) and types (Solid, Subtle, Ghost).
3. Confirm every disabled button dims to 50% and lets the surface behind show through (no opaque neutral backdrop).
4. Confirm the **Secondary Solid** disabled button renders a touch lighter than the others — its fill sits at 40%, its label at 50%.
5. Confirm enabled buttons and the loading state are visually unchanged.

## API Dump

No public API changes. `bcv-check.sh --ci` → **NO_CHANGES**. The change touches only private composables (`CoreButton`/`CoreIconButton`), private helpers, and internal color resolution; the removed `CoreButton` `type` parameter is on a private function. `apiCheck` passes with no baseline drift.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have added all necessary code documentation and specifications
- [ ] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
- [ ] Did I add/update translations?
- [ ] I have considered whether my changes affect E2E tests
- [ ] If these changes rely on a feature flag, does it have the correct value for staging and production?
- [ ] If these changes use a new version of an API, is that new version on staging and production?