### PR TITLE
fix(SymbolContainer): align 2XL to 72dp / radius 20dp with Figma

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -351,7 +351,7 @@ private fun SymbolContainerShape.resolveShape(size: SymbolContainerSize): Shape 
             SymbolContainerSize.Medium -> LocalShapes.current.radius300
             SymbolContainerSize.Large -> LocalShapes.current.radius400
             SymbolContainerSize.XLarge -> LocalShapes.current.radius500
-            SymbolContainerSize.XXLarge -> LocalShapes.current.radius600
+            SymbolContainerSize.XXLarge -> LocalShapes.current.radius500
         }
     }
 
@@ -401,7 +401,7 @@ private fun SymbolContainerSize.defaultSymbolContainerPlatformDimensions(): Symb
         )
 
         SymbolContainerSize.XXLarge -> SymbolContainerPlatformDimensions(
-            containerSize = LocalSizes.current.size2000,
+            containerSize = LocalSizes.current.size1800,
             contentSize = LocalSizes.current.size1000,
             lemonadeIconSize = LemonadeAssetSize.XXLarge,
             textStyle = LocalTypographies.current.headingSmall,

--- a/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSymbolContainer.swift
@@ -67,7 +67,7 @@ public enum SymbolContainerSize {
         case .medium: return LemonadeTheme.sizes.size1000
         case .large: return LemonadeTheme.sizes.size1200
         case .xLarge: return LemonadeTheme.sizes.size1600
-        case .xxLarge: return LemonadeTheme.sizes.size2000
+        case .xxLarge: return LemonadeTheme.sizes.size1800
         }
     }
 
@@ -382,7 +382,7 @@ private struct LemonadeSymbolContainerView<Content: View, Badge: View>: View {
         case .medium: LemonadeTheme.radius.radius300
         case .large: LemonadeTheme.radius.radius400
         case .xLarge: LemonadeTheme.radius.radius500
-        case .xxLarge: LemonadeTheme.radius.radius600
+        case .xxLarge: LemonadeTheme.radius.radius500
         }
     }
 


### PR DESCRIPTION
## What
Fixes the **2XL (XXLarge)** `SymbolContainer` size, which had drifted from the Figma spec:
- container **80dp → 72dp** (`size2000` → `size1800`)
- Rounded corner radius **24dp → 20dp** (`radius600` → `radius500`)

Applied on both platforms: **KMP** (`SymbolContainer.kt`) and **SwiftUI** (`LemonadeSymbolContainer.swift`). `contentSize`, icon size and text style are unchanged.

## Why
Figma defines 2XL as 72dp / 20dp radius; the implementation had drifted to 80dp / 24dp. This realigns the component with the source of truth.

## Impact
Affects every consumer of `SymbolContainer` size **XXLarge** (~25 usages in the Teya app: side menu, terminals, settlement accounts/preferences, risk visibility, card front, etc.) — each shrinks by 8dp with slightly tighter corners. Intended visual change.

## Validation
Rendered the real component on an Android emulator, before vs after:

| | Container | Radius |
|---|---|---|
| Before (`main`) | 80dp | 24dp |
| After (this branch) | 72dp | 20dp |

Fill image and icon both clip cleanly to the new radius. _(Before/after screenshot attached below.)_
<img width="2232" height="467" alt="symbolcontainer_2xl_before_after" src="https://github.com/user-attachments/assets/ef142550-cb66-416a-bc5f-462219c3b8a0" />

## API
No public API change — the `XXLarge` enum entry is unchanged, only its internal value. `apiCheck`: **NO_CHANGES**.
