### PR TITLE
fix(toast): show Android toast above modals; pass side/below taps through

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -4,12 +4,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeIcons
 
 @Composable
 internal fun ToastDisplay() {
     val toastState = LocalLemonadeToastState.current
+    var showSheet by remember { mutableStateOf(false) }
 
     SampleScreenDisplayColumn("Toast", itemsSpacing = LemonadeTheme.spaces.spacing600) {
         ToastSection("Voice Variants") {
@@ -202,6 +207,38 @@ internal fun ToastDisplay() {
                         label = "Above Bottom Action Button",
                         voice = ToastVoice.Success,
                         paddingValues = PaddingValues(bottom = 112.dp),
+                    )
+                },
+            )
+        }
+
+        ToastSection("Over Bottom Sheet") {
+            LemonadeUi.Button(
+                label = "Open bottom sheet",
+                onClick = { showSheet = true },
+            )
+        }
+    }
+
+    LemonadeUi.BottomSheet(
+        expanded = showSheet,
+        onDismissRequest = { showSheet = false },
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(LemonadeTheme.spaces.spacing400),
+        ) {
+            LemonadeUi.Text(
+                text = "Show a toast while this sheet is open — it appears on top of the sheet, " +
+                    "not behind it.",
+                textStyle = LemonadeTheme.typography.bodyMediumRegular,
+                color = LemonadeTheme.colors.content.contentSecondary,
+            )
+            LemonadeUi.Button(
+                label = "Show toast on top",
+                onClick = {
+                    toastState.show(
+                        label = "This toast is above the bottom sheet",
+                        voice = ToastVoice.Success,
                     )
                 },
             )

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
@@ -10,8 +10,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -84,6 +86,9 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
         val startInset = margins.calculateStartPadding(layoutDirection)
         val endInset = margins.calculateEndPadding(layoutDirection)
         ConfigureToastWindow(bottomInset = margins.calculateBottomPadding())
+        // The window is centered; start/end insets only cap the width (the toast keeps clear of the
+        // screen edges). Unlike the inline host they don't shift it horizontally — a bottom-centered
+        // toast has no caller that needs asymmetric horizontal positioning.
         val maxToastWidth = (LocalConfiguration.current.screenWidthDp.dp - startInset - endInset)
             .coerceAtLeast(0.dp)
 
@@ -112,13 +117,18 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
 }
 
 /**
- * Sizes the dialog window to the toast and lifts it [bottomInset] above the screen bottom via a window
- * attribute, not padding — so the frame hugs the pill and taps everywhere else fall through.
+ * Sizes the dialog window to the toast and lifts it [bottomInset] (plus the navigation-bar inset)
+ * above the bottom via a window attribute, not padding — so the frame hugs the pill and taps
+ * everywhere else fall through. The navigation-bar inset resolves to zero when the window already
+ * sits above the bars and to the bar height on edge-to-edge screens, so the toast never lands under
+ * the navigation bar.
  */
 @Composable
 private fun ConfigureToastWindow(bottomInset: Dp) {
     val view = LocalView.current
-    val bottomInsetPx = with(LocalDensity.current) { bottomInset.roundToPx() }
+    val density = LocalDensity.current
+    val navigationBarInsetPx = WindowInsets.navigationBars.getBottom(density)
+    val bottomInsetPx = with(density) { bottomInset.roundToPx() } + navigationBarInsetPx
     DisposableEffect(bottomInsetPx) {
         (view.parent as? DialogWindowProvider)?.window?.apply {
             setBackgroundDrawable(ColorDrawable(AndroidColor.TRANSPARENT))

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
@@ -1,0 +1,141 @@
+package com.teya.lemonade
+
+import android.graphics.drawable.ColorDrawable
+import android.view.Gravity
+import android.view.WindowManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import kotlinx.coroutines.delay
+import android.graphics.Color as AndroidColor
+
+// Let the window's flags/size/gravity settle before animating, else the enter flicks.
+private const val SHOW_DELAY_MS = 100L
+
+@Composable
+internal actual fun PlatformToastHost(
+    modifier: Modifier,
+    toastState: LemonadeToastState,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier) { content() }
+    ToastOverlayWindow(toastState = toastState)
+}
+
+/**
+ * Draws the toast in its own [Dialog] window so it z-orders above any open ModalBottomSheet / Dialog.
+ * `FLAG_NOT_FOCUSABLE` (implies `FLAG_NOT_TOUCH_MODAL`) passes touches outside the toast through to the
+ * content beneath and never takes input focus.
+ */
+@Composable
+private fun ToastOverlayWindow(toastState: LemonadeToastState) {
+    val toast = toastState.currentToast
+
+    // Outlive `currentToast` clearing so the exit animation can play before the Dialog unmounts.
+    var lastToast by remember { mutableStateOf<ToastData?>(null) }
+    if (toast != null) lastToast = toast
+
+    val animState = remember { MutableTransitionState(false) }
+    val animationSettled by remember {
+        derivedStateOf { !animState.currentState && !animState.targetState }
+    }
+
+    LaunchedEffect(toast, animationSettled) {
+        if (toast == null && animationSettled) lastToast = null
+    }
+
+    val displayToast = lastToast ?: return
+
+    Dialog(
+        onDismissRequest = { toastState.dismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        val layoutDirection = LocalLayoutDirection.current
+        val margins = rememberToastPadding(displayToast.paddingValues, layoutDirection)
+        val startInset = margins.calculateStartPadding(layoutDirection)
+        val endInset = margins.calculateEndPadding(layoutDirection)
+        ConfigureToastWindow(bottomInset = margins.calculateBottomPadding())
+        val maxToastWidth = (LocalConfiguration.current.screenWidthDp.dp - startInset - endInset)
+            .coerceAtLeast(0.dp)
+
+        LaunchedEffect(toast) {
+            if (toast != null) {
+                delay(SHOW_DELAY_MS)
+                animState.targetState = true
+            } else {
+                animState.targetState = false
+            }
+        }
+
+        AnimatedVisibility(
+            visibleState = animState,
+            enter = fadeIn() + slideInVertically { it },
+            exit = fadeOut() + slideOutVertically { it },
+        ) {
+            Box(modifier = Modifier.widthIn(max = maxToastWidth)) {
+                SwipeableToast(
+                    toast = displayToast,
+                    onDismiss = { toastState.dismiss() },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Sizes the dialog window to the toast and lifts it [bottomInset] above the screen bottom via a window
+ * attribute, not padding — so the frame hugs the pill and taps everywhere else fall through.
+ */
+@Composable
+private fun ConfigureToastWindow(bottomInset: Dp) {
+    val view = LocalView.current
+    val bottomInsetPx = with(LocalDensity.current) { bottomInset.roundToPx() }
+    DisposableEffect(bottomInsetPx) {
+        (view.parent as? DialogWindowProvider)?.window?.apply {
+            setBackgroundDrawable(ColorDrawable(AndroidColor.TRANSPARENT))
+            clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            addFlags(
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                    WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
+            )
+            setLayout(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+            )
+            attributes = attributes.apply {
+                gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+                y = bottomInsetPx
+            }
+        }
+        onDispose { }
+    }
+}

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
@@ -3,12 +3,11 @@ package com.teya.lemonade
 import android.graphics.drawable.ColorDrawable
 import android.view.Gravity
 import android.view.WindowManager
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -20,10 +19,13 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -101,17 +103,31 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
             }
         }
 
-        AnimatedVisibility(
-            visibleState = animState,
-            enter = fadeIn() + slideInVertically { it },
-            exit = fadeOut() + slideOutVertically { it },
+        // Keep the toast always composed so the wrap-content window measures one fixed size and stays
+        // centered. Animating it in with AnimatedVisibility resized the window as the content appeared,
+        // which made the entrance drift in from the side. Drive enter/exit as a draw-only alpha +
+        // vertical translation instead — those never re-measure the window.
+        var toastHeightPx by remember { mutableIntStateOf(0) }
+        val transition = updateTransition(animState, label = "toast")
+        val alpha by transition.animateFloat(label = "alpha") { visible -> if (visible) 1f else 0f }
+        val translationY by transition.animateFloat(
+            transitionSpec = { spring(dampingRatio = 0.8f, stiffness = Spring.StiffnessMediumLow) },
+            label = "translationY",
+        ) { visible -> if (visible) 0f else toastHeightPx.toFloat() }
+
+        Box(
+            modifier = Modifier
+                .widthIn(max = maxToastWidth)
+                .onSizeChanged { toastHeightPx = it.height }
+                .graphicsLayer {
+                    this.alpha = alpha
+                    this.translationY = translationY
+                },
         ) {
-            Box(modifier = Modifier.widthIn(max = maxToastWidth)) {
-                SwipeableToast(
-                    toast = displayToast,
-                    onDismiss = { toastState.dismiss() },
-                )
-            }
+            SwipeableToast(
+                toast = displayToast,
+                onDismiss = { toastState.dismiss() },
+            )
         }
     }
 }
@@ -144,6 +160,9 @@ private fun ConfigureToastWindow(bottomInset: Dp) {
             attributes = attributes.apply {
                 gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
                 y = bottomInsetPx
+                // Compose drives the enter/exit; suppress the platform window animation so it doesn't
+                // run on top of it.
+                windowAnimations = 0
             }
         }
         onDispose { }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
@@ -414,121 +415,154 @@ public fun LemonadeToastHost(
     content: @Composable () -> Unit,
 ) {
     val toastState = remember { LemonadeToastState() }
-    var hostHeightPx by remember { mutableStateOf(0) }
+
+    val toast = toastState.currentToast
+    val haptic = LocalHapticFeedback.current
+    // Hosted here, not in the platform overlay, so it runs the same inline or in a window.
+    LaunchedEffect(toast?.id) {
+        if (toast != null) {
+            val feedbackType = when (toast.voice) {
+                ToastVoice.Neutral, ToastVoice.Loading -> HapticFeedbackType.TextHandleMove
+                ToastVoice.Success, ToastVoice.Error -> HapticFeedbackType.LongPress
+            }
+            haptic.performHapticFeedback(feedbackType)
+            // A loading toast describes an ongoing action: it persists until explicitly
+            // dismissed or replaced, so skip the auto-dismiss timer.
+            if (toast.voice != ToastVoice.Loading) {
+                delay(toast.duration.millis)
+                toastState.dismiss()
+            }
+        }
+    }
 
     CompositionLocalProvider(LocalLemonadeToastState provides toastState) {
-        Box(
-            modifier = modifier.onSizeChanged { hostHeightPx = it.height },
-        ) {
-            content()
+        PlatformToastHost(
+            modifier = modifier,
+            toastState = toastState,
+            content = content,
+        )
+    }
+}
 
-            val toast = toastState.currentToast
-            val haptic = LocalHapticFeedback.current
-            val spaces = LocalSpaces.current
-            val layoutDirection = LocalLayoutDirection.current
-            // A zero edge is treated as "not overridden" and falls back to the default — `show()` isn't
-            // @Composable, so a caller can't pull the real spacing600/spacing400 token values to build a
-            // PaddingValues that only overrides one edge. The top inset is never honored: the toast is
-            // always bottom-anchored with intrinsic height, so extra top padding only adds invisible space
-            // above it — it has no visible effect on where the toast sits.
-            val overridePadding = toast?.paddingValues
-            val bottomPadding = overridePadding?.calculateBottomPadding()?.takeIf { it > 0.dp }
-                ?: spaces.spacing600
-            val startPadding = overridePadding?.calculateStartPadding(layoutDirection)?.takeIf { it > 0.dp }
-                ?: spaces.spacing400
-            val endPadding = overridePadding?.calculateEndPadding(layoutDirection)?.takeIf { it > 0.dp }
-                ?: spaces.spacing400
+/**
+ * Renders the toast overlay for the current platform. Android draws it in its own window so it z-orders
+ * above any `ModalBottomSheet` / `Dialog`; other platforms render it inline as a sibling of [content].
+ */
+@Composable
+internal expect fun PlatformToastHost(
+    modifier: Modifier,
+    toastState: LemonadeToastState,
+    content: @Composable () -> Unit,
+)
 
-            // Haptic feedback + auto-dismiss timer
-            LaunchedEffect(toast?.id) {
-                if (toast != null) {
-                    val feedbackType = when (toast.voice) {
-                        ToastVoice.Neutral, ToastVoice.Loading -> HapticFeedbackType.TextHandleMove
-                        ToastVoice.Success, ToastVoice.Error -> HapticFeedbackType.LongPress
-                    }
-                    haptic.performHapticFeedback(feedbackType)
-                    // A loading toast describes an ongoing action: it persists until explicitly
-                    // dismissed or replaced, so skip the auto-dismiss timer.
-                    if (toast.voice != ToastVoice.Loading) {
-                        delay(toast.duration.millis)
-                        toastState.dismiss()
-                    }
-                }
-            }
+/** Inline overlay: the animated toast pinned to the bottom of the host [Box], over [content]. */
+@Composable
+internal fun InlineToastHost(
+    modifier: Modifier,
+    toastState: LemonadeToastState,
+    content: @Composable () -> Unit,
+) {
+    var hostHeightPx by remember { mutableStateOf(0) }
+    Box(modifier = modifier.onSizeChanged { hostHeightPx = it.height }) {
+        content()
 
-            AnimatedContent(
-                targetState = toast,
-                contentAlignment = Alignment.BottomCenter,
-                transitionSpec = {
-                    slideInVertically(
+        val toast = toastState.currentToast
+        val padding = rememberToastPadding(toast?.paddingValues, LocalLayoutDirection.current)
+
+        AnimatedContent(
+            targetState = toast,
+            contentAlignment = Alignment.BottomCenter,
+            transitionSpec = {
+                slideInVertically(
+                    animationSpec = spring(
+                        dampingRatio = 0.8f,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+                    initialOffsetY = { hostHeightPx },
+                ).togetherWith(
+                    slideOutVertically(
                         animationSpec = spring(
                             dampingRatio = 0.8f,
                             stiffness = Spring.StiffnessMediumLow,
                         ),
-                        initialOffsetY = { hostHeightPx },
-                    ).togetherWith(
-                        slideOutVertically(
-                            animationSpec = spring(
-                                dampingRatio = 0.8f,
-                                stiffness = Spring.StiffnessMediumLow,
-                            ),
-                            targetOffsetY = { hostHeightPx },
-                        ),
-                    ).using(SizeTransform(clip = false) { _, _ -> snap() })
-                },
-                contentKey = { it?.id },
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .navigationBarsPadding()
-                    .padding(bottom = bottomPadding)
-                    .padding(start = startPadding, end = endPadding),
-            ) { animatedToast ->
-                if (animatedToast != null) {
-                    var offsetY by remember(animatedToast.id) { mutableStateOf(0f) }
-
-                    // A loading toast cannot be swiped away — it stays until the action completes.
-                    val swipeDismissible = animatedToast.dismissible &&
-                        animatedToast.voice != ToastVoice.Loading
-
-                    val swipeModifier = if (swipeDismissible) {
-                        Modifier.pointerInput(animatedToast.id) {
-                            detectVerticalDragGestures(
-                                onDragEnd = {
-                                    if (offsetY > DRAG_DISMISS_THRESHOLD_DP.dp.toPx()) {
-                                        toastState.dismiss()
-                                    } else {
-                                        offsetY = 0f
-                                    }
-                                },
-                                onDragCancel = {
-                                    offsetY = 0f
-                                },
-                                onVerticalDrag = { change, dragAmount ->
-                                    offsetY = (offsetY + dragAmount).coerceAtLeast(0f)
-                                    change.consume()
-                                },
-                            )
-                        }
-                    } else {
-                        Modifier
-                    }
-
-                    LemonadeUi.Toast(
-                        label = animatedToast.label,
-                        voice = animatedToast.voice,
-                        icon = animatedToast.icon,
-                        actionLabel = animatedToast.actionLabel,
-                        onAction = animatedToast.onAction,
-                        modifier = swipeModifier
-                            .offset { IntOffset(x = 0, y = offsetY.roundToInt()) }
-                            .graphicsLayer {
-                                val fadeDistance =
-                                    DRAG_DISMISS_THRESHOLD_DP.dp.toPx() * DRAG_FADE_MULTIPLIER
-                                alpha = 1f - (offsetY / fadeDistance).coerceIn(0f, 1f)
-                            },
-                    )
-                }
+                        targetOffsetY = { hostHeightPx },
+                    ),
+                ).using(SizeTransform(clip = false) { _, _ -> snap() })
+            },
+            contentKey = { it?.id },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(padding),
+        ) { animatedToast ->
+            if (animatedToast != null) {
+                SwipeableToast(
+                    toast = animatedToast,
+                    onDismiss = { toastState.dismiss() },
+                )
             }
         }
     }
+}
+
+/** The toast plus swipe-to-dismiss: a downward drag past a threshold dismisses it (never a loading toast). */
+@Composable
+internal fun SwipeableToast(
+    toast: ToastData,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var offsetY by remember(toast.id) { mutableStateOf(0f) }
+    val swipeDismissible = toast.dismissible && toast.voice != ToastVoice.Loading
+    val swipeModifier = if (swipeDismissible) {
+        Modifier.pointerInput(toast.id) {
+            detectVerticalDragGestures(
+                onDragEnd = {
+                    if (offsetY > DRAG_DISMISS_THRESHOLD_DP.dp.toPx()) {
+                        onDismiss()
+                    } else {
+                        offsetY = 0f
+                    }
+                },
+                onDragCancel = { offsetY = 0f },
+                onVerticalDrag = { change, dragAmount ->
+                    offsetY = (offsetY + dragAmount).coerceAtLeast(0f)
+                    change.consume()
+                },
+            )
+        }
+    } else {
+        Modifier
+    }
+
+    LemonadeUi.Toast(
+        label = toast.label,
+        voice = toast.voice,
+        icon = toast.icon,
+        actionLabel = toast.actionLabel,
+        onAction = toast.onAction,
+        modifier = modifier
+            .then(swipeModifier)
+            .offset { IntOffset(x = 0, y = offsetY.roundToInt()) }
+            .graphicsLayer {
+                val fadeDistance = DRAG_DISMISS_THRESHOLD_DP.dp.toPx() * DRAG_FADE_MULTIPLIER
+                alpha = 1f - (offsetY / fadeDistance).coerceIn(0f, 1f)
+            },
+    )
+}
+
+/**
+ * Resolves the toast margins from a per-edge [override]. A zero edge means "not overridden" and falls
+ * back to the standard margin; the top edge is never honored (the toast is bottom-anchored).
+ */
+@Composable
+internal fun rememberToastPadding(
+    override: PaddingValues?,
+    layoutDirection: LayoutDirection,
+): PaddingValues {
+    val spaces = LocalSpaces.current
+    val bottom = override?.calculateBottomPadding()?.takeIf { it > 0.dp } ?: spaces.spacing600
+    val start = override?.calculateStartPadding(layoutDirection)?.takeIf { it > 0.dp } ?: spaces.spacing400
+    val end = override?.calculateEndPadding(layoutDirection)?.takeIf { it > 0.dp } ?: spaces.spacing400
+    return PaddingValues(start = start, end = end, bottom = bottom)
 }

--- a/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Toast.desktop.kt
+++ b/kmp/ui/src/desktopMain/kotlin/com/teya/lemonade/Toast.desktop.kt
@@ -1,0 +1,13 @@
+package com.teya.lemonade
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal actual fun PlatformToastHost(
+    modifier: Modifier,
+    toastState: LemonadeToastState,
+    content: @Composable () -> Unit,
+) {
+    InlineToastHost(modifier = modifier, toastState = toastState, content = content)
+}

--- a/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Toast.ios.kt
+++ b/kmp/ui/src/iosMain/kotlin/com/teya/lemonade/Toast.ios.kt
@@ -1,0 +1,13 @@
+package com.teya.lemonade
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal actual fun PlatformToastHost(
+    modifier: Modifier,
+    toastState: LemonadeToastState,
+    content: @Composable () -> Unit,
+) {
+    InlineToastHost(modifier = modifier, toastState = toastState, content = content)
+}

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -4,6 +4,7 @@ import Lemonade
 struct ToastDisplayView: View {
     @EnvironmentObject private var toastManager: LemonadeToastManager
     @State private var textFieldValue: String = ""
+    @State private var showOverSheet = false
 
     var body: some View {
         List {
@@ -178,6 +179,12 @@ struct ToastDisplayView: View {
                 }
             }
 
+            Section("Over Bottom Sheet") {
+                Button("Open bottom sheet") {
+                    showOverSheet = true
+                }
+            }
+
             Section("Keyboard Handling") {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("Tap the text field to open keyboard, then show a toast:")
@@ -213,6 +220,22 @@ struct ToastDisplayView: View {
             }
         }
         .navigationTitle("Toast")
+        .sheet(isPresented: $showOverSheet) {
+            VStack(spacing: 16) {
+                Text("Show a toast while this sheet is open — does it appear on top of the sheet, or behind it?")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                Button("Show toast on top") {
+                    toastManager.show(
+                        label: "This toast should be above the bottom sheet",
+                        voice: .success
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+            .presentationDetents([.medium])
+        }
     }
 }
 

--- a/swiftui/SampleApp/ToastDisplayView.swift
+++ b/swiftui/SampleApp/ToastDisplayView.swift
@@ -221,21 +221,34 @@ struct ToastDisplayView: View {
         }
         .navigationTitle("Toast")
         .sheet(isPresented: $showOverSheet) {
-            VStack(spacing: 16) {
-                Text("Show a toast while this sheet is open — does it appear on top of the sheet, or behind it?")
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(.secondary)
-                Button("Show toast on top") {
-                    toastManager.show(
-                        label: "This toast should be above the bottom sheet",
-                        voice: .success
-                    )
-                }
-                .buttonStyle(.borderedProminent)
-            }
-            .padding()
-            .presentationDetents([.medium])
+            // Give the sheet its own toast container so a toast fired from inside it renders on top of
+            // the sheet, not behind it. A `.sheet` is a separate presentation layer above the root, so
+            // the root's container can't reach over it — each presented layer that shows toasts needs
+            // its own container. (This mirrors how the app's navigator wraps every presented screen.)
+            OverBottomSheetContent()
+                .lemonadeToastContainer()
+                .presentationDetents([.medium])
         }
+    }
+}
+
+private struct OverBottomSheetContent: View {
+    @EnvironmentObject private var toastManager: LemonadeToastManager
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("This sheet has its own toast container, so the toast renders on top of it.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Show toast on top") {
+                toastManager.show(
+                    label: "This toast is above the bottom sheet",
+                    voice: .success
+                )
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeToastContainerView.swift
@@ -232,19 +232,24 @@ struct ToastItemView: View {
 
     private var toastContent: some View {
         VStack(spacing: 0) {
-            LemonadeUi.Toast(
-                label: toast.label,
-                voice: toast.voice,
-                icon: toast.icon,
-                actionLabel: toast.actionLabel,
-                onAction: toast.onAction
-            )
-            .frame(maxWidth: .infinity)
-            .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
+            // Only the pill is hittable; the spacers on either side pass touches through to the content
+            // beneath, so taps left/right of the toast reach it (a full-width frame would swallow them).
+            HStack(spacing: 0) {
+                Spacer(minLength: 0).allowsHitTesting(false)
+                LemonadeUi.Toast(
+                    label: toast.label,
+                    voice: toast.voice,
+                    icon: toast.icon,
+                    actionLabel: toast.actionLabel,
+                    onAction: toast.onAction
+                )
+                .padding(.top, .space.spacing1800) // Extra space for dismiss gesture
+                .contentShape(Rectangle())
+                .simultaneousGesture(dismissGesture)
+                Spacer(minLength: 0).allowsHitTesting(false)
+            }
             .padding(.leading, resolvedPadding(toast.paddingValues?.leading, default: .space.spacing200))
             .padding(.trailing, resolvedPadding(toast.paddingValues?.trailing, default: .space.spacing200))
-            .contentShape(Rectangle())
-            .simultaneousGesture(dismissGesture)
 
             // Clears whatever sits below the toast (e.g. a bottom action button). Kept out of
             // the contentShape/gesture above so it stays non-interactive and touches pass through.


### PR DESCRIPTION
## Problem

Two related toast interaction bugs, both Android-side in effect:

1. **Toast hidden behind modals (Android).** `LemonadeToastHost` renders the toast inline as the last child of the app's composition `Box`. A `ModalBottomSheet` / `Dialog` renders in its own separate platform window above the Activity window, so a toast shown while a sheet/dialog is open draws *behind* it. iOS/desktop are unaffected (single window).
2. **Taps beside/below the toast are swallowed.** Both platforms made a full-width region the toast's touch target, so taps to the left/right (and, once a bottom inset is applied, below) the visible pill were consumed instead of reaching the content underneath.

## Fix

**KMP (`Toast.kt` + new `Toast.{android,ios,desktop}.kt`)**
- Split rendering behind an `internal expect fun PlatformToastHost`. The common `LemonadeToastHost` still owns the state, the `CompositionLocal`, and the haptic/auto-dismiss timer.
- **Android actual** draws the toast in its own bottom-anchored `Dialog` window: `FLAG_NOT_FOCUSABLE | FLAG_NOT_TOUCH_MODAL`, `WRAP_CONTENT`, centered, transparent. It z-orders above any `ModalBottomSheet` / `Dialog`. The bottom inset is applied as the window's **y-offset** (not padding), and the window is only as wide as the pill — so the frame hugs the toast and every tap outside it falls through to the content beneath.
- **iOS / desktop actuals** delegate to a shared `InlineToastHost` that is the previous inline overlay verbatim — no behaviour change.

**SwiftUI (`LemonadeToastContainerView.swift`)**
- `ToastItemView` gave the pill a full-width hit target (`.frame(maxWidth: .infinity)` + `.contentShape`), swallowing side taps. The pill is now wrapped in non-hittable `Spacer`s so only the pill is interactive.

## Compatibility

Public API unchanged — `LemonadeToastHost`, `LemonadeUi.Toast`, and `LemonadeToastState.show(...)` keep the same signatures. No consumer call-site changes.

## Testing

- KMP compiles on all targets (`commonMain` metadata, Android, iOS simulator, desktop).
- Verified in the Teya app on Android (phone + tablet emulators) and iOS (iPhone + iPad simulators): toast renders above bottom sheets/dialogs on Android; taps left/right/below the toast reach the content underneath on both platforms; the toast's own action button and swipe-to-dismiss still work.

## Notes

The Teya terminal app carries a bespoke `SnackBar.kt` that reimplements the same Dialog-window pattern; once this lands it can drop that copy and use the DS host.
