### PR TITLE
fix(toast): wrap long labels and fill the toast width

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/ToastDisplay.kt
@@ -55,6 +55,15 @@ internal fun ToastDisplay() {
                     )
                 },
             )
+            LemonadeUi.Button(
+                label = "Long Label",
+                onClick = {
+                    toastState.show(
+                        label = "Something went wrong. Please try again, or contact support if the error persists.",
+                        voice = ToastVoice.Error,
+                    )
+                },
+            )
         }
 
         ToastSection("Loading") {

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Toast.android.kt
@@ -12,8 +12,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -23,15 +24,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
@@ -53,8 +53,15 @@ internal actual fun PlatformToastHost(
 
 /**
  * Draws the toast in its own [Dialog] window so it z-orders above any open ModalBottomSheet / Dialog.
- * `FLAG_NOT_FOCUSABLE` (implies `FLAG_NOT_TOUCH_MODAL`) passes touches outside the toast through to the
+ * `FLAG_NOT_FOCUSABLE` (implies `FLAG_NOT_TOUCH_MODAL`) passes touches outside the window through to the
  * content beneath and never takes input focus.
+ *
+ * Pass-through is bounded by the *window*, not the pill. The window spans the full width (see
+ * [ConfigureToastWindow]), so while a toast is visible, taps in the horizontal band it occupies are
+ * swallowed even beside a short, narrow pill — they don't reach the content behind. The band is the
+ * height of the toast at the bottom of the screen and lasts only as long as the toast is on screen.
+ * Sizing the window to the pill instead would restore that pass-through, but re-applies the platform's
+ * 320dp dialog width cap and stops a wrapped label from ever filling the width.
  */
 @Composable
 private fun ToastOverlayWindow(toastState: LemonadeToastState) {
@@ -88,11 +95,11 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
         val startInset = margins.calculateStartPadding(layoutDirection)
         val endInset = margins.calculateEndPadding(layoutDirection)
         ConfigureToastWindow(bottomInset = margins.calculateBottomPadding())
-        // The window is centered; start/end insets only cap the width (the toast keeps clear of the
-        // screen edges). Unlike the inline host they don't shift it horizontally — a bottom-centered
-        // toast has no caller that needs asymmetric horizontal positioning.
-        val maxToastWidth = (LocalConfiguration.current.screenWidthDp.dp - startInset - endInset)
-            .coerceAtLeast(0.dp)
+        // The window spans the full width and the insets are applied here, in Compose. Sizing the window
+        // to WRAP_CONTENT instead would re-apply the platform's 320dp dialog width cap that
+        // `usePlatformDefaultWidth = false` exists to remove, which stops a wrapped label from ever
+        // reaching the full width. Unlike the inline host the insets don't shift the toast horizontally —
+        // a bottom-centered toast has no caller that needs asymmetric horizontal positioning.
 
         LaunchedEffect(toast) {
             if (toast != null) {
@@ -103,10 +110,10 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
             }
         }
 
-        // Keep the toast always composed so the wrap-content window measures one fixed size and stays
-        // centered. Animating it in with AnimatedVisibility resized the window as the content appeared,
-        // which made the entrance drift in from the side. Drive enter/exit as a draw-only alpha +
-        // vertical translation instead — those never re-measure the window.
+        // Keep the toast always composed so the window measures one fixed size. Animating it in with
+        // AnimatedVisibility resized the window as the content appeared, which made the entrance drift
+        // in from the side. Drive enter/exit as a draw-only alpha + vertical translation instead —
+        // those never re-measure the window.
         var toastHeightPx by remember { mutableIntStateOf(0) }
         val transition = updateTransition(animState, label = "toast")
         val alpha by transition.animateFloat(label = "alpha") { visible -> if (visible) 1f else 0f }
@@ -117,12 +124,14 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
 
         Box(
             modifier = Modifier
-                .widthIn(max = maxToastWidth)
+                .fillMaxWidth()
+                .padding(start = startInset, end = endInset)
                 .onSizeChanged { toastHeightPx = it.height }
                 .graphicsLayer {
                     this.alpha = alpha
                     this.translationY = translationY
                 },
+            contentAlignment = Alignment.Center,
         ) {
             SwipeableToast(
                 toast = displayToast,
@@ -133,9 +142,12 @@ private fun ToastOverlayWindow(toastState: LemonadeToastState) {
 }
 
 /**
- * Sizes the dialog window to the toast and lifts it [bottomInset] (plus the navigation-bar inset)
- * above the bottom via a window attribute, not padding — so the frame hugs the pill and taps
- * everywhere else fall through. The navigation-bar inset resolves to zero when the window already
+ * Spans the dialog window across the screen and lifts it [bottomInset] (plus the navigation-bar inset)
+ * above the bottom via a window attribute, not padding — so the frame hugs the pill vertically and taps
+ * above and below it fall through (but not beside it — see [ToastOverlayWindow]). `MATCH_PARENT` is
+ * deliberate: `WRAP_CONTENT` re-applies the platform's 320dp dialog width cap that
+ * `usePlatformDefaultWidth = false` exists to remove, which caps the toast well short of the screen.
+ * The navigation-bar inset resolves to zero when the window already
  * sits above the bars and to the bar height on edge-to-edge screens, so the toast never lands under
  * the navigation bar.
  */
@@ -154,7 +166,7 @@ private fun ConfigureToastWindow(bottomInset: Dp) {
                     WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
             )
             setLayout(
-                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.MATCH_PARENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
             )
             attributes = attributes.apply {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -369,8 +368,6 @@ private fun CoreToast(
             text = label,
             textStyle = LocalTypographies.current.bodySmallMedium,
             color = colors.content.contentPrimaryInverse,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .weight(weight = 1f, fill = false)
                 .padding(horizontal = spaces.spacing100),

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Toast.kt
@@ -335,6 +335,10 @@ private fun CoreToast(
         ToastVoice.Neutral, ToastVoice.Loading -> colors.content.contentNeutralOnColor
     }
 
+    // A label that wraps stretches the row to the full width the host allows, so a multi-line toast
+    // reads as a block instead of a ragged pill. A single-line label still hugs its content.
+    var labelWraps by remember(label) { mutableStateOf(false) }
+
     Row(
         modifier = modifier
             .heightIn(min = sizes.size1100)
@@ -368,8 +372,9 @@ private fun CoreToast(
             text = label,
             textStyle = LocalTypographies.current.bodySmallMedium,
             color = colors.content.contentPrimaryInverse,
+            onTextLayout = { labelWraps = it.lineCount > 1 },
             modifier = Modifier
-                .weight(weight = 1f, fill = false)
+                .weight(weight = 1f, fill = labelWraps)
                 .padding(horizontal = spaces.spacing100),
         )
 


### PR DESCRIPTION
# Summary

A toast label longer than the toast was cut off: the KMP toast capped it at one line with an ellipsis, while SwiftUI's `.lineLimit(nil)` rendered the same string in full. Lifting that cap alone left the row shrinking to the widest wrapped line — a ragged pill stopping well short of the screen.

This PR does both halves: a long label wraps, and a wrapped label fills the width the host allows, inset by `spacing400` on each side. A single-line label still hugs its content and stays centered.

Found from a consumer side: the Direct Debit setup error in teya-business-app reads *"Something went wrong. Please try again, or contact support if the error persists."* — complete on iOS, ellipsised after a few words on Android.

## What changed

**1. The label wraps.** Dropped `maxLines = 1` / `overflow = Ellipsis` from the label in `private fun CoreToast`, falling back to `LemonadeUi.Text`'s default `maxLines = Int.MAX_VALUE` — what `.lineLimit(nil)` already gives SwiftUI. `show()` gained no parameter; there was no way to opt out of the truncation before, and now there is nothing to opt out of.

**2. A wrapped label fills the width.** Two things had to change here, and the first alone did nothing:

- The label's weight used `fill = false`, letting the row collapse to the widest wrapped line. It now fills only when the label actually wraps, driven by `onTextLayout`'s `lineCount`.
- The real cap was the Android overlay window. `ConfigureToastWindow` sized it `WRAP_CONTENT`, which re-applies the platform's **320dp dialog width cap** that `usePlatformDefaultWidth = false` exists to remove. Instrumenting the row showed it measured with `maxWidth` 840px while the file's own `maxToastWidth` computed 995px — so no amount of filling could get past 320dp. The window is now `MATCH_PARENT`, with the start/end insets applied in Compose instead.

I confirmed the weight change was insufficient on its own by forcing `fill = true` unconditionally and re-measuring: byte-identical 320dp. That is what pointed at the window rather than the layout.

The fill rule lives in common `CoreToast`, so the inline host (iOS/desktop Compose) inherits it; only the window sizing is Android-specific.

## Worth your opinion

**Tall toasts.** A very long label now produces a tall toast, where before it was always one line. That matches iOS today, so I've treated the one-line cap as the bug. If you'd rather bound it, the natural alternative is a `maxLines` parameter on `show()` defaulting to something like 2 or 3.

**Touch pass-through — a deliberate regression.** This is now bounded by the *window* rather than the pill, so while a toast is visible, taps in the horizontal band it occupies no longer reach the content behind it, even beside a short, narrow toast. The band is the height of the toast at the bottom of the screen and lasts only as long as the toast (3–9s). I verified it directly: with "Link copied" showing, a tap on the button beside it did not register. Sizing the window to the pill would restore pass-through but reinstates the 320dp cap. Both KDoc blocks document this. Happy to rework the window to follow the measured pill width if you'd rather keep it.

**SwiftUI parity.** `LemonadeToast.swift` has no `maxWidth: .infinity`, so it still hugs and wraps ragged — the shape KMP had before this PR. Left alone here; matching it is a follow-up.

## Figma component

n/a — this restores parity with the existing SwiftUI implementation rather than changing the design.

## Screenshot

Added a **Long Label** entry to the sample app's Toast screen (Voice Variants section) that fires the message above, so the behaviour is visible in `composeApp` on both platforms.

Measured from a full-resolution `screencap` on a Pixel 10a (1080px, 420dpi), multi-line toast:

```
width       = 996px = 379.4dp
left inset  =  42px =  16.0dp   (spacing400)
right inset =  42px =  16.0dp   (spacing400)
```

Before the width fix, the same toast measured 842px / 320.8dp with 45dp insets. A single-line toast ("Link copied") still hugs at 139.8dp, centered.

## API Dump

**Verdict:** NO_CHANGES

`.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` reports *"NO_CHANGES — public API is identical. Nothing to review."* The changes are inside `private fun CoreToast` and the internal Android host, so no public declaration is touched and no `api/` baseline moved.

**Changes that are not a concern, and why:**
- None — the baseline is unchanged.

**Genuine breaking changes (if any):**
- None.

## How to test

1. Run the Compose sample app (`:composeApp`) on an Android device or emulator.
2. Navigate to **Toast** (Display Components section).
3. Tap **Long Label** under Voice Variants — the toast should wrap and span the full width, `spacing400` (16dp) clear of both screen edges, with no ragged right edge.
4. Tap **Neutral with Icon** ("Link copied") — a single-line toast should still hug its content and stay centered, not stretch.
5. Swipe a toast down to confirm swipe-to-dismiss still works.
6. Tap **Success Toast with Action** to confirm the action button still sits at the trailing end.
