### PR TITLE
fix(bottomtabbar): stop labels clipping at large font scales

### DIFF
--- a/kmp/expressive/api/android/expressive.api
+++ b/kmp/expressive/api/android/expressive.api
@@ -41,7 +41,7 @@ public final class com/teya/lemonade/ComposableSingletons$BottomSheetKt {
 public final class com/teya/lemonade/ComposableSingletons$BottomTabBarKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$BottomTabBarKt;
 	public fun <init> ()V
-	public final fun getLambda$-692955140$expressive_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1737069344$expressive_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/teya/lemonade/DialogKt {

--- a/kmp/expressive/api/desktop/expressive.api
+++ b/kmp/expressive/api/desktop/expressive.api
@@ -35,7 +35,7 @@ public final class com/teya/lemonade/ComposableSingletons$BottomSheetKt {
 public final class com/teya/lemonade/ComposableSingletons$BottomTabBarKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$BottomTabBarKt;
 	public fun <init> ()V
-	public final fun getLambda$-692955140$expressive ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1737069344$expressive ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/teya/lemonade/DialogKt {

--- a/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
+++ b/kmp/expressive/src/commonMain/kotlin/com/teya/lemonade/BottomTabBar.kt
@@ -18,8 +18,10 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -41,8 +43,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -77,6 +81,16 @@ public data class BottomTabBarItem(
  *
  * The component already applies `Modifier.navigationBarsPadding`, so callers do not need to pad
  * around the system navigation bar themselves.
+ *
+ * ## Large font scales
+ * Items grow with the user's font scale rather than clipping their label. When the labels no longer
+ * fit their slots the bar drops all of them at once and shows only icons, rather than ellipsising
+ * them down to a couple of meaningless characters. The labels are still announced by accessibility
+ * services, as each item's content description.
+ *
+ * The fit is measured, not pinned to a font-scale threshold, so how long the labels survive depends
+ * on the space actually available: a tablet keeps its labels at text sizes where a compact phone
+ * cannot.
  *
  * ## Usage
  * ```kotlin
@@ -207,10 +221,14 @@ internal fun CoreBottomTabBar(
             // of its content, and a SubcomposeLayout throws on intrinsic queries. The row width is
             // captured via onSizeChanged so the pill can be positioned in pixels.
             var rowWidthPx by remember { mutableIntStateOf(0) }
+            val showLabels = rememberLabelsFit(
+                items = items,
+                rowWidthPx = rowWidthPx,
+            )
             Box(
                 modifier = Modifier
                     .weight(weight = 1f)
-                    .height(height = ItemHeight)
+                    .height(intrinsicSize = IntrinsicSize.Min)
                     .onSizeChanged { rowWidthPx = it.width },
             ) {
                 if (rowWidthPx > 0) {
@@ -222,7 +240,7 @@ internal fun CoreBottomTabBar(
                         modifier = Modifier
                             .offset { IntOffset(x = (slotWidthPx * clampedPosition).roundToInt(), y = 0) }
                             .width(width = slotWidthDp)
-                            .height(height = ItemHeight)
+                            .fillMaxHeight()
                             .clip(shape = LemonadeTheme.shapes.radiusFull)
                             .background(color = LemonadeTheme.colors.background.bgElevated),
                     )
@@ -233,6 +251,7 @@ internal fun CoreBottomTabBar(
                         BottomTabBarItemContent(
                             item = item,
                             isSelected = index == selectedIndex,
+                            showLabel = showLabels,
                             onClick = { onItemSelected(index) },
                             modifier = Modifier.weight(weight = 1f),
                         )
@@ -243,10 +262,52 @@ internal fun CoreBottomTabBar(
     }
 }
 
+/**
+ * Whether every label fits its slot at the current text size, screen width and item count.
+ *
+ * A label ellipsised down to a couple of characters carries no meaning, so the bar drops all of
+ * them at once and lets the icons speak instead. The decision is measured rather than pinned to a
+ * font-scale threshold: how much room a label needs depends just as much on the label itself, the
+ * number of items and the width available — a tablet at 500dp keeps its labels at text sizes where
+ * a 320dp phone cannot.
+ *
+ * The measurement is uniform on purpose. Hiding only the labels that overflow would leave a bar
+ * with some items labelled and some not.
+ *
+ * Returns `true` until the row has been measured, so bars whose labels fit — the common case —
+ * never flash through a label-less first frame.
+ */
+@Composable
+private fun rememberLabelsFit(
+    items: List<BottomTabBarItem>,
+    rowWidthPx: Int,
+): Boolean {
+    val textMeasurer = rememberTextMeasurer()
+    val labelStyle = LemonadeTheme.typography.bodyXSmallMedium.textStyle
+    val density = LocalDensity.current
+    // Mirrors the horizontal padding the label itself carries, so neighbouring slots never touch.
+    val labelGutterPx = with(density) { (LemonadeTheme.spaces.spacing100 * 2).roundToPx() }
+
+    return remember(rowWidthPx, items, labelStyle, textMeasurer, labelGutterPx) {
+        if (rowWidthPx == 0) return@remember true
+
+        val availableWidthPx = rowWidthPx / items.size - labelGutterPx
+        items.all { item ->
+            val measured = textMeasurer.measure(
+                text = item.label,
+                style = labelStyle,
+                maxLines = 1,
+            )
+            measured.size.width <= availableWidthPx
+        }
+    }
+}
+
 @Composable
 private fun BottomTabBarItemContent(
     item: BottomTabBarItem,
     isSelected: Boolean,
+    showLabel: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -256,15 +317,19 @@ private fun BottomTabBarItemContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
         modifier = modifier
-            .height(height = ItemHeight)
+            .fillMaxHeight()
+            .heightIn(min = ItemHeight)
             .clip(shape = LemonadeTheme.shapes.radiusFull)
             .clickable(
                 onClick = onClick,
                 role = Role.Tab,
                 interactionSource = interactionSource,
                 indication = LocalEffects.current.interactionIndication,
-            ).semantics { selected = isSelected }
-            .padding(vertical = LemonadeTheme.spaces.spacing200),
+            ).semantics {
+                selected = isSelected
+                // With the label hidden the tab itself has to carry the name.
+                if (!showLabel) contentDescription = item.label
+            }.padding(vertical = LemonadeTheme.spaces.spacing200),
     ) {
         val displayedIcon = if (isSelected) {
             item.selectedIcon
@@ -302,14 +367,17 @@ private fun BottomTabBarItemContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(height = LemonadeTheme.spaces.spacing50))
+        if (showLabel) {
+            Spacer(modifier = Modifier.height(height = LemonadeTheme.spaces.spacing50))
 
-        LemonadeUi.Text(
-            text = item.label,
-            textStyle = LemonadeTheme.typography.bodyXSmallMedium,
-            color = LemonadeTheme.colors.content.contentPrimary,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+            LemonadeUi.Text(
+                text = item.label,
+                modifier = Modifier.padding(horizontal = LemonadeTheme.spaces.spacing100),
+                textStyle = LemonadeTheme.typography.bodyXSmallMedium,
+                color = LemonadeTheme.colors.content.contentPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }


### PR DESCRIPTION
# Summary

`LemonadeUi.BottomTabBar` clipped its item labels at any font scale above 1.0.

`ItemHeight` is a fixed `54.dp`, but an item's content is partly `sp`-based. At `fontScale 1.0` the budget closes exactly, with zero headroom:

| part | dp @ fontScale 1.0 |
|---|---|
| padding vertical (`spacing200` × 2) | 16 |
| icon (`size500`) | 20 |
| spacer (`spacing50`) | 2 |
| label line height (`LineHeight400` = 16sp) | 16 |
| **total** | **54** = `ItemHeight` |

Anything above 1.0 overflows, and the fixed `.height(54.dp)` followed by `.clip(radiusFull)` cuts the excess off. Instrumented on a Pixel 10a (420dpi) with `onTextLayout`:

- `fontScale 1.15` (the first step above default) — all four labels already report `didOverflowHeight = true`.
- `fontScale 2.0` — the label needs `84px`, is given `42px`. Exactly half the glyph.

`TextOverflow.Ellipsis` was correct all along. Compose reports `didOverflowWidth = false` at 420dpi, and on narrow screens the labels *are* ellipsized — the `…` just sits on the baseline, inside the band the clip removes, which is why truncation read as a hard cut.

**The fix, in two parts:**

1. Item height is driven by its content with a `54.dp` floor (`IntrinsicSize.Min` on the slot box, `fillMaxHeight` on the selection pill so it stays in sync, `heightIn(min = ItemHeight)` on the item). Labels also get a `spacing100` gutter so neighbouring slots never touch — "Teya AI" measured `207px` in a `223px` slot, 93% fill with zero gap.

2. A label ellipsised to two characters carries no meaning, so once the labels stop fitting the bar drops all of them and shows only icons. **That decision is measured against the slot width, not pinned to a font-scale threshold.** How much room a label needs depends as much on the label itself, the item count and the width available as on the text size — and this component ships to tablets as well as phones.

The measurement is uniform: hiding only the labels that overflow would leave a bar with some items labelled and some not.

## Figma component

n/a — layout fix, no visual change at the default font scale.

## Screenshot

Verified on device and emulator across form factors and text sizes:

| form factor | fontScale | result |
|---|---|---|
| Pixel 10a, 411dp | 1.0 | unchanged from `main` — 54dp bar, pill in place, all labels full |
| Pixel 10a, 411dp | 1.3 | bar grows, labels full, no clipping |
| emulator, 411dp | 1.5 | **all four labels still shown** — a 1.5 threshold would have dropped them here |
| emulator, 411dp | 2.0 | icon-only, bar back to 54dp |
| emulator, 800dp (tablet) | 2.0 | **all four labels shown** — the bar caps at `MaxBarWidth` 500dp, so a slot is ~123dp and "Teya AI" fits comfortably |
| Pixel 10a, 320dp | 2.0 | icon-only, no clipping |

The last two rows are the point: same build, same `fontScale 2.0`, opposite outcomes, both correct.

The `IntrinsicSize.Min` is a **height** intrinsic; `HorizontalFloatingToolbar` queries **width** intrinsics, so it does not hit the `SubcomposeLayout` limitation documented at `BottomTabBar.kt:216`. The fit check uses `rememberTextMeasurer()` for the same reason — no `SubcomposeLayout`, no `BoxWithConstraints`. No crash across any configuration above.

**Behaviour change worth flagging:** long labels on narrow screens can now drop to icon-only *at the default font scale*, where before they ellipsised. That is the intended trade (`"Settl…"` tells a user less than the icon plus the accessible name), but it is a change for consumers with long labels on compact devices.

**Not verified:** I could not dump the accessibility tree to confirm the TalkBack announcement in icon-only mode — `uiautomator dump` is killed by the system on this device. The content description is wired through the standard `semantics { contentDescription = … }` on the tab node, but a reviewer with TalkBack should give it a pass.

## API Dump

**Verdict:** `ADDITIONS_ONLY`

```
-	public final fun getLambda$-692955140$expressive_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1737069344$expressive_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-692955140$expressive ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1737069344$expressive ()Lkotlin/jvm/functions/Function3;
```

**Changes that are not a concern, and why:**

- The only baseline movement is the name-mangled `internal` Compose singleton `ComposableSingletons$BottomTabBarKt` re-hashing, because the file's `@Composable` lambdas moved. The class itself is unchanged and is never consumer-visible — it exists only so the Compose compiler can hoist capture-free lambdas within this module. This is the case CLAUDE.md calls out as additive, and the classifier agrees.

Worth noting for the reviewer: an earlier iteration set the content description on the `LemonadeUi.Icon` inside the `Crossfade`. That made the content lambda capture state, so the compiler stopped hoisting it and the singleton **disappeared** from the baseline — which the classifier correctly flagged `BREAKING`. Moving the content description onto the tab node keeps the lambda capture-free, so the singleton survives. That is also the better semantics: the name belongs on the node with `Role.Tab`, not on a decorative image nested inside it.

**Genuine breaking changes (if any):**

None.

Closes MOP-342

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
