### PR TITLE
fix(list-item): center leading slot for single-line content

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ResourceListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ResourceListItemDisplay.kt
@@ -45,7 +45,7 @@ internal fun ResourceListItemDisplay() {
                         icon = LemonadeIcons.Money,
                         contentDescription = null,
                         voice = SymbolContainerVoice.Info,
-                        size = SymbolContainerSize.Large,
+                        size = SymbolContainerSize.Medium,
                     )
                 },
             )
@@ -60,7 +60,7 @@ internal fun ResourceListItemDisplay() {
                         icon = LemonadeIcons.Coins,
                         contentDescription = null,
                         voice = SymbolContainerVoice.Positive,
-                        size = SymbolContainerSize.Large,
+                        size = SymbolContainerSize.Medium,
                     )
                 },
             )
@@ -83,7 +83,7 @@ internal fun ResourceListItemDisplay() {
                         icon = LemonadeIcons.ArrowUpRight,
                         contentDescription = null,
                         voice = SymbolContainerVoice.Critical,
-                        size = SymbolContainerSize.Large,
+                        size = SymbolContainerSize.Medium,
                     )
                 },
             )

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SelectListItemDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SelectListItemDisplay.kt
@@ -211,7 +211,7 @@ internal fun SelectListItemDisplay() {
                             LemonadeUi.SymbolContainer(
                                 icon = option.icon,
                                 contentDescription = null,
-                                size = SymbolContainerSize.Large,
+                                size = SymbolContainerSize.Medium,
                                 shape = SymbolContainerShape.Rounded,
                                 voice = if (isChecked) {
                                     SymbolContainerVoice.Positive
@@ -244,7 +244,7 @@ internal fun SelectListItemDisplay() {
                             LemonadeUi.SymbolContainer(
                                 icon = option.icon,
                                 contentDescription = null,
-                                size = SymbolContainerSize.Large,
+                                size = SymbolContainerSize.Medium,
                                 shape = SymbolContainerShape.Rounded,
                                 voice = if (isChecked) {
                                     SymbolContainerVoice.Positive
@@ -300,7 +300,7 @@ internal fun SelectListItemDisplay() {
                             LemonadeUi.SymbolContainer(
                                 icon = option.icon,
                                 contentDescription = null,
-                                size = SymbolContainerSize.Large,
+                                size = SymbolContainerSize.Medium,
                                 shape = SymbolContainerShape.Rounded,
                                 voice = SymbolContainerVoice.Neutral,
                             )
@@ -329,7 +329,7 @@ internal fun SelectListItemDisplay() {
                             LemonadeUi.SymbolContainer(
                                 icon = option.icon,
                                 contentDescription = null,
-                                size = SymbolContainerSize.Large,
+                                size = SymbolContainerSize.Medium,
                                 shape = SymbolContainerShape.Rounded,
                                 voice = if (isChecked) {
                                     SymbolContainerVoice.Positive
@@ -363,7 +363,7 @@ internal fun SelectListItemDisplay() {
                             LemonadeUi.SymbolContainer(
                                 icon = option.icon,
                                 contentDescription = null,
-                                size = SymbolContainerSize.Large,
+                                size = SymbolContainerSize.Medium,
                                 shape = SymbolContainerShape.Rounded,
                                 voice = if (isChecked) {
                                     SymbolContainerVoice.Positive
@@ -409,7 +409,7 @@ internal fun SelectListItemDisplay() {
                         LemonadeUi.SymbolContainer(
                             icon = LemonadeIcons.Padlock,
                             contentDescription = null,
-                            size = SymbolContainerSize.Large,
+                            size = SymbolContainerSize.Medium,
                             shape = SymbolContainerShape.Rounded,
                             voice = SymbolContainerVoice.Neutral,
                         )
@@ -427,7 +427,7 @@ internal fun SelectListItemDisplay() {
                         LemonadeUi.SymbolContainer(
                             icon = LemonadeIcons.Bell,
                             contentDescription = null,
-                            size = SymbolContainerSize.Large,
+                            size = SymbolContainerSize.Medium,
                             shape = SymbolContainerShape.Rounded,
                             voice = SymbolContainerVoice.Neutral,
                         )

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -129,7 +129,9 @@ public fun LemonadeUi.ResourceListItem(
         modifier = modifier,
         showDivider = showDivider,
         interactionSource = interactionSource,
-        trailingVerticalAlignment = Alignment.Top,
+        // With support text the content is multi-line, so top-align the value with the label's first
+        // line. With a single-line label, center it (and the leading slot) against the lone text line.
+        trailingVerticalAlignment = if (supportText == null) Alignment.CenterVertically else Alignment.Top,
     )
 }
 
@@ -271,7 +273,8 @@ public fun LemonadeUi.ActionListItem(
  * @param trailingVerticalAlignment - Vertical alignment of the trailing slot and navigation
  *  indicator against the label/supportText column. Defaults to [Alignment.CenterVertically].
  * @param leadingVerticalAlignment - Vertical alignment of the leading slot against the
- *  label/supportText column. Defaults to [Alignment.Top].
+ *  label/supportText column. Defaults to [Alignment.CenterVertically] for single-line content
+ *  (no [topLabel] or [supportText]) and [Alignment.Top] otherwise.
  * @param slotContent - Optional slot rendered below the support text, inside the label column
  *  so it stays aligned with the leading/trailing slots. Use for secondary content like an
  *  inline status text, badge, or compact widget that should sit under the row's text.
@@ -301,7 +304,10 @@ public fun LemonadeUi.ActionListItem(
     showNavigationIndicator: Boolean = false,
     showDivider: Boolean = false,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    leadingVerticalAlignment: Alignment.Vertical = Alignment.Top,
+    // slotContent is declared below and can't be referenced in this default, so an ActionListItem with
+    // only slotContent centers its leading slot (a minor divergence from the slotContent-aware ListItem).
+    leadingVerticalAlignment: Alignment.Vertical =
+        singleLineLeadingAlignment(topLabel, supportText),
     slotContent: (@Composable ColumnScope.() -> Unit)? = null,
     labelMaxLines: Int = Int.MAX_VALUE,
     labelOverflow: TextOverflow = TextOverflow.Clip,
@@ -589,7 +595,8 @@ public fun LemonadeUi.ListItem(
  * @param trailingVerticalAlignment - Vertical alignment of the trailing slot and navigation
  *  indicator against the label/supportText column. Defaults to [Alignment.CenterVertically].
  * @param leadingVerticalAlignment - Vertical alignment of the leading slot against the
- *  label/supportText column. Defaults to [Alignment.Top].
+ *  label/supportText column. Defaults to [Alignment.CenterVertically] for single-line content
+ *  (no [topLabel], [supportText], or [slotContent]) and [Alignment.Top] otherwise.
  * @param labelMaxLines - Maximum number of lines for the [label] before it truncates. Defaults to
  *  [Int.MAX_VALUE] (no limit).
  * @param labelOverflow - [TextOverflow] strategy applied to the [label] when it exceeds
@@ -619,7 +626,8 @@ public fun LemonadeUi.ListItem(
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     slotContent: (@Composable ColumnScope.() -> Unit)? = null,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    leadingVerticalAlignment: Alignment.Vertical = Alignment.Top,
+    leadingVerticalAlignment: Alignment.Vertical =
+        singleLineLeadingAlignment(topLabel, supportText, slotContent),
     labelMaxLines: Int = Int.MAX_VALUE,
     labelOverflow: TextOverflow = TextOverflow.Clip,
     supportTextMaxLines: Int = Int.MAX_VALUE,
@@ -823,6 +831,21 @@ public fun LemonadeUi.ListItem(
         priority = priority,
     )
 }
+
+/**
+ * Vertical alignment for a list item's leading slot: centered against single-line content (nothing
+ * stacked below the label), top-aligned otherwise so it lines up with the label's first line.
+ */
+private fun singleLineLeadingAlignment(
+    topLabel: String?,
+    supportText: String?,
+    slotContent: Any? = null,
+): Alignment.Vertical =
+    if (topLabel == null && supportText == null && slotContent == null) {
+        Alignment.CenterVertically
+    } else {
+        Alignment.Top
+    }
 
 @Composable
 private fun CoreListItem(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -129,9 +129,9 @@ public fun LemonadeUi.ResourceListItem(
         modifier = modifier,
         showDivider = showDivider,
         interactionSource = interactionSource,
-        // With support text the content is multi-line, so top-align the value with the label's first
-        // line. With a single-line label, center it (and the leading slot) against the lone text line.
-        trailingVerticalAlignment = if (supportText == null) Alignment.CenterVertically else Alignment.Top,
+        // Keep the value top-aligned with the label's first line: the label can wrap (no maxLines cap),
+        // and the outer Row already centers a single-line row, so this handles both without extra logic.
+        trailingVerticalAlignment = Alignment.Top,
     )
 }
 
@@ -839,7 +839,7 @@ public fun LemonadeUi.ListItem(
 private fun singleLineLeadingAlignment(
     topLabel: String?,
     supportText: String?,
-    slotContent: Any? = null,
+    slotContent: (@Composable ColumnScope.() -> Unit)? = null,
 ): Alignment.Vertical =
     if (topLabel == null && supportText == null && slotContent == null) {
         Alignment.CenterVertically

--- a/swiftui/SampleApp/ListItemDisplayView.swift
+++ b/swiftui/SampleApp/ListItemDisplayView.swift
@@ -211,7 +211,7 @@ struct ResourceListItemPreview: View {
                             icon: .coins,
                             contentDescription: nil,
                             voice: .positive,
-                            size: .large,
+                            size: .medium,
                             shape: .rounded
                         )
                     }
@@ -238,7 +238,7 @@ struct ResourceListItemPreview: View {
                             icon: .arrowUpRight,
                             contentDescription: nil,
                             voice: .critical,
-                            size: .large,
+                            size: .medium,
                             shape: .rounded
                         )
                     }
@@ -504,7 +504,7 @@ struct ActionListItemPreview: View {
                             icon: .bank,
                             contentDescription: nil,
                             voice: .neutral,
-                            size: .large,
+                            size: .medium,
                             shape: .rounded
                         )
                     },
@@ -873,7 +873,7 @@ struct OutlinedSelectListItemPreview: View {
                                     icon: option.icon,
                                     contentDescription: nil,
                                     voice: isChecked ? .positive : .neutral,
-                                    size: .large,
+                                    size: .medium,
                                     shape: .rounded
                                 )
                             }
@@ -907,7 +907,7 @@ struct OutlinedSelectListItemPreview: View {
                                     icon: option.icon,
                                     contentDescription: nil,
                                     voice: isChecked ? .positive : .neutral,
-                                    size: .large,
+                                    size: .medium,
                                     shape: .rounded
                                 )
                             },
@@ -967,7 +967,7 @@ struct OutlinedSelectListItemPreview: View {
                                     icon: option.icon,
                                     contentDescription: nil,
                                     voice: .neutral,
-                                    size: .large,
+                                    size: .medium,
                                     shape: .rounded
                                 )
                             }
@@ -1005,7 +1005,7 @@ struct OutlinedSelectListItemPreview: View {
                                     icon: option.icon,
                                     contentDescription: nil,
                                     voice: isChecked ? .positive : .neutral,
-                                    size: .large,
+                                    size: .medium,
                                     shape: .rounded
                                 )
                             }
@@ -1041,7 +1041,7 @@ struct OutlinedSelectListItemPreview: View {
                                     icon: option.icon,
                                     contentDescription: nil,
                                     voice: isChecked ? .positive : .neutral,
-                                    size: .large,
+                                    size: .medium,
                                     shape: .rounded
                                 )
                             },
@@ -1085,7 +1085,7 @@ struct OutlinedSelectListItemPreview: View {
                                 icon: .padlock,
                                 contentDescription: nil,
                                 voice: .neutral,
-                                size: .large,
+                                size: .medium,
                                 shape: .rounded
                             )
                         }
@@ -1103,7 +1103,7 @@ struct OutlinedSelectListItemPreview: View {
                                 icon: .bell,
                                 contentDescription: nil,
                                 voice: .neutral,
-                                size: .large,
+                                size: .medium,
                                 shape: .rounded
                             )
                         },

--- a/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeActionListItem.swift
@@ -27,7 +27,9 @@ public extension LemonadeUi {
     ///   - isLoading: Shows a skeleton loading placeholder instead of content
     ///   - enabled: Flag to define if component is enabled. Defaults to true
     ///   - showDivider: Flag to show a divider below the list item. Defaults to false
-    ///   - leadingAlignment: Vertical alignment of the leading slot. Defaults to `.top`.
+    ///   - leadingAlignment: Vertical alignment of the leading slot. Pass `nil` (the default) to let the
+    ///     component center the leading slot against the text for single-line content (no `topLabel`,
+    ///     `supportText`, or `slotContent`) and top-align it otherwise. Pass an explicit value to override.
     ///   - trailingAlignment: Vertical alignment of the trailing slot and navigation indicator. Defaults to `.center`.
     ///   - labelMaxLines: Maximum number of lines for the label before it truncates. Defaults to `nil` (no limit).
     ///   - labelOverflow: Truncation mode applied to the label when it exceeds `labelMaxLines`. Defaults to `.tail`.
@@ -50,7 +52,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
-        leadingAlignment: VerticalAlignment = .top,
+        leadingAlignment: VerticalAlignment? = nil,
         trailingAlignment: VerticalAlignment = .center,
         labelMaxLines: Int? = nil,
         labelOverflow: Text.TruncationMode = .tail,
@@ -97,7 +99,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
-        leadingAlignment: VerticalAlignment = .top,
+        leadingAlignment: VerticalAlignment? = nil,
         trailingAlignment: VerticalAlignment = .center,
         labelMaxLines: Int? = nil,
         labelOverflow: Text.TruncationMode = .tail,
@@ -140,7 +142,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
-        leadingAlignment: VerticalAlignment = .top,
+        leadingAlignment: VerticalAlignment? = nil,
         trailingAlignment: VerticalAlignment = .center,
         labelMaxLines: Int? = nil,
         labelOverflow: Text.TruncationMode = .tail,
@@ -183,7 +185,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
-        leadingAlignment: VerticalAlignment = .top,
+        leadingAlignment: VerticalAlignment? = nil,
         trailingAlignment: VerticalAlignment = .center,
         labelMaxLines: Int? = nil,
         labelOverflow: Text.TruncationMode = .tail,

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -528,10 +528,9 @@ struct LemonadeListItem_Previews: PreviewProvider {
             )
             
             LemonadeUi.ListItem(
-                label: "Delivery to",
-                supportText: "Metadata",
+                label: "Resource Label",
+                supportText: "09:37 • [Automated TQC TestingStore] Way4 ES 01",
                 showDivider: true,
-                priority: .label,
                 leadingSlot: {
                     LemonadeUi.SymbolContainer(
                         icon: .heart,
@@ -553,7 +552,7 @@ struct LemonadeListItem_Previews: PreviewProvider {
             LemonadeUi.ResourceListItem(
                 label: "Resource Label",
                 value: "$100.00",
-//                supportText: "Metadata",
+                supportText: "09:37 • [Automated TQC TestingStore] Way4 ES 01",
                 showDivider: true,
                 onItemClicked: {},
             ) {

--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -77,7 +77,10 @@ public extension LemonadeUi {
     ///   - isLoading: Shows a skeleton loading placeholder instead of content
     ///   - enabled: Flag to define if component is enabled
     ///   - showDivider: Flag to show a divider below the list item
-    ///   - leadingAlignment: Vertical alignment of the leading slot. Defaults to `.top`.
+    ///   - leadingAlignment: Vertical alignment of the leading slot. Pass `nil` (the default) to let the
+    ///     component decide: it centers the leading slot against the text when the content is a single line
+    ///     (no `topLabel`, `supportText`, or `slotContent`) and top-aligns it otherwise. Pass an explicit
+    ///     value to override this automatic behavior.
     ///   - trailingAlignment: Vertical alignment of the content row — both the label/content and the trailing slot align to it (e.g. `.top` keeps them on the same first line when one wraps). Defaults to `.center`.
     ///   - priority: Which slot claims layout space first when label and trailing content compete for width. Use `.both` to split the width evenly. Defaults to `.trailing`.
     ///   - labelMaxLines: Maximum number of lines for the label before it truncates. Defaults to `nil` (no limit).
@@ -98,7 +101,7 @@ public extension LemonadeUi {
         isLoading: Bool = false,
         enabled: Bool = true,
         showDivider: Bool = false,
-        leadingAlignment: VerticalAlignment = .top,
+        leadingAlignment: VerticalAlignment? = nil,
         trailingAlignment: VerticalAlignment = .center,
         priority: LemonadeListItemPriority = .trailing,
         labelMaxLines: Int? = nil,
@@ -113,12 +116,20 @@ public extension LemonadeUi {
         if isLoading {
             ListItemSkeletonView(showDivider: showDivider)
         } else {
+            // The content is effectively single-line when there is nothing stacked below the
+            // label — no top label, no support text, and no custom slot content. In that case the
+            // leading slot is centered against the lone text line unless the caller explicitly pins
+            // an alignment.
+            let isSingleLineContent = topLabel == nil
+                && supportText == nil
+                && SlotContent.self == EmptyView.self
+
             ListItem(
                 voice: voice,
                 navigationIndicator: navigationIndicator,
                 enabled: enabled,
                 showDivider: showDivider,
-                leadingAlignment: leadingAlignment,
+                leadingAlignment: leadingAlignment ?? (isSingleLineContent ? .center : .top),
                 trailingAlignment: trailingAlignment,
                 priority: priority,
                 onListItemClick: onListItemClick,
@@ -516,8 +527,27 @@ struct LemonadeListItem_Previews: PreviewProvider {
                 supportText: "Support text"
             )
             
-            LemonadeUi.HorizontalDivider()
-                .padding(.vertical, LemonadeTheme.spaces.spacing200)
+            LemonadeUi.ListItem(
+                label: "Delivery to",
+                supportText: "Metadata",
+                showDivider: true,
+                priority: .label,
+                leadingSlot: {
+                    LemonadeUi.SymbolContainer(
+                        icon: .heart,
+                        contentDescription: nil,
+                        size: .medium,
+                        shape: .rounded
+                    )
+                },
+                trailingSlot: {
+                    LemonadeUi.Text(
+                        "$100.00",
+                        textStyle: LemonadeTypography.shared.bodyMediumMedium,
+                        textAlign: .trailing
+                    )
+                }
+            )
             
             // ResourceListItem with divider
             LemonadeUi.ResourceListItem(
@@ -546,7 +576,7 @@ struct LemonadeListItem_Previews: PreviewProvider {
                         icon: .check,
                         contentDescription: nil,
                         voice: .positive,
-                        size: .large,
+                        size: .medium,
                         shape: .rounded
                     )
                 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
@@ -47,7 +47,10 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
-            trailingAlignment: .top,
+            // With support text the content is multi-line, so pin the trailing value to the top to
+            // align it with the label's first line. With a single-line label there's nothing to align
+            // to — center it (and the auto-centered leading slot) against the lone text line instead.
+            trailingAlignment: supportText == nil ? .center : .top,
             onListItemClick: onItemClicked,
             leadingSlot: {
                 leadingSlot()

--- a/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeResourceListItem.swift
@@ -47,9 +47,11 @@ public extension LemonadeUi {
             isLoading: isLoading,
             enabled: enabled,
             showDivider: showDivider,
-            // With support text the content is multi-line, so pin the trailing value to the top to
-            // align it with the label's first line. With a single-line label there's nothing to align
-            // to — center it (and the auto-centered leading slot) against the lone text line instead.
+            // No support text ⇒ treat the row as single-line and center the value (and the
+            // auto-centered leading slot) against the text. SwiftUI drives the content's vertical
+            // position from this alignment, so it must be `.center` for the single-line fix — this
+            // assumes a short, non-wrapping label. With support text, pin to `.top` to align the
+            // value with the label's first line.
             trailingAlignment: supportText == nil ? .center : .top,
             onListItemClick: onItemClicked,
             leadingSlot: {


### PR DESCRIPTION
# Summary

List items with a leading slot but no support text now **center** the leading slot against the single text line instead of pinning it to the top. Multi-line content (support text, top label, or slot content) keeps the existing top alignment so the leading/trailing slots line up with the label's first line. Mirrored across SwiftUI and KMP/Compose.

## Figma component
<!-- N/A — behavioural alignment fix on the existing ListItem family -->

## What changed

- **SwiftUI** — `leadingAlignment` on the string `ListItem` became a `nil`-sentinel resolved once (`isSingleLineContent`); `ActionListItem` overloads forward it; `ResourceListItem` centers the trailing value when there's no support text. `trailingAlignment` stays a plain `.center` default (no behavioural change there).
- **KMP** — content-aware default via a shared private `singleLineLeadingAlignment(topLabel, supportText, slotContent)` helper, applied to `ListItem`/`ActionListItem` defaults; `ResourceListItem` centers the trailing value when single-line.
- **Sample apps** — leading `SymbolContainer` in the list-item example screens switched from large to medium (`ResourceListItemDisplay`, `SelectListItemDisplay`, `ListItemDisplayView`).

## How to test

1. Run composeApp (Android) or the SwiftUI SampleApp.
2. Open the ListItem / ActionListItem / ResourceListItem screens.
3. A single-line item with a leading icon → icon is vertically centered with the label.
4. Add support text (or a top label / slot content) → icon top-aligns with the first line. Passing an explicit alignment still overrides the automatic behaviour.

## API Dump

**Verdict:** NO_CHANGES — no `kmp/<module>/api/*.api` or `*.klib.api` file changed (confirmed via `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci`).

**Changes that are not a concern, and why:**
- The KMP change only alters the *default values* of the existing `leadingVerticalAlignment` parameters (and adds a `private` helper). BCV records parameter signatures, not default-value expressions, so the public API baseline is byte-for-byte identical. `:ui:apiCheck` passes.

**Genuine breaking changes (if any):** None.