### PR TITLE
fix(assets): decode the new vector when an asset slot changes resource

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/AssetPainter.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/AssetPainter.kt
@@ -1,9 +1,11 @@
 package com.teya.lemonade
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
@@ -41,12 +43,10 @@ internal fun rememberAssetPainter(resource: DrawableResource): Painter {
     }
     val density = LocalDensity.current
     val environment = rememberResourceEnvironment()
-    val imageVector by produceState(
-        initialValue = assetVectorCache[resource],
-        key1 = resource,
-    ) {
-        if (value == null) {
-            value = withContext(context = Dispatchers.Default) {
+    var imageVector by remember(resource) { mutableStateOf(assetVectorCache[resource]) }
+    LaunchedEffect(resource) {
+        if (imageVector == null) {
+            imageVector = withContext(context = Dispatchers.Default) {
                 getDrawableResourceBytes(
                     environment = environment,
                     resource = resource,


### PR DESCRIPTION
# Summary

`rememberAssetPainter` never decoded a second resource in the same composition slot, so `LemonadeUi.CountryFlag`, `LemonadeUi.Icon` and `LemonadeUi.BrandLogo` kept rendering whichever asset they decoded first when their `resource` changed in place.

`produceState` backs its state with an unkeyed `remember { mutableStateOf(initialValue) }`, so the previously decoded `ImageVector` survives a `key1` change. The producer restarted on the new resource, hit `if (value == null)` with the old non-null vector still in place, and returned without decoding. The stale asset then stayed on screen for the lifetime of that slot.

The fix drops `produceState` for `remember(resource) { mutableStateOf(assetVectorCache[resource]) }` plus a `LaunchedEffect(resource)`. The state now re-initialises from the cache on every resource change — a cache hit renders synchronously with no extra decode, a miss decodes off the main thread exactly as before.

Reported downstream in the Teya app: picking a country in the phone-number field updated the dial code to `+351` but left the UK flag on screen. Grids and lists were unaffected because each item composes its own slot, which is why the catalog never showed it.

## Figma component

n/a — behaviour fix, no design change.

## API Dump

No public API changes. `rememberAssetPainter` is `internal`; `bcv-check.sh --ci` reports `NO_CHANGES`.

## Test plan

- [x] `./gradlew detektMetadataCommonMain ktlintCheck`
- [x] `./gradlew :ui:lint`
- [x] `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` → `NO_CHANGES`
- [x] Catalog on a Pixel 9 Pro emulator: a flag cycling through `GB → PT → IS → HR` in one slot follows the code; on `origin/main` the same build freezes on `GB`
- [x] Static grid of every flag and the icon galleries still render on first composition
