### PR TITLE
fix(date-picker): align the iOS weekday header with the day grid's first weekday

### DIFF
--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
@@ -146,6 +146,24 @@ enum CalendarUtils {
         return "\(monthFormatter(month)) \(year)"
     }
 
+    /// Rotates 7 Sunday-first weekday labels so index 0 is the calendar's `firstWeekday`.
+    ///
+    /// A month grid from ``generateMonthDays(year:month:calendar:)`` places its first column
+    /// on `calendar.firstWeekday`, so a header row must be rotated with this before rendering
+    /// or its labels drift from the day cells on any non-Sunday-first calendar.
+    ///
+    /// - Parameters:
+    ///   - abbreviations: Exactly 7 labels ordered Sunday through Saturday. Anything past the
+    ///     first 7 is dropped; fewer than 7 are returned unchanged.
+    ///   - calendar: The calendar whose `firstWeekday` decides the rotation.
+    /// - Returns: The labels reordered to start at the calendar's first weekday.
+    static func orderedWeekdayAbbreviations(_ abbreviations: [String], calendar: Calendar) -> [String] {
+        let labels = Array(abbreviations.prefix(7))
+        guard labels.count == 7 else { return labels }
+        let first = calendar.firstWeekday - 1
+        return (0..<7).map { labels[(first + $0) % 7] }
+    }
+
     /// Returns an array of 7 weekday labels starting from the calendar's first weekday.
     ///
     /// - Parameters:

--- a/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
+++ b/swiftui/Sources/Lemonade/Components/Calendar/CalendarUtils.swift
@@ -178,7 +178,6 @@ enum CalendarUtils {
         case .short:
             symbols = calendar.shortWeekdaySymbols
         }
