### PR TITLE
fix(ui): load asset drawables without blocking the main thread

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/AssetPainter.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/AssetPainter.kt
@@ -1,0 +1,67 @@
+package com.teya.lemonade
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToImageVector
+import org.jetbrains.compose.resources.getDrawableResourceBytes
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.rememberResourceEnvironment
+
+private val assetVectorCache = mutableMapOf<DrawableResource, ImageVector>()
+
+/**
+ * Loads a vector [DrawableResource] without blocking the main thread.
+ *
+ * compose-resources' [painterResource] resolves synchronously on non-web targets
+ * (`runBlocking` during composition), which can ANR on contended cold starts. This
+ * helper decodes on a background dispatcher instead, rendering a transparent painter
+ * until the first decode of each resource completes. Decoded vectors are cached for
+ * the process lifetime, so every later composition resolves synchronously.
+ *
+ * [LocalInspectionMode] keeps previews and screenshot tests on the synchronous path.
+ */
+@OptIn(ExperimentalResourceApi::class)
+@Composable
+internal fun rememberAssetPainter(resource: DrawableResource): Painter {
+    if (LocalInspectionMode.current) {
+        return painterResource(resource = resource)
+    }
+    val density = LocalDensity.current
+    val environment = rememberResourceEnvironment()
+    val imageVector by produceState(
+        initialValue = assetVectorCache[resource],
+        key1 = resource,
+    ) {
+        if (value == null) {
+            value = withContext(context = Dispatchers.Default) {
+                getDrawableResourceBytes(
+                    environment = environment,
+                    resource = resource,
+                ).decodeToImageVector(density = density)
+            }.also { decodedVector ->
+                assetVectorCache[resource] = decodedVector
+            }
+        }
+    }
+    val loadedVector = imageVector
+    return if (loadedVector != null) {
+        rememberVectorPainter(image = loadedVector)
+    } else {
+        remember {
+            ColorPainter(color = Color.Transparent)
+        }
+    }
+}

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/BrandLogo.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/BrandLogo.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeBrandLogos
-import org.jetbrains.compose.resources.painterResource
 
 /**
  * Brand logo component, to indication of Card Schemes in standardized way.
@@ -59,7 +58,7 @@ private fun CoreBrandLogo(
         logo.drawableResource
     }
     Image(
-        painter = painterResource(resource = resource),
+        painter = rememberAssetPainter(resource = resource),
         contentDescription = contentDescription,
         modifier = modifier.requiredSize(size = size.dp),
     )

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/CountryFlag.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/CountryFlag.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.Dp
 import com.teya.lemonade.core.CountryFlagShape
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeCountryFlags
-import org.jetbrains.compose.resources.painterResource
 
 /**
  * Country Flags component, to display the available country flags in standardized way.
@@ -86,7 +85,7 @@ private fun CoreCountryFlag(
 ) {
     val resolvedShape = shape.resolveShape(size = size)
     Image(
-        painter = painterResource(resource = flag.drawableResource),
+        painter = rememberAssetPainter(resource = flag.drawableResource),
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
         modifier = modifier

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
-import org.jetbrains.compose.resources.painterResource
 
 /**
  * Icon component, to indication status and possible actions via iconography
@@ -49,7 +48,7 @@ public fun LemonadeUi.Icon(
     modifier: Modifier = Modifier,
 ) {
     CoreIcon(
-        painter = painterResource(resource = icon.drawableResource),
+        painter = rememberAssetPainter(resource = icon.drawableResource),
         contentDescription = contentDescription,
         tint = tint,
         size = size,


### PR DESCRIPTION
# Summary

A consumer app hit an ANR whose trace ends in `CountryFlagKt.CoreCountryFlag` → compose-resources `painterResource`. On non-web targets, compose-resources resolves `painterResource(DrawableResource)` through `rememberResourceState` (`ResourceState.blocking.kt`), which is literally `remember { mutableStateOf(runBlocking { load() }) }` — the main thread opens the vector XML from the APK, reads it, and parses it during composition. On a contended cold start, the cumulative first-load cost of every asset on screen crossed the ~5s input-dispatch timeout.

This PR removes that main-thread block for all three components that load resources internally (`Icon`, `CountryFlag`, `BrandLogo`):

- New internal `rememberAssetPainter(resource)` (`AssetPainter.kt`): decodes the vector on `Dispatchers.Default` via `getDrawableResourceBytes` + `decodeToImageVector`, renders a transparent painter for the (first-load-only) in-flight frames, and caches decoded `ImageVector`s for the process lifetime so every later composition resolves synchronously — same steady-state behavior as today, minus the block.
- `LocalInspectionMode` falls back to the synchronous `painterResource`, keeping previews and screenshot tests pixel-identical.
- Each call site is a one-line swap; layout is unchanged (the existing `requiredSize` modifiers reserve the slot, so the asset late-paints without reflow).

Known gap (possible follow-up): slot APIs where consumers build painters themselves via `painterResource` (e.g. `Chip`'s `leadingPainter`) still block on the consumer side; a public async helper would be ADDITIONS_ONLY.

## Benchmark (before vs after)

Measured with the `composeApp` sample — debug APKs built from `main` (`f61fbd3e`, **before**) and this branch (**after**) — on an Android 16 (API 36) arm64 emulator. Stress surface: the **CountryFlag display screen** (~250 flags at `XXLarge` in a lazy grid). Each run: fresh process → open the flags screen → two scroll flings over a ~5s window; frame stats from `dumpsys gfxinfo` (reset right before opening the screen).

**Flags screen — cold I/O (first run after a fresh APK install), the ANR scenario:**

| Metric | Before (blocking) | After (async) |
|---|---|---|
| Frames rendered in the window | 33 | **148** |
| Janky frames | 21 (**63.6 %**) | 5 (**3.4 %**) |
| Frame time p50 / p90 | 48 / 150 ms | 17 / 20 ms |
| Frame time p95 / p99 | **400 / 650 ms** | **24 / 81 ms** |

Before, every newly composed flag runs blocking I/O + XML parsing on the main thread: individual frames reached 650 ms *on an emulator backed by a fast host SSD* — on low-end hardware with contended flash at cold start, that same work is what crossed the ~5 s input-dispatch timeout. After, the worst frame is 81 ms and the UI produced 4.5× more frames in the same wall-clock window.

**Flags screen — warm OS page cache (second fresh-process run):** before 4.8 % janky / p99 77 ms vs after 5.4 % / p99 65 ms — statistically identical; the process-wide `ImageVector` cache keeps steady-state behavior unchanged.

**Cold app start (`am start -W`, 3 runs):** before 999/805/792 ms vs after 858/776/802 ms — unchanged within noise.

**Rendering verification:** screenshots on the after build confirm all three components render correctly — full flags grid, 279-icon grid (tint applied), and all brand logos including the largest asset (SEPA).

*Caveats: debug builds, emulator, 1–2 runs per cell — directional comparison; real low-end hardware amplifies the "before" numbers.*

## Figma component

N/A — no visual/design change.

## Screenshot

N/A — rendering is unchanged; only the loading mechanism moved off the main thread (see benchmark section for on-device verification).

## API Dump

No public API changes.

**Verdict:** NO_CHANGES (`bcv-check.sh --ci`: "public API is identical")