### PR TITLE
[ios] Fix unresponsive tap area on top-bar close (X) button

### DIFF
--- a/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
+++ b/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
@@ -60,5 +60,6 @@ extension View {
     /// ```
     func clickableFrame(minSize: LemonadeSizes) -> some View {
         frame(minWidth: minSize.value, minHeight: minSize.value)
+            .contentShape(Rectangle())
     }
 }

--- a/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
+++ b/swiftui/Sources/Lemonade/Extensions/View+Lemonade.swift
@@ -43,3 +43,22 @@ extension View {
         }
     }
 }
+
+// MARK: - Minimum Tappable Frame
+
+extension View {
+    /// Grows the view's layout frame to at least `minSize` on each side, centered on the
+    /// content. Use on icon-only button labels whose rendered size is smaller than the
+    /// platform's minimum touch target, so the enclosing `Button`'s tappable area grows
+    /// with it instead of matching the icon's small visual bounds.
+    ///
+    /// ```swift
+    /// Button(action: onClick) {
+    ///     LemonadeUi.Icon(icon: .times, contentDescription: "Close")
+    /// }
+    /// .clickableFrame(minSize: .size800)
+    /// ```
+    func clickableFrame(minSize: LemonadeSizes) -> some View {
+        frame(minWidth: minSize.value, minHeight: minSize.value)
+    }
+}

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeTopBar.swift
@@ -67,6 +67,7 @@ private struct BasicTopBarModifier<Toolbar: ToolbarContent, BottomContent: View>
                                 icon: .times,
                                 contentDescription: "Close"
                             )
+                            .clickableFrame(minSize: .size800)
                         }
                     }
                 }
@@ -108,6 +109,7 @@ private struct SearchTopBarModifier<Toolbar: ToolbarContent, BottomContent: View
                                 icon: .times,
                                 contentDescription: "Close"
                             )
+                            .clickableFrame(minSize: .size800)
                         }
                     }
                 }


### PR DESCRIPTION
# Summary
- The leading close (X) action in .lemonadeTopBar(navigationAction: .close) rendered a bare Button { LemonadeUi.Icon(...) } with no frame, so its tappable area matched the icon's small rendered glyph instead
  of a real touch target — taps near the edge of the icon were silently swallowed.
- Added View.clickableFrame(minSize: LemonadeSizes) (Extensions/View+Lemonade.swift) — grows a view's layout frame to at least the given size token, centered on its content, for icon-only button labels whose
  rendered size is smaller than the touch target. Takes a LemonadeSizes token rather than a raw CGFloat to keep call sites tied to the design system's scale instead of arbitrary numbers.
- Applied .clickableFrame(minSize: .size800) (32pt) to both close-button call sites in LemonadeTopBar.swift (basic top bar and search top bar variants).


## Before changes

https://github.com/user-attachments/assets/bfea1db7-cf64-4099-895f-523b29067e88



## API Dump
<!--
Required when any kmp/<module>/api/*.api or *.klib.api file changed.
Run `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` to get the verdict.
If nothing in api/ changed, write "No public API changes" and delete the rest.
-->

**Verdict:** <!-- NO_CHANGES / ADDITIONS_ONLY / BREAKING -->

**Changes that are not a concern, and why:**
<!--
- Interface addition — the interface is local-only, no external implementers.
- Enum entry addition — config enum; the component owns the `when`.
- `@Deprecated(HIDDEN)` overload — the `-` line is only the `synthetic` flag,
  the JVM descriptor is unchanged, so already-compiled consumers keep linking.
-->

**Genuine breaking changes (if any):**
<!--
List each one, who needs to approve (@caiqueslp / @williankl / @DevSrSouza),
and why the break is acceptable. Leave empty if the verdict is not BREAKING.
-->