-        let first = calendar.firstWeekday - 1 // 0-indexed
-        return (0..<7).map { symbols[(first + $0) % 7] }
+        return orderedWeekdayAbbreviations(symbols, calendar: calendar)
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeDatePicker.swift
@@ -92,7 +92,9 @@ public extension LemonadeUi {
     ///   - state: Configuration state holding the selected date, min/max bounds.
     ///     Observe ``LemonadeDatePickerState/selectedDate`` to react to user selections.
     ///   - monthFormatter: Formatter that returns the month name for a given month number (1-12).
-    ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday.
+    ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday. The header
+    ///     renders them starting from the current calendar's first weekday, so the labels stay
+    ///     aligned with the day grid on every device region.
     ///   - today: The date treated as "today" — drives both the "today" indicator and the pager's
     ///     initial month. Defaults to `Date()`. Callers can pass a different value (e.g. the
     ///     currently-selected day) to have the pager open on that day's month; the day will also
@@ -139,7 +141,9 @@ public extension LemonadeUi {
     ///     Observe ``LemonadeDateRangePickerState/selectedStartDate`` and
     ///     ``LemonadeDateRangePickerState/selectedEndDate`` to react to user selections.
     ///   - monthFormatter: Formatter that returns the month name for a given month number (1-12).
-    ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday.
+    ///   - weekdayAbbreviations: Exactly 7 items representing Sunday through Saturday. The header
+    ///     renders them starting from the current calendar's first weekday, so the labels stay
+    ///     aligned with the day grid on every device region.
     ///   - today: The date treated as "today" — drives both the "today" indicator and the pager's
     ///     initial month. Defaults to `Date()`. See ``DatePicker(state:monthFormatter:weekdayAbbreviations:today:onMonthDisplayed:)``
     ///     for the intended usage.
@@ -335,7 +339,10 @@ private struct CoreDatePickerView: View {
             Spacer().frame(height: LemonadeTheme.spaces.spacing200)
             
             HStack(spacing: 0) {
-                ForEach(Array(weekdayAbbreviations.prefix(7).enumerated()), id: \.offset) { _, day in
+                ForEach(
+                    Array(CalendarUtils.orderedWeekdayAbbreviations(weekdayAbbreviations, calendar: calendar).enumerated()),
+                    id: \.offset
+                ) { _, day in
                     LemonadeUi.Text(
                         day,
                         textStyle: LemonadeTypography.shared.bodyXSmallOverline,

--- a/swiftui/Tests/LemonadeTests/CalendarUtilsTests.swift
+++ b/swiftui/Tests/LemonadeTests/CalendarUtilsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+@testable import Lemonade
+
+final class CalendarUtilsTests: XCTestCase {
+
+    // The DatePicker header renders the caller's Sunday-first abbreviations, while
+    // generateMonthDays places day cells starting at the calendar's firstWeekday.
+    // These tests pin the invariant that keeps the two aligned: the label at column c
+    // must name the weekday of the dates in column c.
+
+    private let sundayFirst = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+    private func gregorian(firstWeekday: Int) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = firstWeekday
+        return calendar
+    }
+
+    // MARK: - orderedWeekdayAbbreviations
+
+    func testSundayFirstCalendarKeepsLabelsUnchanged() {
+        let labels = CalendarUtils.orderedWeekdayAbbreviations(sundayFirst, calendar: gregorian(firstWeekday: 1))
+
+        XCTAssertEqual(labels, ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"])
+    }
+
+    func testMondayFirstCalendarRotatesLabelsToStartOnMonday() {
+        let labels = CalendarUtils.orderedWeekdayAbbreviations(sundayFirst, calendar: gregorian(firstWeekday: 2))
+
+        XCTAssertEqual(labels, ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"])
+    }
+
+    func testSaturdayFirstCalendarRotatesLabelsToStartOnSaturday() {
+        let labels = CalendarUtils.orderedWeekdayAbbreviations(sundayFirst, calendar: gregorian(firstWeekday: 7))
+
+        XCTAssertEqual(labels, ["Sat", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri"])
+    }
+
+    func testFewerThanSevenLabelsAreReturnedAsIs() {
+        let labels = CalendarUtils.orderedWeekdayAbbreviations(["S", "M"], calendar: gregorian(firstWeekday: 2))
+
+        XCTAssertEqual(labels, ["S", "M"])
+    }
+
+    // MARK: - Header/grid alignment
+
+    // The reported bug: on a Monday-first device, July 13 2026 (a Monday) rendered under
+    // the "S" header because the labels were not rotated to match the grid's columns.
+    func testJuly13th2026RendersUnderMondayOnAMondayFirstCalendar() {
+        let calendar = gregorian(firstWeekday: 2)
+        let labels = CalendarUtils.orderedWeekdayAbbreviations(sundayFirst, calendar: calendar)
+        let days = CalendarUtils.generateMonthDays(year: 2026, month: 7, calendar: calendar)
+
+        let july13 = days.firstIndex { date in
+            calendar.component(.day, from: date) == 13 && calendar.component(.month, from: date) == 7
+        }
+
+        XCTAssertNotNil(july13)
+        XCTAssertEqual(labels[july13! % 7], "Mon")
+    }
+
+    func testEveryColumnLabelMatchesItsDatesWeekdayForAllFirstWeekdays() {
+        for firstWeekday in 1...7 {
+            let calendar = gregorian(firstWeekday: firstWeekday)
+            let labels = CalendarUtils.orderedWeekdayAbbreviations(sundayFirst, calendar: calendar)
+            let days = CalendarUtils.generateMonthDays(year: 2026, month: 7, calendar: calendar)
+
+            XCTAssertEqual(days.count, 42, "firstWeekday \(firstWeekday)")
+            for (index, date) in days.enumerated() {
+                let weekday = calendar.component(.weekday, from: date) // 1=Sun...7=Sat
+                XCTAssertEqual(
+                    labels[index % 7],
+                    sundayFirst[weekday - 1],
+                    "firstWeekday \(firstWeekday), cell \(index)"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Fixes a visual misalignment in the SwiftUI `DatePicker` / `DateRangePicker` month grid, reported by a UK merchant through the Teya app (Zendesk #1106576): July 13 2026 — a Monday — rendered under the "S" (Sunday) header column.

**Root cause:** the weekday header rendered the caller's Sunday-first `weekdayAbbreviations` array verbatim, while `CalendarUtils.generateMonthDays` places day cells starting at `Calendar.current.firstWeekday`. Those two conventions only coincide on Sunday-first regions (e.g. US). On Monday-first regions (UK and most of Europe) every date landed one column left of its label. Date *selection* was always correct — the bug was purely the header/grid alignment.

**Fix:** rotate the header labels by the same calendar's `firstWeekday` before rendering (`CalendarUtils.orderedWeekdayAbbreviations`), so header and grid share one source of truth. The documented `weekdayAbbreviations` contract (Sunday→Saturday) is unchanged, so no caller needs to change. Both `DatePicker` and `DateRangePicker` are fixed — they share `CoreDatePickerView`.

The `InlineCalendar` strip is unaffected (each cell carries its own weekday label, and its `weekdayLabels` helper already honours `firstWeekday`).

## Repro

On a device with Region = United Kingdom (or any Monday-first region), open any screen using `LemonadeUi.DatePicker`. The grid lays out Monday-first while the header stays Sunday-first — all dates shift one column. US-region devices/simulators mask the bug.

## Screenshot

Merchant screenshot (Teya app, "Filter by period"): July 1 (a Wednesday) under "T", July 13 (Monday) under "S". After the fix the header reads M T W T F S S on Monday-first devices, matching the grid.

## Tests

Added `CalendarUtilsTests`:
- label rotation for Sunday-first / Monday-first / Saturday-first calendars,
- the reported case — July 13 2026 must sit under "Mon" on a Monday-first calendar,
- an exhaustive invariant: for every `firstWeekday` 1–7, every one of the 42 grid cells' weekday matches its column label.

`swift test`: 20 tests, 0 failures.

## API Dump

No public API changes (Swift-only change; no `kmp/<module>/api` files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
