### PR TITLE
fix(iconbutton): pair the 40dp icon button with a 20dp glyph

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/IconButton.kt
@@ -336,7 +336,7 @@ private fun LemonadeButtonSize.toSizeData(shape: LemonadeIconButtonShape): IconB
         )
 
         LemonadeButtonSize.Small -> IconButtonSizeData(
-            iconSize = LemonadeAssetSize.Small,
+            iconSize = LemonadeAssetSize.Medium,
             spinnerSize = LemonadeAssetSize.XSmall,
             size = LocalSizes.current.size1000,
             shape = shape.resolveShape(roundedShape = LocalShapes.current.radius300),

--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -1213,7 +1213,7 @@ private fun CoreTopBarActionContent(
             onClick = navigationAction.onNavigationActionClicked,
             variant = LemonadeButtonVariant.Neutral,
             type = type,
-            size = LemonadeButtonSize.Medium,
+            size = LemonadeButtonSize.Small,
             shape = LemonadeIconButtonShape.Circular,
         )
     }


### PR DESCRIPTION
# Summary

Two lines, one root cause.

**`IconButton`'s `Small` size draws the wrong glyph.** A 40dp button gets a 16dp glyph, so the glyph fills 40% of the button. Every other size sits near half:

| size | button | glyph | ratio |
|---|---|---|---|
| Large | 56dp | 24dp | 0.43 |
| Medium | 48dp | 24dp | 0.50 |
| **Small** | **40dp** | **16dp → 20dp** | **0.40 → 0.50** |
| XSmall | 32dp | 16dp | 0.50 |

`Small` is the odd one out. This moves it to a 20dp glyph, so a 40dp icon button matches the rest of the scale — everywhere the size is used, not only in the top bar.

**The top bar's navigation button can then be a plain `Small`.** It used `Medium`, so it rendered 48dp, while the trailing slot caps its content at `size1000` (40dp). Every top bar in the app therefore paired a 48dp back/close button with a 40dp action. It now asks for `Small` and gets 40dp with the 20dp glyph.

### Verification

Rendered through the Teya app's Roborazzi golden for `CardsHomeChainsaw`, built against this branch published locally — real pixels, not reasoning about modifiers. The golden's 40dp button measures 55px, so 1.375px/dp:

| | Navigation button | Trailing action | Match? |
|---|---|---|---|
| Before | 67px (48dp) | 55px (40dp) | no |
| After | **55px (40dp)** | 55px (40dp) | yes |

Arrow ink measures 14.5 × 10.9dp inside the 20dp box, the expected 0.83 ratio against the previous 24dp box.

### Blast radius

The `Small` change is deliberate and repo-wide: every `IconButton(size = Small)` in every consumer gets the 20dp glyph. In the Teya app that's ~15 call sites (chat composer, widgets, bill payments, epos) plus the ~40 top-bar actions once they move to `Small`. That is the intent — the variant was mis-specified, so this corrects it at the component rather than patching call sites.

Considered and rejected: an `iconSize` override so only the top bar gets 40dp + 20dp. It leaves the mis-specified variant in place and lets the next screen hit the same problem.

Paired app change: saltpay/teya-business-app#3301.

## Figma component

n/a — no new component. Worth a designer confirming 20dp is the intended glyph for the 40dp icon button, since this sets it for every consumer.

## Screenshot

<!-- Attach: topbar_40dp_before_after.png — before: 48dp nav vs 40dp action; after: both 40dp. -->

## API Dump

**Verdict:** NO_CHANGES

`.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` → "public API is identical". Both changes are values inside existing private/internal composables; no `api/*.api` or `*.klib.api` file changed.

**Changes that are not a concern, and why:**

n/a — no baseline drift.

**Genuine breaking changes (if any):**

None. Note this is a visual change for existing `Small` icon buttons, which no API check can catch — see Blast radius.
