### PR TITLE
feat(sample): appearance settings sheet (light/dark/system) in Compose & SwiftUI samples

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/HomeDisplay.kt
@@ -1,30 +1,43 @@
 package com.teya.lemonade
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.teya.lemonade.core.LemonadeAssetSize
+import com.teya.lemonade.core.LemonadeButtonType
 import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.SelectListItemType
 import com.teya.lemonade.core.TabButtonProperties
 
 @Composable
 internal fun HomeDisplay(onNavigate: (Displays) -> Unit) {
     val styleHandler = LocalLemonadeStyleHandler.current
-    val styles = LemonadeStyle.entries
-    val selectedIndex = styles.indexOf(styleHandler.currentStyle)
     val variants = LemonadeThemeVariant.entries
     val selectedVariantIndex = variants.indexOf(styleHandler.currentVariant)
 
+    var showSettings by remember { mutableStateOf(value = false) }
+
     SampleScreenDisplayLazyColumn(
         title = "Lemonade Design System",
+        action = {
+            LemonadeUi.IconButton(
+                icon = LemonadeIcons.Gear,
+                contentDescription = "Settings",
+                type = LemonadeButtonType.Ghost,
+                onClick = { showSettings = true },
+            )
+        },
     ) {
         item {
-            LemonadeUi.SegmentedControl(
-                selectedTab = selectedIndex,
-                onTabSelected = { index -> styleHandler.currentStyle = styles[index] },
-                properties = styles.map { style -> TabButtonProperties.label(label = style.label) },
-                modifier = Modifier.padding(bottom = LemonadeTheme.spaces.spacing200),
-            )
             LemonadeUi.SegmentedControl(
                 selectedTab = selectedVariantIndex,
                 onTabSelected = { index -> styleHandler.currentVariant = variants[index] },
@@ -55,6 +68,52 @@ internal fun HomeDisplay(onNavigate: (Displays) -> Unit) {
                     }
                 }
             }
+        }
+    }
+
+    SettingsSheet(
+        expanded = showSettings,
+        onDismissRequest = { showSettings = false },
+    )
+}
+
+@Composable
+private fun SettingsSheet(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+) {
+    val styleHandler = LocalLemonadeStyleHandler.current
+    LemonadeUi.BottomSheet(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(space = LemonadeTheme.spaces.spacing400),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = LemonadeTheme.spaces.spacing400),
+        ) {
+            LemonadeUi.Text(
+                text = "Settings",
+                textStyle = LemonadeTheme.typography.headingSmall,
+            )
+
+            LemonadeUi.Card(
+                header = CardHeaderConfig(title = "Appearance"),
+            ) {
+                val styles = LemonadeStyle.entries
+                styles.forEachIndexed { index, style ->
+                    LemonadeUi.SelectListItem(
+                        label = style.label,
+                        type = SelectListItemType.Single,
+                        checked = styleHandler.currentStyle == style,
+                        onItemClicked = { styleHandler.currentStyle = style },
+                        showDivider = index != styles.lastIndex,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(height = LemonadeTheme.spaces.spacing400))
         }
     }
 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/LemonadeStyle.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/LemonadeStyle.kt
@@ -1,21 +1,42 @@
 package com.teya.lemonade
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+
 internal sealed interface LemonadeStyle {
     val label: String
-    val colors: LemonadeSemanticColors
+
+    @Composable
+    fun resolveColors(): LemonadeSemanticColors
 
     data object Light : LemonadeStyle {
         override val label: String = "Light"
-        override val colors: LemonadeSemanticColors = LemonadeLightTheme
+
+        @Composable
+        override fun resolveColors(): LemonadeSemanticColors = LemonadeLightTheme
     }
 
     data object Dark : LemonadeStyle {
         override val label: String = "Dark"
-        override val colors: LemonadeSemanticColors = LemonadeDarkTheme
+
+        @Composable
+        override fun resolveColors(): LemonadeSemanticColors = LemonadeDarkTheme
+    }
+
+    data object System : LemonadeStyle {
+        override val label: String = "System"
+
+        @Composable
+        override fun resolveColors(): LemonadeSemanticColors =
+            if (isSystemInDarkTheme()) {
+                LemonadeDarkTheme
+            } else {
+                LemonadeLightTheme
+            }
     }
 
     companion object {
-        val entries: List<LemonadeStyle> = listOf(Light, Dark)
-        val Default: LemonadeStyle = Light
+        val entries: List<LemonadeStyle> = listOf(Light, Dark, System)
+        val Default: LemonadeStyle = System
     }
 }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/LemonadeStyleHandler.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/LemonadeStyleHandler.kt
@@ -32,11 +32,12 @@ internal fun LemonadeStyledTheme(
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(LocalLemonadeStyleHandler provides handler) {
+        val colors = handler.currentStyle.resolveColors()
         when (handler.currentVariant) {
-            LemonadeThemeVariant.Standard -> LemonadeTheme(colors = handler.currentStyle.colors) {
+            LemonadeThemeVariant.Standard -> LemonadeTheme(colors = colors) {
                 content()
             }
-            LemonadeThemeVariant.Expressive -> LemonadeExpressiveTheme(colors = handler.currentStyle.colors) {
+            LemonadeThemeVariant.Expressive -> LemonadeExpressiveTheme(colors = colors) {
                 content()
             }
         }

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SampleScreenDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SampleScreenDisplay.kt
@@ -111,8 +111,9 @@ internal fun SampleScreenDisplayLazyColumn(
     modifier: Modifier = Modifier,
     contentHorizontalPadding: Dp = LemonadeTheme.spaces.spacing400,
     background: Color = LemonadeTheme.colors.background.bgSubtle,
+    action: (@Composable () -> Unit)? = null,
     header: @Composable (progress: Float) -> Unit = { progress ->
-        SampleScreenHeader(title = title, progress = progress)
+        SampleScreenHeader(title = title, progress = progress, action = action)
     },
     content: LazyListScope.() -> Unit,
 ) {

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SampleScreenHeader.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SampleScreenHeader.kt
@@ -6,12 +6,14 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
@@ -25,6 +27,7 @@ internal fun SampleScreenHeader(
     background: Color = LemonadeTheme.colors.background.bgDefault,
     progress: Float,
     onBack: (() -> Unit)? = null,
+    action: (@Composable () -> Unit)? = null,
 ) {
     if (title.isNullOrBlank()) return
 
@@ -66,8 +69,10 @@ internal fun SampleScreenHeader(
             .background(background.copy(animatedAlpha))
             .statusBarsPadding(),
     ) {
-        Column(
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
+                .fillMaxWidth()
                 .padding(
                     horizontal = LemonadeTheme.spaces.spacing400,
                     vertical = verticalPad,
@@ -76,7 +81,9 @@ internal fun SampleScreenHeader(
             LemonadeUi.Text(
                 text = title,
                 textStyle = LemonadeTheme.typography.headingMedium.copy(fontSize = animatedFontSize),
+                modifier = Modifier.weight(weight = 1f),
             )
+            action?.invoke()
         }
 
         Box(

--- a/swiftui/SampleApp/HomeView.swift
+++ b/swiftui/SampleApp/HomeView.swift
@@ -4,6 +4,7 @@ import Lemonade
 struct HomeView: View {
     @EnvironmentObject private var styleHandler: LemonadeStyleHandler
     @State private var searchText: String = ""
+    @State private var showSettings: Bool = false
 
     private struct DemoItem: Identifiable {
         let id = UUID()
@@ -122,22 +123,8 @@ struct HomeView: View {
         }
     }
 
-    private var selectedStyleIndex: Int {
-        LemonadeStyle.allCases.firstIndex(of: styleHandler.currentStyle) ?? 0
-    }
-
     var body: some View {
         List {
-            Section {
-                LemonadeUi.SegmentedControl(
-                    properties: LemonadeStyle.allCases.map { .label($0.label) },
-                    selectedTab: selectedStyleIndex,
-                    onTabSelected: { index in
-                        styleHandler.currentStyle = LemonadeStyle.allCases[index]
-                    }
-                )
-            }
-
             ForEach(filteredSections) { section in
                 Section(section.title) {
                     ForEach(section.items) { item in
@@ -150,6 +137,20 @@ struct HomeView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
         .textInputAutocapitalization(.never)
         .disableAutocorrection(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: { showSettings = true }) {
+                    LemonadeUi.Icon(
+                        icon: .gear,
+                        contentDescription: "Settings"
+                    )
+                }
+            }
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+                .environmentObject(styleHandler)
+        }
     }
 }
 

--- a/swiftui/SampleApp/LemonadeSampleApp.swift
+++ b/swiftui/SampleApp/LemonadeSampleApp.swift
@@ -27,18 +27,19 @@ struct LemonadeSampleApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(styleHandler)
-                .id(styleHandler.currentStyle)
-                .preferredColorScheme(styleHandler.currentStyle.colorScheme)
                 .environment(\.font, Font.custom("Figtree", size: LemonadeTypography.shared.bodyMediumMedium.fontSize))
         }
     }
 }
 
 struct ContentView: View {
+    @EnvironmentObject private var styleHandler: LemonadeStyleHandler
+
     var body: some View {
         NavigationStack {
             HomeView()
         }
         .lemonadeToastContainer()
+        .onAppear { styleHandler.applyToWindows() }
     }
 }

--- a/swiftui/SampleApp/LemonadeStyle.swift
+++ b/swiftui/SampleApp/LemonadeStyle.swift
@@ -1,19 +1,22 @@
-import SwiftUI
+import UIKit
 
 enum LemonadeStyle: CaseIterable {
-    case light, dark
+    case light, dark, system
 
     var label: String {
         switch self {
         case .light: "Light"
         case .dark: "Dark"
+        case .system: "System"
         }
     }
 
-    var colorScheme: ColorScheme {
+    /// The UIKit interface style to force, or `.unspecified` to follow the system setting.
+    var userInterfaceStyle: UIUserInterfaceStyle {
         switch self {
         case .light: .light
         case .dark: .dark
+        case .system: .unspecified
         }
     }
 }

--- a/swiftui/SampleApp/LemonadeStyleHandler.swift
+++ b/swiftui/SampleApp/LemonadeStyleHandler.swift
@@ -1,5 +1,18 @@
 import SwiftUI
+import UIKit
 
 final class LemonadeStyleHandler: ObservableObject {
-    @Published var currentStyle: LemonadeStyle = .light
+    @Published var currentStyle: LemonadeStyle = .system {
+        didSet { applyToWindows() }
+    }
+
+    /// Applies the selected appearance to every window so that presented sheets
+    /// (which don't inherit SwiftUI's `.preferredColorScheme`) stay in sync.
+    func applyToWindows() {
+        let style = currentStyle.userInterfaceStyle
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .forEach { $0.overrideUserInterfaceStyle = style }
+    }
 }

--- a/swiftui/SampleApp/LemonadeStyleHandler.swift
+++ b/swiftui/SampleApp/LemonadeStyleHandler.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 
+@MainActor
 final class LemonadeStyleHandler: ObservableObject {
     @Published var currentStyle: LemonadeStyle = .system {
         didSet { applyToWindows() }

--- a/swiftui/SampleApp/SettingsView.swift
+++ b/swiftui/SampleApp/SettingsView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import Lemonade
+
+struct SettingsView: View {
+    @EnvironmentObject private var styleHandler: LemonadeStyleHandler
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: .space.spacing400) {
+                    LemonadeUi.Card(
+                        contentPadding: .none,
+                        header: CardHeaderConfig(title: "Appearance", headingStyle: .overline)
+                    ) {
+                        let styles = LemonadeStyle.allCases
+                        ForEach(Array(styles.enumerated()), id: \.element) { index, style in
+                            LemonadeUi.SelectListItem(
+                                label: style.label,
+                                type: .single,
+                                checked: styleHandler.currentStyle == style,
+                                onItemClicked: { styleHandler.currentStyle = style },
+                                showDivider: index < styles.count - 1
+                            )
+                        }
+                    }
+                }
+                .padding(.space.spacing400)
+            }
+            .background(.bg.bgSubtle)
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: { dismiss() }) {
+                        LemonadeUi.Icon(
+                            icon: .times,
+                            contentDescription: "Close"
+                        )
+                    }
+                }
+            }
+        }
+        // The sheet may be hosted in its own window; make sure it picks up the
+        // selected appearance as soon as it appears. Subsequent changes are
+        // handled by the handler's `didSet`.
+        .onAppear { styleHandler.applyToWindows() }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environmentObject(LemonadeStyleHandler())
+}


### PR DESCRIPTION
# Summary

Adds a **Settings** action to both sample apps (KMP Compose `composeApp` and SwiftUI `SampleApp`). The action presents a sheet with an **Appearance** section offering **Light / Dark / System**, rendered as single-selection `SelectListItem`s inside a Lemonade `Card`. Selecting an option updates the theme live and keeps the sheet open. This only touches the (unpublished) sample apps.

## What was done

**KMP Compose (`composeApp`)**
- `LemonadeStyle` gained a `System` entry; `colors` became a `@Composable resolveColors()` so `System` can resolve via `isSystemInDarkTheme()`. Default is now `System`.
- `LemonadeStyleHandler`/`LemonadeStyledTheme` resolve colors through `resolveColors()`.
- `SampleScreenDisplayLazyColumn`/`SampleScreenHeader` gained an optional trailing `action` slot (title moved into a `Row` with the action pinned right).
- `HomeDisplay` shows a gear `IconButton` that opens a `LemonadeUi.BottomSheet` with the Appearance `Card`; the old inline light/dark `SegmentedControl` was removed (the variant control stays).

**SwiftUI (`SampleApp`)**
- `LemonadeStyle` gained `system` and exposes `userInterfaceStyle` (`.unspecified` for system).
- Theme is applied via `overrideUserInterfaceStyle` on the scene windows (`LemonadeStyleHandler.applyToWindows()`), so a presented sheet stays in sync — SwiftUI's `.preferredColorScheme` does not reliably propagate to sheets (notably `nil`/system did not reset an already-presented sheet).
- New `SettingsView` sheet with the Appearance `Card` and a leading close (✕) button; `HomeView` gained a gear toolbar action; the old inline segmented control was removed.

## Screenshot

Verified on the iOS Simulator (iPhone 17 Pro): opening the sheet, switching Light↔Dark↔System updates both the main screen and the sheet live without dismissing. (Screenshots captured during development; happy to attach on request.)

## API Dump

**Verdict:** NO_CHANGES

No public API changes — only the unpublished sample apps (`composeApp`, SwiftUI `SampleApp`) were modified. No `kmp/<module>/api/*.api` or `*.klib.api` files changed.