### PR TITLE
feat(search-field): let a host own the field's focus

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -84,14 +84,6 @@ private struct LemonadeSearchFieldView: View {
     private let externalFocus: Binding<Bool>?
     @FocusState private var isFocused: Bool
 
-    /// Mirrors `shouldShowCancel`, but is only ever written from inside an explicit `withAnimation`.
-    /// `@FocusState` updates arrive without an animation transaction, so an `if` driven straight off
-    /// `isFocused` would insert and remove the button untransitioned no matter what `.transition` it
-    /// carries. Routing the change through plain state is what lets the scale actually run.
-    /// Seeded in `init` rather than `onAppear` so a pre-filled field draws its cancel button on the
-    /// very first frame instead of popping it in one frame late.
-    @State private var isCancelPresented: Bool
-
     init(
         input: Binding<String>,
         onInputChanged: ((String) -> Void)?,
@@ -112,13 +104,6 @@ private struct LemonadeSearchFieldView: View {
         self.cancelContentDescription = cancelContentDescription
         self.enabled = enabled
         self.externalFocus = externalFocus
-        // The full `shouldShowCancel` predicate, focus included: a host that drives focus can hand
-        // the field a caret before its first render, and `onChange` only fires on a change, so a
-        // field born focused would otherwise never draw its cancel button at all.
-        self._isCancelPresented = State(
-            initialValue: dismissible && enabled
-                && (externalFocus?.wrappedValue == true || !input.wrappedValue.isEmpty)
-        )
     }
 
     private let height: CGFloat = LemonadeTheme.sizes.size1100
@@ -154,7 +139,7 @@ private struct LemonadeSearchFieldView: View {
         HStack(spacing: LemonadeTheme.spaces.spacing200) {
             searchField
 
-            if isCancelPresented {
+            if shouldShowCancel {
                 LemonadeUi.IconButton(
                     icon: .times,
                     contentDescription: cancelContentDescription,
@@ -174,9 +159,7 @@ private struct LemonadeSearchFieldView: View {
                 .transition(.scale(scale: cancelCollapsedScale).combined(with: .opacity))
             }
         }
-        .onChange(of: shouldShowCancel) { newValue in
-            withAnimation(.easeInOut(duration: animationDuration)) { isCancelPresented = newValue }
-        }
+        .animation(.easeInOut(duration: animationDuration), value: shouldShowCancel)
         .onChange(of: isFocused) { newValue in
             guard externalFocus?.wrappedValue != newValue else { return }
             externalFocus?.wrappedValue = newValue

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -33,6 +33,10 @@ public extension LemonadeUi {
     ///     accessibility. The component leaves it unset by default so the label can be localised by
     ///     the consumer; supply one whenever the field is `dismissible`.
     ///   - enabled: Flag to enable or disable the component
+    ///   - isFocused: Optional binding to the host's own `@FocusState`, for hosts that need to read
+    ///     the focus or drive it — moving the field into a toolbar when a search begins, say, or
+    ///     handing focus to a replacement field. Left unset the field keeps its own focus state and
+    ///     behaves exactly as before.
     /// - Returns: A styled SearchField view
     @ViewBuilder
     static func SearchField(
@@ -43,7 +47,8 @@ public extension LemonadeUi {
         dismissible: Bool = true,
         onCancel: (() -> Void)? = nil,
         cancelContentDescription: String? = nil,
-        enabled: Bool = true
+        enabled: Bool = true,
+        isFocused: FocusState<Bool>.Binding? = nil
     ) -> some View {
         LemonadeSearchFieldView(
             input: input,
@@ -53,7 +58,8 @@ public extension LemonadeUi {
             dismissible: dismissible,
             onCancel: onCancel,
             cancelContentDescription: cancelContentDescription,
-            enabled: enabled
+            enabled: enabled,
+            externalFocus: isFocused
         )
     }
 }
@@ -70,7 +76,12 @@ private struct LemonadeSearchFieldView: View {
     let cancelContentDescription: String?
     let enabled: Bool
 
-    @FocusState private var isFocused: Bool
+    /// The host's focus state when it supplied one; otherwise the field falls back to its own.
+    private let externalFocus: FocusState<Bool>.Binding?
+    @FocusState private var ownFocus: Bool
+
+    private var focus: FocusState<Bool>.Binding { externalFocus ?? $ownFocus }
+    private var isFocused: Bool { focus.wrappedValue }
 
     /// Mirrors `shouldShowCancel`, but is only ever written from inside an explicit `withAnimation`.
     /// `@FocusState` updates arrive without an animation transaction, so an `if` driven straight off
@@ -88,7 +99,8 @@ private struct LemonadeSearchFieldView: View {
         dismissible: Bool,
         onCancel: (() -> Void)?,
         cancelContentDescription: String?,
-        enabled: Bool
+        enabled: Bool,
+        externalFocus: FocusState<Bool>.Binding?
     ) {
         self._input = input
         self.onInputChanged = onInputChanged
@@ -98,6 +110,7 @@ private struct LemonadeSearchFieldView: View {
         self.onCancel = onCancel
         self.cancelContentDescription = cancelContentDescription
         self.enabled = enabled
+        self.externalFocus = externalFocus
         // Same predicate as `shouldShowCancel`, minus focus — nothing is focused before first render.
         self._isCancelPresented = State(
             initialValue: dismissible && enabled && !input.wrappedValue.isEmpty
@@ -142,7 +155,7 @@ private struct LemonadeSearchFieldView: View {
                     icon: .times,
                     contentDescription: cancelContentDescription,
                     onClick: {
-                        isFocused = false
+                        focus.wrappedValue = false
                         // Deliberately not routed through `onInputClear`: that callback belongs to
                         // the inner clear icon, and a consumer who overrides it to only log would
                         // otherwise stop cancel from emptying the field.
@@ -186,7 +199,7 @@ private struct LemonadeSearchFieldView: View {
                     .font(LemonadeTypography.shared.bodyMediumRegular.font)
                     .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
                     .tint(LemonadeTheme.colors.content.contentPrimary)
-                    .focused($isFocused)
+                    .focused(focus)
                     .disabled(!enabled)
                     .onChange(of: input) { newValue in
                         onInputChanged?(newValue)

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -111,9 +111,12 @@ private struct LemonadeSearchFieldView: View {
         self.cancelContentDescription = cancelContentDescription
         self.enabled = enabled
         self.externalFocus = externalFocus
-        // Same predicate as `shouldShowCancel`, minus focus — nothing is focused before first render.
+        // The full `shouldShowCancel` predicate, focus included: a host that drives focus can hand
+        // the field a caret before its first render, and `onChange` only fires on a change, so a
+        // field born focused would otherwise never draw its cancel button at all.
         self._isCancelPresented = State(
-            initialValue: dismissible && enabled && !input.wrappedValue.isEmpty
+            initialValue: dismissible && enabled
+                && (externalFocus?.wrappedValue == true || !input.wrappedValue.isEmpty)
         )
     }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -77,34 +77,12 @@ private struct LemonadeSearchFieldView: View {
     let cancelContentDescription: String?
     let enabled: Bool
 
-    /// The host's mirror of the focus, when it supplied one. The field always drives the real
-    /// `@FocusState` itself: a plain binding cannot invalidate this view, so reading focus straight
-    /// off it would leave everything keyed on focus — the cancel button above all — updating only
-    /// when the host happened to redraw us.
-    private let externalFocus: Binding<Bool>?
+    /// The host's mirror of the focus, when it supplied one. The field still owns the real
+    /// `@FocusState`: `.focused(_:)` takes nothing else, and it is what invalidates this view when
+    /// the *user* focuses or dismisses the field — a change the host's binding only learns about
+    /// once we write it back. Everything keyed on focus, the cancel button above all, hangs off it.
+    let externalFocus: Binding<Bool>?
     @FocusState private var isFocused: Bool
-
-    init(
-        input: Binding<String>,
-        onInputChanged: ((String) -> Void)?,
-        placeholder: String?,
-        onInputClear: (() -> Void)?,
-        dismissible: Bool,
-        onCancel: (() -> Void)?,
-        cancelContentDescription: String?,
-        enabled: Bool,
-        externalFocus: Binding<Bool>?
-    ) {
-        self._input = input
-        self.onInputChanged = onInputChanged
-        self.placeholder = placeholder
-        self.onInputClear = onInputClear
-        self.dismissible = dismissible
-        self.onCancel = onCancel
-        self.cancelContentDescription = cancelContentDescription
-        self.enabled = enabled
-        self.externalFocus = externalFocus
-    }
 
     private let height: CGFloat = LemonadeTheme.sizes.size1100
     private let horizontalPadding: CGFloat = LemonadeTheme.spaces.spacing300
@@ -161,8 +139,8 @@ private struct LemonadeSearchFieldView: View {
         }
         .animation(.easeInOut(duration: animationDuration), value: shouldShowCancel)
         .onChange(of: isFocused) { newValue in
-            guard externalFocus?.wrappedValue != newValue else { return }
-            externalFocus?.wrappedValue = newValue
+            guard let externalFocus, externalFocus.wrappedValue != newValue else { return }
+            externalFocus.wrappedValue = newValue
         }
         .onChange(of: externalFocus?.wrappedValue) { newValue in
             guard let newValue, newValue != isFocused else { return }
@@ -170,8 +148,13 @@ private struct LemonadeSearchFieldView: View {
         }
         .onAppear {
             // A host can hand the field focus before it ever renders — a search promoted into a
-            // toolbar does exactly that — so adopt whatever it asked for on the way in.
-            if let wanted = externalFocus?.wrappedValue, wanted != isFocused { isFocused = wanted }
+            // toolbar does exactly that — so adopt what it asked for on the way in. Nothing is
+            // focused yet at this point, so only a requested `true` is worth acting on, and it has
+            // to wait a frame: a `@FocusState` set synchronously from `onAppear` lands before the
+            // field is in the hierarchy and is dropped. `LemonadePinCode` defers auto-focus for the
+            // same reason.
+            guard externalFocus?.wrappedValue == true else { return }
+            DispatchQueue.main.async { isFocused = true }
         }
     }
 
@@ -289,6 +272,21 @@ struct LemonadeSearchField_Previews: PreviewProvider {
                     placeholder: "Disabled search",
                     enabled: false
                 )
+            }
+
+            // Host-owned focus: the button drives the field, the field reports back.
+            StatefulPreviewWrapper(false) { focus in
+                StatefulPreviewWrapper("") { input in
+                    VStack(alignment: .leading, spacing: 8) {
+                        LemonadeUi.SearchField(
+                            input: input,
+                            placeholder: "Host-driven focus...",
+                            isFocused: focus
+                        )
+
+                        SwiftUI.Button("Focus from the host") { focus.wrappedValue = true }
+                    }
+                }
             }
         }
         .padding()

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -33,10 +33,11 @@ public extension LemonadeUi {
     ///     accessibility. The component leaves it unset by default so the label can be localised by
     ///     the consumer; supply one whenever the field is `dismissible`.
     ///   - enabled: Flag to enable or disable the component
-    ///   - isFocused: Optional binding to the host's own `@FocusState`, for hosts that need to read
-    ///     the focus or drive it — moving the field into a toolbar when a search begins, say, or
-    ///     handing focus to a replacement field. Left unset the field keeps its own focus state and
-    ///     behaves exactly as before.
+    ///   - isFocused: Optional two-way binding to the field's focus, for hosts that need to read it
+    ///     or drive it — moving the field into a toolbar when a search begins, say, or handing focus
+    ///     to a replacement field. Writing `true` focuses the field and raises the keyboard; the
+    ///     field writes back whenever the user focuses or dismisses it. Left unset the field keeps
+    ///     its focus entirely to itself and behaves exactly as before.
     /// - Returns: A styled SearchField view
     @ViewBuilder
     static func SearchField(
@@ -48,7 +49,7 @@ public extension LemonadeUi {
         onCancel: (() -> Void)? = nil,
         cancelContentDescription: String? = nil,
         enabled: Bool = true,
-        isFocused: FocusState<Bool>.Binding? = nil
+        isFocused: Binding<Bool>? = nil
     ) -> some View {
         LemonadeSearchFieldView(
             input: input,
@@ -76,12 +77,12 @@ private struct LemonadeSearchFieldView: View {
     let cancelContentDescription: String?
     let enabled: Bool
 
-    /// The host's focus state when it supplied one; otherwise the field falls back to its own.
-    private let externalFocus: FocusState<Bool>.Binding?
-    @FocusState private var ownFocus: Bool
-
-    private var focus: FocusState<Bool>.Binding { externalFocus ?? $ownFocus }
-    private var isFocused: Bool { focus.wrappedValue }
+    /// The host's mirror of the focus, when it supplied one. The field always drives the real
+    /// `@FocusState` itself: a plain binding cannot invalidate this view, so reading focus straight
+    /// off it would leave everything keyed on focus — the cancel button above all — updating only
+    /// when the host happened to redraw us.
+    private let externalFocus: Binding<Bool>?
+    @FocusState private var isFocused: Bool
 
     /// Mirrors `shouldShowCancel`, but is only ever written from inside an explicit `withAnimation`.
     /// `@FocusState` updates arrive without an animation transaction, so an `if` driven straight off
@@ -100,7 +101,7 @@ private struct LemonadeSearchFieldView: View {
         onCancel: (() -> Void)?,
         cancelContentDescription: String?,
         enabled: Bool,
-        externalFocus: FocusState<Bool>.Binding?
+        externalFocus: Binding<Bool>?
     ) {
         self._input = input
         self.onInputChanged = onInputChanged
@@ -158,7 +159,7 @@ private struct LemonadeSearchFieldView: View {
                     icon: .times,
                     contentDescription: cancelContentDescription,
                     onClick: {
-                        focus.wrappedValue = false
+                        isFocused = false
                         // Deliberately not routed through `onInputClear`: that callback belongs to
                         // the inner clear icon, and a consumer who overrides it to only log would
                         // otherwise stop cancel from emptying the field.
@@ -175,6 +176,19 @@ private struct LemonadeSearchFieldView: View {
         }
         .onChange(of: shouldShowCancel) { newValue in
             withAnimation(.easeInOut(duration: animationDuration)) { isCancelPresented = newValue }
+        }
+        .onChange(of: isFocused) { newValue in
+            guard externalFocus?.wrappedValue != newValue else { return }
+            externalFocus?.wrappedValue = newValue
+        }
+        .onChange(of: externalFocus?.wrappedValue) { newValue in
+            guard let newValue, newValue != isFocused else { return }
+            isFocused = newValue
+        }
+        .onAppear {
+            // A host can hand the field focus before it ever renders — a search promoted into a
+            // toolbar does exactly that — so adopt whatever it asked for on the way in.
+            if let wanted = externalFocus?.wrappedValue, wanted != isFocused { isFocused = wanted }
         }
     }
 
@@ -202,7 +216,7 @@ private struct LemonadeSearchFieldView: View {
                     .font(LemonadeTypography.shared.bodyMediumRegular.font)
                     .foregroundStyle(LemonadeTheme.colors.content.contentPrimary)
                     .tint(LemonadeTheme.colors.content.contentPrimary)
-                    .focused(focus)
+                    .focused($isFocused)
                     .disabled(!enabled)
                     .onChange(of: input) { newValue in
                         onInputChanged?(newValue)


### PR DESCRIPTION
# Summary

`LemonadeSearchField` kept its focus entirely to itself, which is fine until a screen needs to do something with it.

The case that surfaced this: promoting search into the navigation bar. The host puts a field in the toolbar when a search begins and has to hand focus to it — otherwise the user taps search and no keyboard arrives. Reading focus was equally unreachable, so a screen could not tell whether a search was under way.

`isFocused` now takes the host's own `@FocusState` binding and the field defers to it:

```swift
@FocusState private var searchFocused: Bool

LemonadeUi.SearchField(
    input: $query,
    placeholder: "Search by company name",
    isFocused: $searchFocused
)
```

Left unset, the field allocates its own focus state and behaves exactly as before.

No Android counterpart: Compose already covers both directions through the existing parameters — `interactionSource` reads focus, and `Modifier.focusRequester` drives it via `modifier`.

## Figma component

No visual change — this is an API addition only.

## Screenshot

No visual change.

## API Dump

No public API changes — the SwiftUI package carries no `api/` baseline, and nothing under `kmp/` was touched.

**Verdict:** ADDITIONS_ONLY

**Changes that are not a concern, and why:**
- New parameter is optional with a `nil` default and sits last in the signature, so existing call sites compile untouched. The sample app builds without modification, which exercises them.
