### PR TITLE
Add ToastAnchor to position a toast above a bottom action button

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -182,6 +182,29 @@ internal fun ToastDisplay() {
                 },
             )
         }
+
+        ToastSection("Anchor") {
+            LemonadeUi.Button(
+                label = "Bottom (default)",
+                onClick = {
+                    toastState.show(
+                        label = "Default bottom position",
+                        voice = ToastVoice.Neutral,
+                        anchor = ToastAnchor.Bottom,
+                    )
+                },
+            )
+            LemonadeUi.Button(
+                label = "Above Bottom Action Button",
+                onClick = {
+                    toastState.show(
+                        label = "Above Bottom Action Button",
+                        voice = ToastVoice.Success,
+                        anchor = ToastAnchor.AboveBottomActionButton,
+                    )
+                },
+            )
+        }
     }
 }
 

--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -2,7 +2,9 @@ package com.teya.lemonade
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeIcons
 
 @Composable
@@ -183,14 +185,13 @@ internal fun ToastDisplay() {
             )
         }
 
-        ToastSection("Anchor") {
+        ToastSection("Padding") {
             LemonadeUi.Button(
                 label = "Bottom (default)",
                 onClick = {
                     toastState.show(
                         label = "Default bottom position",
                         voice = ToastVoice.Neutral,
-                        anchor = ToastAnchor.Bottom,
                     )
                 },
             )
@@ -200,7 +201,7 @@ internal fun ToastDisplay() {
                     toastState.show(
                         label = "Above Bottom Action Button",
                         voice = ToastVoice.Success,
-                        anchor = ToastAnchor.AboveBottomActionButton,
+                        paddingValues = PaddingValues(bottom = 112.dp),
                     )
                 },
             )

--- a/kmp/ui/api/android/ui.api
+++ b/kmp/ui/api/android/ui.api
@@ -369,9 +369,11 @@ public final class com/teya/lemonade/LemonadeToastState {
 	public fun <init> ()V
 	public final fun dismiss ()V
 	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;Z)V
-	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final synthetic fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZILjava/lang/Object;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;ILjava/lang/Object;)V
 }
 
 public final class com/teya/lemonade/LemonadeTypefacesKt {
@@ -560,6 +562,14 @@ public final class com/teya/lemonade/TileKt {
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lcom/teya/lemonade/core/LemonadeTileOrientation;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/teya/lemonade/ToastAnchor : java/lang/Enum {
+	public static final field AboveBottomActionButton Lcom/teya/lemonade/ToastAnchor;
+	public static final field Bottom Lcom/teya/lemonade/ToastAnchor;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/teya/lemonade/ToastAnchor;
+	public static fun values ()[Lcom/teya/lemonade/ToastAnchor;
 }
 
 public abstract class com/teya/lemonade/ToastDuration {

--- a/kmp/ui/api/android/ui.api
+++ b/kmp/ui/api/android/ui.api
@@ -370,10 +370,10 @@ public final class com/teya/lemonade/LemonadeToastState {
 	public final fun dismiss ()V
 	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;Z)V
 	public final synthetic fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;)V
+	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZILjava/lang/Object;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;ILjava/lang/Object;)V
 }
 
 public final class com/teya/lemonade/LemonadeTypefacesKt {
@@ -562,14 +562,6 @@ public final class com/teya/lemonade/TileKt {
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lcom/teya/lemonade/core/LemonadeTileOrientation;Landroidx/compose/runtime/Composer;III)V
-}
-
-public final class com/teya/lemonade/ToastAnchor : java/lang/Enum {
-	public static final field AboveBottomActionButton Lcom/teya/lemonade/ToastAnchor;
-	public static final field Bottom Lcom/teya/lemonade/ToastAnchor;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/teya/lemonade/ToastAnchor;
-	public static fun values ()[Lcom/teya/lemonade/ToastAnchor;
 }
 
 public abstract class com/teya/lemonade/ToastDuration {

--- a/kmp/ui/api/desktop/ui.api
+++ b/kmp/ui/api/desktop/ui.api
@@ -363,10 +363,10 @@ public final class com/teya/lemonade/LemonadeToastState {
 	public final fun dismiss ()V
 	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;Z)V
 	public final synthetic fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;)V
+	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZILjava/lang/Object;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;ILjava/lang/Object;)V
 }
 
 public final class com/teya/lemonade/LemonadeTypographyExtensionsKt {
@@ -534,14 +534,6 @@ public final class com/teya/lemonade/TileKt {
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lcom/teya/lemonade/core/LemonadeTileOrientation;Landroidx/compose/runtime/Composer;III)V
-}
-
-public final class com/teya/lemonade/ToastAnchor : java/lang/Enum {
-	public static final field AboveBottomActionButton Lcom/teya/lemonade/ToastAnchor;
-	public static final field Bottom Lcom/teya/lemonade/ToastAnchor;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/teya/lemonade/ToastAnchor;
-	public static fun values ()[Lcom/teya/lemonade/ToastAnchor;
 }
 
 public abstract class com/teya/lemonade/ToastDuration {

--- a/kmp/ui/api/desktop/ui.api
+++ b/kmp/ui/api/desktop/ui.api
@@ -362,9 +362,11 @@ public final class com/teya/lemonade/LemonadeToastState {
 	public fun <init> ()V
 	public final fun dismiss ()V
 	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;Z)V
-	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final synthetic fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun show (Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZILjava/lang/Object;)V
 	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun show$default (Lcom/teya/lemonade/LemonadeToastState;Ljava/lang/String;Lcom/teya/lemonade/ToastVoice;Lcom/teya/lemonade/core/LemonadeIcons;Lcom/teya/lemonade/ToastDuration;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Lcom/teya/lemonade/ToastAnchor;ILjava/lang/Object;)V
 }
 
 public final class com/teya/lemonade/LemonadeTypographyExtensionsKt {
@@ -532,6 +534,14 @@ public final class com/teya/lemonade/TileKt {
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 	public static final synthetic fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Tile (Lcom/teya/lemonade/LemonadeUi;Ljava/lang/String;Lcom/teya/lemonade/core/LemonadeIcons;Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/teya/lemonade/core/LemonadeTileVariant;Lcom/teya/lemonade/core/LemonadeTileOrientation;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/teya/lemonade/ToastAnchor : java/lang/Enum {
+	public static final field AboveBottomActionButton Lcom/teya/lemonade/ToastAnchor;
+	public static final field Bottom Lcom/teya/lemonade/ToastAnchor;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/teya/lemonade/ToastAnchor;
+	public static fun values ()[Lcom/teya/lemonade/ToastAnchor;
 }
 
 public abstract class com/teya/lemonade/ToastDuration {

--- a/kmp/ui/api/ui.klib.api
+++ b/kmp/ui/api/ui.klib.api
@@ -33,6 +33,17 @@ final enum class com.teya.lemonade/TextFieldSize : kotlin/Enum<com.teya.lemonade
     final fun values(): kotlin/Array<com.teya.lemonade/TextFieldSize> // com.teya.lemonade/TextFieldSize.values|values#static(){}[0]
 }
 
+final enum class com.teya.lemonade/ToastAnchor : kotlin/Enum<com.teya.lemonade/ToastAnchor> { // com.teya.lemonade/ToastAnchor|null[0]
+    enum entry AboveBottomActionButton // com.teya.lemonade/ToastAnchor.AboveBottomActionButton|null[0]
+    enum entry Bottom // com.teya.lemonade/ToastAnchor.Bottom|null[0]
+
+    final val entries // com.teya.lemonade/ToastAnchor.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.teya.lemonade/ToastAnchor> // com.teya.lemonade/ToastAnchor.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.teya.lemonade/ToastAnchor // com.teya.lemonade/ToastAnchor.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.teya.lemonade/ToastAnchor> // com.teya.lemonade/ToastAnchor.values|values#static(){}[0]
+}
+
 final enum class com.teya.lemonade/ToastVoice : kotlin/Enum<com.teya.lemonade/ToastVoice> { // com.teya.lemonade/ToastVoice|null[0]
     enum entry Error // com.teya.lemonade/ToastVoice.Error|null[0]
     enum entry Loading // com.teya.lemonade/ToastVoice.Loading|null[0]
@@ -215,6 +226,7 @@ final class com.teya.lemonade/LemonadeToastState { // com.teya.lemonade/Lemonade
     final fun dismiss() // com.teya.lemonade/LemonadeToastState.dismiss|dismiss(){}[0]
     final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean){}[0]
     final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ..., kotlin/String? = ..., kotlin/Function0<kotlin/Unit>? = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean;kotlin.String?;kotlin.Function0<kotlin.Unit>?){}[0]
+    final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ..., kotlin/String? = ..., kotlin/Function0<kotlin/Unit>? = ..., com.teya.lemonade/ToastAnchor = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean;kotlin.String?;kotlin.Function0<kotlin.Unit>?;com.teya.lemonade.ToastAnchor){}[0]
 }
 
 final class com.teya.lemonade/NavigationAction { // com.teya.lemonade/NavigationAction|null[0]

--- a/kmp/ui/api/ui.klib.api
+++ b/kmp/ui/api/ui.klib.api
@@ -33,17 +33,6 @@ final enum class com.teya.lemonade/TextFieldSize : kotlin/Enum<com.teya.lemonade
     final fun values(): kotlin/Array<com.teya.lemonade/TextFieldSize> // com.teya.lemonade/TextFieldSize.values|values#static(){}[0]
 }
 
-final enum class com.teya.lemonade/ToastAnchor : kotlin/Enum<com.teya.lemonade/ToastAnchor> { // com.teya.lemonade/ToastAnchor|null[0]
-    enum entry AboveBottomActionButton // com.teya.lemonade/ToastAnchor.AboveBottomActionButton|null[0]
-    enum entry Bottom // com.teya.lemonade/ToastAnchor.Bottom|null[0]
-
-    final val entries // com.teya.lemonade/ToastAnchor.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<com.teya.lemonade/ToastAnchor> // com.teya.lemonade/ToastAnchor.entries.<get-entries>|<get-entries>#static(){}[0]
-
-    final fun valueOf(kotlin/String): com.teya.lemonade/ToastAnchor // com.teya.lemonade/ToastAnchor.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<com.teya.lemonade/ToastAnchor> // com.teya.lemonade/ToastAnchor.values|values#static(){}[0]
-}
-
 final enum class com.teya.lemonade/ToastVoice : kotlin/Enum<com.teya.lemonade/ToastVoice> { // com.teya.lemonade/ToastVoice|null[0]
     enum entry Error // com.teya.lemonade/ToastVoice.Error|null[0]
     enum entry Loading // com.teya.lemonade/ToastVoice.Loading|null[0]
@@ -226,7 +215,7 @@ final class com.teya.lemonade/LemonadeToastState { // com.teya.lemonade/Lemonade
     final fun dismiss() // com.teya.lemonade/LemonadeToastState.dismiss|dismiss(){}[0]
     final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean){}[0]
     final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ..., kotlin/String? = ..., kotlin/Function0<kotlin/Unit>? = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean;kotlin.String?;kotlin.Function0<kotlin.Unit>?){}[0]
-    final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ..., kotlin/String? = ..., kotlin/Function0<kotlin/Unit>? = ..., com.teya.lemonade/ToastAnchor = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean;kotlin.String?;kotlin.Function0<kotlin.Unit>?;com.teya.lemonade.ToastAnchor){}[0]
+    final fun show(kotlin/String, com.teya.lemonade/ToastVoice = ..., com.teya.lemonade.core/LemonadeIcons? = ..., com.teya.lemonade/ToastDuration = ..., kotlin/Boolean = ..., kotlin/String? = ..., kotlin/Function0<kotlin/Unit>? = ..., androidx.compose.foundation.layout/PaddingValues? = ...) // com.teya.lemonade/LemonadeToastState.show|show(kotlin.String;com.teya.lemonade.ToastVoice;com.teya.lemonade.core.LemonadeIcons?;com.teya.lemonade.ToastDuration;kotlin.Boolean;kotlin.String?;kotlin.Function0<kotlin.Unit>?;androidx.compose.foundation.layout.PaddingValues?){}[0]
 }
 
 final class com.teya.lemonade/NavigationAction { // com.teya.lemonade/NavigationAction|null[0]

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -193,6 +193,34 @@ public class LemonadeToastState {
         )
     }
 
+    @Deprecated(
+        message = "Use show() with an anchor parameter to position the toast.",
+        replaceWith = ReplaceWith(
+            expression = "show(label, voice, icon, duration, dismissible, actionLabel, onAction, ToastAnchor.Bottom)",
+        ),
+        level = DeprecationLevel.HIDDEN,
+    )
+    public fun show(
+        label: String,
+        voice: ToastVoice = ToastVoice.Neutral,
+        icon: LemonadeIcons? = null,
+        duration: ToastDuration = ToastDuration.Short,
+        dismissible: Boolean = true,
+        actionLabel: String? = null,
+        onAction: (() -> Unit)? = null,
+    ) {
+        show(
+            label = label,
+            voice = voice,
+            icon = icon,
+            duration = duration,
+            dismissible = dismissible,
+            actionLabel = actionLabel,
+            onAction = onAction,
+            anchor = ToastAnchor.Bottom,
+        )
+    }
+
     /** Programmatically dismiss the current toast. */
     public fun dismiss() {
         currentToast = null

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
@@ -36,6 +39,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -85,17 +89,6 @@ public sealed class ToastDuration(internal val millis: kotlin.Long) {
     }
 }
 
-/**
- * Where a toast anchors itself at the bottom of the screen.
- */
-public enum class ToastAnchor {
-    /** Default position, just above the navigation/gesture bar. */
-    Bottom,
-
-    /** Raised clear of a screen's persistent bottom action button. */
-    AboveBottomActionButton,
-}
-
 internal data class ToastData(
     val label: String,
     val voice: ToastVoice,
@@ -105,7 +98,7 @@ internal data class ToastData(
     val id: Int,
     val actionLabel: String?,
     val onAction: (() -> Unit)?,
-    val anchor: ToastAnchor,
+    val paddingValues: PaddingValues?,
 )
 
 /**
@@ -168,7 +161,12 @@ public class LemonadeToastState {
      * @param actionLabel Optional label for the action button shown at the trailing end of the toast.
      * @param onAction Optional callback invoked when the action button is tapped. The button is only shown
      *   when both [actionLabel] and [onAction] are non-null.
-     * @param anchor Where the toast sits at the bottom of the screen. Defaults to [ToastAnchor.Bottom].
+     * @param paddingValues Extra space to clear around the toast, e.g. to raise it clear of a screen's
+     *   persistent bottom action button, or to inset it from a side element. Bottom/start/end are honored;
+     *   a zero edge falls back to the standard margin for that edge (there's no way to tell "unset" from
+     *   "explicitly zero" on a plain [PaddingValues]). The top inset is never honored — the toast is always
+     *   bottom-anchored with intrinsic height, so it has no visible effect. Defaults to `null` (standard
+     *   margins on every edge).
      */
     public fun show(
         label: String,
@@ -178,7 +176,7 @@ public class LemonadeToastState {
         dismissible: Boolean = true,
         actionLabel: String? = null,
         onAction: (() -> Unit)? = null,
-        anchor: ToastAnchor = ToastAnchor.Bottom,
+        paddingValues: PaddingValues? = null,
     ) {
         currentToast = ToastData(
             label = label,
@@ -189,14 +187,14 @@ public class LemonadeToastState {
             id = nextId++,
             actionLabel = actionLabel,
             onAction = onAction,
-            anchor = anchor,
+            paddingValues = paddingValues,
         )
     }
 
     @Deprecated(
-        message = "Use show() with an anchor parameter to position the toast.",
+        message = "Use show() with a paddingValues parameter to position the toast.",
         replaceWith = ReplaceWith(
-            expression = "show(label, voice, icon, duration, dismissible, actionLabel, onAction, ToastAnchor.Bottom)",
+            expression = "show(label, voice, icon, duration, dismissible, actionLabel, onAction, null)",
         ),
         level = DeprecationLevel.HIDDEN,
     )
@@ -217,7 +215,7 @@ public class LemonadeToastState {
             dismissible = dismissible,
             actionLabel = actionLabel,
             onAction = onAction,
-            anchor = ToastAnchor.Bottom,
+            paddingValues = null,
         )
     }
 
@@ -395,7 +393,6 @@ private fun CoreToast(
 }
 
 private const val DRAG_DISMISS_THRESHOLD_DP = 25
-private const val ABOVE_BOTTOM_ACTION_BUTTON_PADDING_DP = 112
 private const val DRAG_FADE_MULTIPLIER = 4
 
 /**
@@ -428,10 +425,19 @@ public fun LemonadeToastHost(
             val toast = toastState.currentToast
             val haptic = LocalHapticFeedback.current
             val spaces = LocalSpaces.current
-            val bottomPadding = when (toast?.anchor ?: ToastAnchor.Bottom) {
-                ToastAnchor.Bottom -> spaces.spacing600
-                ToastAnchor.AboveBottomActionButton -> ABOVE_BOTTOM_ACTION_BUTTON_PADDING_DP.dp
-            }
+            val layoutDirection = LocalLayoutDirection.current
+            // A zero edge is treated as "not overridden" and falls back to the default — `show()` isn't
+            // @Composable, so a caller can't pull the real spacing600/spacing400 token values to build a
+            // PaddingValues that only overrides one edge. The top inset is never honored: the toast is
+            // always bottom-anchored with intrinsic height, so extra top padding only adds invisible space
+            // above it — it has no visible effect on where the toast sits.
+            val overridePadding = toast?.paddingValues
+            val bottomPadding = overridePadding?.calculateBottomPadding()?.takeIf { it > 0.dp }
+                ?: spaces.spacing600
+            val startPadding = overridePadding?.calculateStartPadding(layoutDirection)?.takeIf { it > 0.dp }
+                ?: spaces.spacing400
+            val endPadding = overridePadding?.calculateEndPadding(layoutDirection)?.takeIf { it > 0.dp }
+                ?: spaces.spacing400
 
             // Haptic feedback + auto-dismiss timer
             LaunchedEffect(toast?.id) {
@@ -466,7 +472,7 @@ public fun LemonadeToastHost(
                                 dampingRatio = 0.8f,
                                 stiffness = Spring.StiffnessMediumLow,
                             ),
-                            targetOffsetY = { toastHeight -> toastHeight * 3 },
+                            targetOffsetY = { hostHeightPx },
                         ),
                     ).using(SizeTransform(clip = false) { _, _ -> snap() })
                 },
@@ -475,7 +481,7 @@ public fun LemonadeToastHost(
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
                     .padding(bottom = bottomPadding)
-                    .padding(horizontal = spaces.spacing400),
+                    .padding(start = startPadding, end = endPadding),
             ) { animatedToast ->
                 if (animatedToast != null) {
                     var offsetY by remember(animatedToast.id) { mutableStateOf(0f) }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -85,6 +85,17 @@ public sealed class ToastDuration(internal val millis: kotlin.Long) {
     }
 }
 
+/**
+ * Where a toast anchors itself at the bottom of the screen.
+ */
+public enum class ToastAnchor {
+    /** Default position, just above the navigation/gesture bar. */
+    Bottom,
+
+    /** Raised clear of a screen's persistent bottom action button. */
+    AboveBottomActionButton,
+}
+
 internal data class ToastData(
     val label: String,
     val voice: ToastVoice,
@@ -94,6 +105,7 @@ internal data class ToastData(
     val id: Int,
     val actionLabel: String?,
     val onAction: (() -> Unit)?,
+    val anchor: ToastAnchor,
 )
 
 /**
@@ -156,6 +168,7 @@ public class LemonadeToastState {
      * @param actionLabel Optional label for the action button shown at the trailing end of the toast.
      * @param onAction Optional callback invoked when the action button is tapped. The button is only shown
      *   when both [actionLabel] and [onAction] are non-null.
+     * @param anchor Where the toast sits at the bottom of the screen. Defaults to [ToastAnchor.Bottom].
      */
     public fun show(
         label: String,
@@ -165,6 +178,7 @@ public class LemonadeToastState {
         dismissible: Boolean = true,
         actionLabel: String? = null,
         onAction: (() -> Unit)? = null,
+        anchor: ToastAnchor = ToastAnchor.Bottom,
     ) {
         currentToast = ToastData(
             label = label,
@@ -175,6 +189,7 @@ public class LemonadeToastState {
             id = nextId++,
             actionLabel = actionLabel,
             onAction = onAction,
+            anchor = anchor,
         )
     }
 
@@ -352,6 +367,7 @@ private fun CoreToast(
 }
 
 private const val DRAG_DISMISS_THRESHOLD_DP = 25
+private const val ABOVE_BOTTOM_ACTION_BUTTON_PADDING_DP = 112
 private const val DRAG_FADE_MULTIPLIER = 4
 
 /**
@@ -384,6 +400,10 @@ public fun LemonadeToastHost(
             val toast = toastState.currentToast
             val haptic = LocalHapticFeedback.current
             val spaces = LocalSpaces.current
+            val bottomPadding = when (toast?.anchor ?: ToastAnchor.Bottom) {
+                ToastAnchor.Bottom -> spaces.spacing600
+                ToastAnchor.AboveBottomActionButton -> ABOVE_BOTTOM_ACTION_BUTTON_PADDING_DP.dp
+            }
 
             // Haptic feedback + auto-dismiss timer
             LaunchedEffect(toast?.id) {
@@ -426,7 +446,7 @@ public fun LemonadeToastHost(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
-                    .padding(bottom = spaces.spacing600)
+                    .padding(bottom = bottomPadding)
                     .padding(horizontal = spaces.spacing400),
             ) { animatedToast ->
                 if (animatedToast != null) {

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -161,12 +161,11 @@ struct ToastDisplayView: View {
                 }
             }
 
-            Section("Anchor") {
+            Section("Padding") {
                 Button("Bottom (default)") {
                     toastManager.show(
                         label: "Default bottom position",
-                        voice: .neutral,
-                        anchor: .bottom
+                        voice: .neutral
                     )
                 }
 
@@ -174,7 +173,7 @@ struct ToastDisplayView: View {
                     toastManager.show(
                         label: "Item added to cart",
                         voice: .success,
-                        anchor: .aboveBottomActionButton
+                        paddingValues: EdgeInsets(top: 0, leading: 0, bottom: 112, trailing: 0)
                     )
                 }
             }

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -161,6 +161,24 @@ struct ToastDisplayView: View {
                 }
             }
 
+            Section("Anchor") {
+                Button("Bottom (default)") {
+                    toastManager.show(
+                        label: "Default bottom position",
+                        voice: .neutral,
+                        anchor: .bottom
+                    )
+                }
+
+                Button("Above Bottom Action Button") {
+                    toastManager.show(
+                        label: "Item added to cart",
+                        voice: .success,
+                        anchor: .aboveBottomActionButton
+                    )
+                }
+            }
+
             Section("Keyboard Handling") {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Tap the text field to open keyboard, then show a toast:")

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
@@ -231,17 +231,26 @@ struct ToastItemView: View {
     }
 
     private var toastContent: some View {
-        LemonadeUi.Toast(
-            label: toast.label,
-            voice: toast.voice,
-            icon: toast.icon,
-            actionLabel: toast.actionLabel,
-            onAction: toast.onAction
-        )
-        .frame(maxWidth: .infinity)
-        .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
-        .padding(.horizontal, .space.spacing200)
-        .padding(.bottom, toast.anchor.bottomPadding)
+        VStack(spacing: 0) {
+            LemonadeUi.Toast(
+                label: toast.label,
+                voice: toast.voice,
+                icon: toast.icon,
+                actionLabel: toast.actionLabel,
+                onAction: toast.onAction
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
+            .padding(.horizontal, .space.spacing200)
+            .contentShape(Rectangle())
+            .simultaneousGesture(dismissGesture)
+
+            // Clears whatever sits below the toast (e.g. a bottom action button). Kept out of
+            // the contentShape/gesture above so it stays non-interactive and touches pass through.
+            Color.clear
+                .frame(height: toast.anchor.bottomPadding)
+                .allowsHitTesting(false)
+        }
         .background(
             GeometryReader { geometry in
                 Color.clear
@@ -252,9 +261,8 @@ struct ToastItemView: View {
                         onHeightChanged(newHeight)
                     }
             }
+            .allowsHitTesting(false)
         )
-        .contentShape(Rectangle())
-        .simultaneousGesture(dismissGesture)
     }
 
     private var dismissGesture: some Gesture {

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
@@ -241,14 +241,15 @@ struct ToastItemView: View {
             )
             .frame(maxWidth: .infinity)
             .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
-            .padding(.horizontal, .space.spacing200)
+            .padding(.leading, resolvedPadding(toast.paddingValues?.leading, default: .space.spacing200))
+            .padding(.trailing, resolvedPadding(toast.paddingValues?.trailing, default: .space.spacing200))
             .contentShape(Rectangle())
             .simultaneousGesture(dismissGesture)
 
             // Clears whatever sits below the toast (e.g. a bottom action button). Kept out of
             // the contentShape/gesture above so it stays non-interactive and touches pass through.
             Color.clear
-                .frame(height: toast.anchor.bottomPadding)
+                .frame(height: resolvedPadding(toast.paddingValues?.bottom, default: .space.spacing400))
                 .allowsHitTesting(false)
         }
         .background(
@@ -278,13 +279,11 @@ struct ToastItemView: View {
     }
 }
 
-private extension LemonadeToastAnchor {
-    // Not a spacing-scale token — matches the height + margin of a standard bottom action
-    // button so `.aboveBottomActionButton` toasts clear it.
-    var bottomPadding: CGFloat {
-        switch self {
-        case .bottom: return .space.spacing400
-        case .aboveBottomActionButton: return 112
-        }
-    }
+// A zero edge is treated as "not overridden" and falls back to the default — `show()` isn't a
+// SwiftUI view, so a caller can't pull the real spacing200/spacing400 token values to build an
+// EdgeInsets that only overrides one edge. `top` is never read: the toast is always bottom-anchored
+// with intrinsic height, so extra top inset only adds invisible space above it — no visible effect.
+private func resolvedPadding(_ override: CGFloat?, default defaultValue: CGFloat) -> CGFloat {
+    guard let override, override > 0 else { return defaultValue }
+    return override
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
@@ -241,7 +241,7 @@ struct ToastItemView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
         .padding(.horizontal, .space.spacing200)
-        .padding(.bottom, .space.spacing400)
+        .padding(.bottom, toast.anchor.bottomPadding)
         .background(
             GeometryReader { geometry in
                 Color.clear
@@ -267,5 +267,16 @@ struct ToastItemView: View {
                 guard toast.isDismissible else { return }
                 onDragEnded(value.translation.height)
             }
+    }
+}
+
+private extension LemonadeToastAnchor {
+    // Not a spacing-scale token — matches the height + margin of a standard bottom action
+    // button so `.aboveBottomActionButton` toasts clear it.
+    var bottomPadding: CGFloat {
+        switch self {
+        case .bottom: return .space.spacing400
+        case .aboveBottomActionButton: return 112
+        }
     }
 }

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
@@ -64,16 +64,6 @@ public enum LemonadeToastDuration: Sendable, Equatable {
     }
 }
 
-// MARK: - Toast Anchor
-
-/// Where a toast anchors itself at the bottom of the screen.
-public enum LemonadeToastAnchor: Sendable {
-    /// Default position, just above the safe-area / home indicator.
-    case bottom
-    /// Raised clear of a screen's persistent bottom action button.
-    case aboveBottomActionButton
-}
-
 // MARK: - Toast Item
 
 /// Represents a toast notification to be displayed.
@@ -86,7 +76,7 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
     public let isDismissible: Bool
     public let actionLabel: String?
     public let onAction: (@MainActor @Sendable () -> Void)?
-    public let anchor: LemonadeToastAnchor
+    public let paddingValues: EdgeInsets?
 
     public init(
         id: UUID = UUID(),
@@ -97,7 +87,7 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
         isDismissible: Bool = true,
         actionLabel: String? = nil,
         onAction: (@MainActor @Sendable () -> Void)? = nil,
-        anchor: LemonadeToastAnchor = .bottom
+        paddingValues: EdgeInsets? = nil
     ) {
         self.id = id
         self.label = label
@@ -107,7 +97,7 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
         self.isDismissible = isDismissible
         self.actionLabel = actionLabel
         self.onAction = onAction
-        self.anchor = anchor
+        self.paddingValues = paddingValues
     }
 
     public static func == (lhs: LemonadeToastItem, rhs: LemonadeToastItem) -> Bool {
@@ -166,7 +156,12 @@ public final class LemonadeToastManager: ObservableObject {
     ///   - dismissible: Whether the toast can be dismissed by swiping. Ignored (forced off) when `voice` is `.loading`.
     ///   - actionLabel: Optional label for the action button shown at the trailing end of the toast.
     ///   - onAction: Optional callback invoked when the action button is tapped. The button is only shown when both `actionLabel` and `onAction` are non-nil.
-    ///   - anchor: Where the toast sits at the bottom of the screen. Defaults to `.bottom`.
+    ///   - paddingValues: Extra space to clear around the toast, e.g. to raise it clear of a screen's
+    ///     persistent bottom action button, or to inset it from a side element. Bottom/leading/trailing
+    ///     are honored; a zero edge falls back to the standard margin for that edge (there's no way to
+    ///     tell "unset" from "explicitly zero" on a plain `EdgeInsets`). The top inset is never honored —
+    ///     the toast is always bottom-anchored with intrinsic height, so it has no visible effect.
+    ///     Defaults to `nil` (standard margins on every edge).
     ///
     /// Use `.loading` to communicate an ongoing action (e.g. "Downloading your document…"). A loading
     /// toast shows a spinner and persists until you call ``dismiss()`` or replace it with another `show`.
@@ -178,7 +173,7 @@ public final class LemonadeToastManager: ObservableObject {
         dismissible: Bool = true,
         actionLabel: String? = nil,
         onAction: (@MainActor @Sendable () -> Void)? = nil,
-        anchor: LemonadeToastAnchor = .bottom
+        paddingValues: EdgeInsets? = nil
     ) {
         let toast = LemonadeToastItem(
             label: label,
@@ -189,7 +184,7 @@ public final class LemonadeToastManager: ObservableObject {
             isDismissible: voice == .loading ? false : dismissible,
             actionLabel: actionLabel,
             onAction: onAction,
-            anchor: anchor
+            paddingValues: paddingValues
         )
 
         if currentToast != nil {

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastManager.swift
@@ -64,6 +64,16 @@ public enum LemonadeToastDuration: Sendable, Equatable {
     }
 }
 
+// MARK: - Toast Anchor
+
+/// Where a toast anchors itself at the bottom of the screen.
+public enum LemonadeToastAnchor: Sendable {
+    /// Default position, just above the safe-area / home indicator.
+    case bottom
+    /// Raised clear of a screen's persistent bottom action button.
+    case aboveBottomActionButton
+}
+
 // MARK: - Toast Item
 
 /// Represents a toast notification to be displayed.
@@ -76,6 +86,7 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
     public let isDismissible: Bool
     public let actionLabel: String?
     public let onAction: (@MainActor @Sendable () -> Void)?
+    public let anchor: LemonadeToastAnchor
 
     public init(
         id: UUID = UUID(),
@@ -85,7 +96,8 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
         duration: LemonadeToastDuration = .short,
         isDismissible: Bool = true,
         actionLabel: String? = nil,
-        onAction: (@MainActor @Sendable () -> Void)? = nil
+        onAction: (@MainActor @Sendable () -> Void)? = nil,
+        anchor: LemonadeToastAnchor = .bottom
     ) {
         self.id = id
         self.label = label
@@ -95,6 +107,7 @@ public struct LemonadeToastItem: Identifiable, Equatable, Sendable {
         self.isDismissible = isDismissible
         self.actionLabel = actionLabel
         self.onAction = onAction
+        self.anchor = anchor
     }
 
     public static func == (lhs: LemonadeToastItem, rhs: LemonadeToastItem) -> Bool {
@@ -153,6 +166,7 @@ public final class LemonadeToastManager: ObservableObject {
     ///   - dismissible: Whether the toast can be dismissed by swiping. Ignored (forced off) when `voice` is `.loading`.
     ///   - actionLabel: Optional label for the action button shown at the trailing end of the toast.
     ///   - onAction: Optional callback invoked when the action button is tapped. The button is only shown when both `actionLabel` and `onAction` are non-nil.
+    ///   - anchor: Where the toast sits at the bottom of the screen. Defaults to `.bottom`.
     ///
     /// Use `.loading` to communicate an ongoing action (e.g. "Downloading your document…"). A loading
     /// toast shows a spinner and persists until you call ``dismiss()`` or replace it with another `show`.
@@ -163,7 +177,8 @@ public final class LemonadeToastManager: ObservableObject {
         duration: LemonadeToastDuration = .short,
         dismissible: Bool = true,
         actionLabel: String? = nil,
-        onAction: (@MainActor @Sendable () -> Void)? = nil
+        onAction: (@MainActor @Sendable () -> Void)? = nil,
+        anchor: LemonadeToastAnchor = .bottom
     ) {
         let toast = LemonadeToastItem(
             label: label,
@@ -173,7 +188,8 @@ public final class LemonadeToastManager: ObservableObject {
             // A loading toast describes an ongoing action: it cannot be swiped away.
             isDismissible: voice == .loading ? false : dismissible,
             actionLabel: actionLabel,
-            onAction: onAction
+            onAction: onAction,
+            anchor: anchor
         )
 
         if currentToast != nil {


### PR DESCRIPTION
# Summary
Toasts currently always anchor to the very bottom edge, so on screens with a fixed bottom action button, the toast overlaps it.                                                                                
                                                                                                                                                                                                                 
  Adds a ToastAnchor (ToastAnchor / LemonadeToastAnchor on Swift) with two cases:                                                                                                                                
  - Bottom (default, unchanged) — flush with the bottom edge.                                                                                                                                                    
  - AboveBottomActionButton — 112dp/pt bottom padding, clearing a standard bottom action button.                                                                                                                 
                                                                                                                                                                                                                 
  Settable via LemonadeToastState.show(...) (Kotlin) and LemonadeToastManager.show(...) (Swift).                                                                                                                 
                                                                                                                                                                                                                 
  Also fixes an iOS hit-testing bug: the toast's tap/drag gesture area extended into its bottom padding via contentShape(Rectangle()), so anything visible underneath the toast (e.g. an action button) was
  unclickable while a toast was shown. The anchor's bottom padding is now excluded from the interactive region.

## Figma component
<!-- Provide figma link (if any) to the component, it makes it easy for reviewers to find it -->

## Screenshot
<!-- Provide at least one image of your change if applicable -->
<!-- <img src="drawing.jpg" alt="drawing" width="200"/> -->
<!-- You can define the width/height to resize the image if needed -->

### Teya Business App
| android | ios |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1784127449" src="https://github.com/user-attachments/assets/88529292-5906-45e6-b185-da5f2daaf16b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-15 at 18 10 24" src="https://github.com/user-attachments/assets/9f5cc970-da56-4c46-88bf-8fd8caa69c9e" /> | 

### Demo
| Default | Above action button |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_1784543932" src="https://github.com/user-attachments/assets/2f855504-8179-46ac-896f-9ede4c2f8c08" /> | <img width="1080" height="2400" alt="Screenshot_1784544009" src="https://github.com/user-attachments/assets/0c0e2fee-c2c6-4a7f-b46f-ca5b930e81a4" /> | 


## API Dump
<!--
Required when any kmp/<module>/api/*.api or *.klib.api file changed.
Run `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` to get the verdict.
If nothing in api/ changed, write "No public API changes" and delete the rest.
-->

**Verdict:** <!-- NO_CHANGES / ADDITIONS_ONLY / BREAKING -->

**Changes that are not a concern, and why:**
<!--
- Interface addition — the interface is local-only, no external implementers.
- Enum entry addition — config enum; the component owns the `when`.
- `@Deprecated(HIDDEN)` overload — the `-` line is only the `synthetic` flag,
  the JVM descriptor is unchanged, so already-compiled consumers keep linking.
-->

**Genuine breaking changes (if any):**
<!--
List each one, who needs to approve (@caiqueslp / @williankl / @DevSrSouza),
and why the break is acceptable. Leave empty if the verdict is not BREAKING.
-->
