### PR TITLE
fix(ui): stop publishing a dependency on compose.desktop.currentOs

### DIFF
--- a/kmp/ui/build.gradle.kts
+++ b/kmp/ui/build.gradle.kts
@@ -36,10 +36,6 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.compose.ui.tooling.preview)
         }
-        val desktopMain by getting
-        desktopMain.dependencies {
-            implementation(compose.desktop.currentOs)
-        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/kmp/ui/dependencies.allowlist
+++ b/kmp/ui/dependencies.allowlist
@@ -11,7 +11,6 @@ api projects.core
 api projects.tokens
 debugImplementation libs.compose.ui.tooling
 implementation compose.components.resources
-implementation compose.desktop.currentOs
 implementation compose.foundation
 implementation compose.runtime
 implementation compose.ui


### PR DESCRIPTION
# Summary

`kmp/ui` declared `implementation(compose.desktop.currentOs)` in `desktopMain`. `currentOs` is resolved at build time against the OS of the machine doing the build — so when CI publishes from a macOS runner, the released pom for `lemonade-ui-desktop` hardcodes:

```xml
<groupId>org.jetbrains.compose.desktop</groupId>
<artifactId>desktop-jvm-macos-arm64</artifactId>
```

That artifact is an aggregator with no jar, and its name is tied to the publisher OS rather than the consumer one. A Gradle consumer gets away with it because Gradle Module Metadata redirects; a **Maven** consumer cannot resolve it on any OS, including macOS. The Unified ePOS SDK ships a Compose Desktop UI to partners who build with Maven, and today it has to carry `exclude(group = "org.jetbrains.compose.desktop")` on every Lemonade dependency to stay usable.

`currentOs` is an **application** concern: it is what drags in the Skiko native renderer for the machine the app will run on. An application should ask for it, and Lemonade own `composeApp` already does (`kmp/composeApp/build.gradle.kts:70`), so the demo app is unaffected. A library must not, because it cannot know where it will run.

## Why this is safe

- Nothing in `ui/src/desktopMain` used it. The only two files there (`Platform.kt`, `SecureFieldModifier.kt`) import `androidx.compose.runtime.Composable` and `androidx.compose.ui.Modifier`, both of which already come from `compose.runtime` / `compose.ui` in `commonMain`. The dependency was dead weight.
- `:ui`, `:expressive`, `:calendar` and `:composeApp` all still compile for desktop.
- `:expressive` and `:calendar` were only inheriting the aggregator transitively through `:ui`, so this fixes them too.
- There are no `desktopTest` source sets and no screenshot tests, so nothing relied on `:ui` transitively providing the Skiko native.
- `kmp/ui/dependencies.allowlist` is updated in the same commit range, as `checkDependencyAllowlist` requires.

Verified by generating the pom on both sides of the change: on `main` it names `desktop-jvm-macos-arm64`; with this commit it is gone, and the remaining Compose dependencies (`runtime-desktop`, `foundation-desktop`, `ui-desktop`, …) are unchanged.

## What consumers see

Resolving `desktopRuntimeClasspath` on both sides of the change:

- **`:composeApp` (the demo app) is byte-for-byte unchanged** — 149 modules before, 149 after, nothing added or removed. It declares its own `currentOs`, so it never relied on `:ui` for the renderer.
- **`:ui`** drops `desktop-jvm-macos-arm64`, `desktop-jvm`, the Skiko native, and **Compose Material 2** (`material`, `material-ripple`), which the aggregator was dragging in. No module in the repo (`ui`, `expressive`, `calendar`) imports `androidx.compose.material.*` — only `material3` — so this was dead weight that existed on the desktop target alone.
- **`:expressive`** drops the same, plus a handful of *lower-version duplicates* (`ui-text:1.10.3`, `foundation-layout:1.10.3`, `skiko-awt:0.9.37.4`) that the aggregator pulled in alongside the `1.11.0-alpha02` / `0.9.40` ones that already won. Nothing is lost; the graph just gets less noisy.

The one consequence worth naming: a desktop consumer that was picking up Material 2 or the Skiko native *incidentally* through Lemonade now has to declare it. That accidental inheritance only ever existed on desktop — it was already absent on Android and iOS — so no consumer could have been depending on it across targets.

## Figma component

N/A — build configuration only, no visual change.

## Screenshot

N/A — no visual change.

## API Dump

No public API changes. `apiCheck` passes and no `api/*.api` or `*.klib.api` baseline file changed — this only removes an `implementation` dependency, which never reaches the ABI.

**Verdict:** NO_CHANGES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

