### PR TITLE
feat(tabs): let a host hide the tab divider

### DIFF
--- a/swiftui/SampleApp/TabsDisplayView.swift
+++ b/swiftui/SampleApp/TabsDisplayView.swift
@@ -8,6 +8,7 @@ struct TabsDisplayView: View {
     @State private var iconTabsSelectedIndex = 0
     @State private var disabledTabsSelectedIndex = 0
     @State private var rightEdgeSelectedIndex = 5
+    @State private var noDividerSelectedIndex = 0
 
     var body: some View {
         ScrollView {
@@ -88,6 +89,19 @@ struct TabsDisplayView: View {
                         ],
                         selectedIndex: disabledTabsSelectedIndex,
                         onTabSelected: { disabledTabsSelectedIndex = $0 }
+                    )
+                }
+
+                sectionView(title: "Without Divider") {
+                    LemonadeUi.Tabs(
+                        tabs: [
+                            LemonadeTabItem(label: "Overview"),
+                            LemonadeTabItem(label: "Details"),
+                            LemonadeTabItem(label: "Reviews")
+                        ],
+                        selectedIndex: noDividerSelectedIndex,
+                        onTabSelected: { noDividerSelectedIndex = $0 },
+                        showDivider: false
                     )
                 }
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeTabs.swift
@@ -51,19 +51,23 @@ public extension LemonadeUi {
     ///   - selectedIndex: Index of the currently selected tab
     ///   - onTabSelected: Callback invoked with the tab index when tapped
     ///   - itemsSize: `.hug` for content-sized scrollable tabs, `.stretch` for equal-width tabs
+    ///   - showDivider: Flag to show a divider below the tabs. Defaults to true.
+    ///     Pass `false` when the host already draws its own separator.
     /// - Returns: A styled tabs view
     @ViewBuilder
     static func Tabs(
         tabs: [LemonadeTabItem],
         selectedIndex: Int,
         onTabSelected: @escaping (Int) -> Void,
-        itemsSize: TabItemsSize = .hug
+        itemsSize: TabItemsSize = .hug,
+        showDivider: Bool = true
     ) -> some View {
         LemonadeTabsView(
             tabs: tabs,
             selectedIndex: selectedIndex,
             onTabSelected: onTabSelected,
-            itemsSize: itemsSize
+            itemsSize: itemsSize,
+            showDivider: showDivider
         )
     }
 }
@@ -75,6 +79,7 @@ private struct LemonadeTabsView: View {
     let selectedIndex: Int
     let onTabSelected: (Int) -> Void
     let itemsSize: TabItemsSize
+    let showDivider: Bool
 
     @Namespace private var tabNamespace
     @State private var contentWidth: CGFloat = 0
@@ -154,9 +159,9 @@ private struct LemonadeTabsView: View {
                 tabRow
             }
 
-            Rectangle()
-                .fill(LemonadeTheme.colors.border.borderNeutralLow)
-                .frame(height: LemonadeTheme.borderWidth.base.border25)
+            if showDivider {
+                LemonadeUi.HorizontalDivider()
+            }
         }
     }
 
@@ -455,7 +460,7 @@ struct LemonadeTabs_Previews: PreviewProvider {
                 onTabSelected: { _ in }
             )
 
-            // Stretch mode
+            // Stretch mode, without the bottom divider
             LemonadeUi.Tabs(
                 tabs: [
                     LemonadeTabItem(label: "Tab A"),
@@ -464,7 +469,8 @@ struct LemonadeTabs_Previews: PreviewProvider {
                 ],
                 selectedIndex: 0,
                 onTabSelected: { _ in },
-                itemsSize: .stretch
+                itemsSize: .stretch,
+                showDivider: false
             )
         }
         .previewLayout(.sizeThatFits)


### PR DESCRIPTION
# Summary

`LemonadeUi.Tabs` always drew a subtle bottom border. When the component sits inside a scroll edge effect, the host already supplies its own separator, so the two double up. This adds `showDivider` to the SwiftUI `Tabs`, defaulting to `true` so nothing changes for existing call sites.

```swift
LemonadeUi.Tabs(
    tabs: tabs,
    selectedIndex: index,
    onTabSelected: { index = $0 },
    showDivider: false
)
```

**What's in here**

- `showDivider: Bool = true` appended to `LemonadeUi.Tabs` — last position, so every existing call site keeps compiling untouched.
- Hiding the divider omits the view entirely rather than making it transparent, so its `border25` height leaves the layout and the tabs end flush against the host's own line. That is the point of the flag — a zero-opacity divider would still hold the gap open.
- The divider now reuses `LemonadeUi.HorizontalDivider()` instead of a hand-rolled `Rectangle().fill(borderNeutralLow).frame(height: border25)`. Identical tokens and pixels, and it matches the `if showDivider { LemonadeUi.HorizontalDivider() }` shape `ListItemSafeArea` already uses — so a future change to the divider's treatment no longer silently skips Tabs.
- Sample app: new **"Without Divider"** section in `TabsDisplayView`.
- Preview: the existing "Stretch mode" case now passes `showDivider: false` rather than adding a near-duplicate sixth case.

The naming follows `showDivider: Bool` as used by `LemonadeListItem`, `LemonadeActionListItem` and `LemonadeResourceListItem`. The default differs from theirs (`false`) because each component's default preserves its own prior behaviour, and Tabs previously always drew the border.

**Scope:** SwiftUI only, as requested — better fit for hosts using the scroll edge effect. The KMP `Tabs` is unchanged, so the two platforms' signatures now differ; worth a follow-up if we want parity.

## Figma component

n/a — no visual change by default; this only lets a host opt out of an existing element.

## Screenshot
<img width="300" src="https://github.com/user-attachments/assets/fdc1ca11-fedd-4273-82bd-829e3baea487" />

Not attached — the change is the *absence* of a 1px hairline, which does not survive image compression legibly. It is verifiable in the sample app under **Tabs → Without Divider**.

## API Dump

No public API changes.

<!--
KMP untouched — no kmp/<module>/api/*.api or *.klib.api file is modified by this PR.
The Swift-side signature change is source-compatible (defaulted trailing parameter)
and the BCV baseline does not cover SwiftUI.
-->
