### PR TITLE
fix(card): tighten the header top padding and floor the overline box

### DIFF
--- a/kmp/ui/api/android/ui.api
+++ b/kmp/ui/api/android/ui.api
@@ -85,6 +85,7 @@ public final class com/teya/lemonade/ComposableSingletons$CardKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$CardKt;
 	public fun <init> ()V
 	public final fun getLambda$-184555069$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1863766657$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-33923509$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$262353886$ui_release ()Lkotlin/jvm/functions/Function3;
 }

--- a/kmp/ui/api/desktop/ui.api
+++ b/kmp/ui/api/desktop/ui.api
@@ -85,6 +85,7 @@ public final class com/teya/lemonade/ComposableSingletons$CardKt {
 	public static final field INSTANCE Lcom/teya/lemonade/ComposableSingletons$CardKt;
 	public fun <init> ()V
 	public final fun getLambda$-184555069$ui ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1863766657$ui ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-33923509$ui ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$262353886$ui ()Lkotlin/jvm/functions/Function3;
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -144,7 +145,7 @@ private fun CardHeader(
         modifier = modifier
             .padding(
                 start = LocalSpaces.current.spacing400,
-                top = LocalSpaces.current.spacing400,
+                top = LocalSpaces.current.spacing300,
                 end = LocalSpaces.current.spacing400,
                 bottom = LocalSpaces.current.spacing0,
             ),
@@ -153,7 +154,12 @@ private fun CardHeader(
             config.leadingSlot.invoke(this)
         }
 
-        Column(modifier = Modifier.weight(1F)) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .weight(1F)
+                .defaultMinSize(minHeight = config.headingStyle.minTextBoxHeight),
+        ) {
             LemonadeUi.Text(
                 text = config.title,
                 textStyle = titleTextStyle,
@@ -230,6 +236,17 @@ private val LemonadeCardHeadingStyle.textStyle: LemonadeTextStyle
         return when (this) {
             LemonadeCardHeadingStyle.Default -> LocalTypographies.current.headingXXSmall
             LemonadeCardHeadingStyle.Overline -> LocalTypographies.current.bodyXSmallOverline
+        }
+    }
+
+// The overline's own line box is only 16dp, so a header titled with just an overline would
+// sit tighter than one with a default heading. Holding the text box to a minimum of size500
+// evens that out. The default heading is already taller, so it keeps wrapping its own text.
+private val LemonadeCardHeadingStyle.minTextBoxHeight: Dp
+    @Composable get() {
+        return when (this) {
+            LemonadeCardHeadingStyle.Default -> Dp.Unspecified
+            LemonadeCardHeadingStyle.Overline -> LocalSizes.current.size500
         }
     }
 
@@ -316,6 +333,20 @@ private fun CardHeadingSubtitlePreview() {
             )
         }
     }
+}
+
+// The overline's minimum box height only changes the layout when nothing else in the header
+// row is taller than it — no subtitle, no trailing slot — so keep that case previewed.
+@LemonadePreview
+@Composable
+private fun CardOverlineHeadingPreview() {
+    LemonadeUi.Card(
+        header = CardHeaderConfig(
+            title = "Card heading",
+            headingStyle = LemonadeCardHeadingStyle.Overline,
+        ),
+        content = {},
+    )
 }
 
 @OptIn(InternalLemonadeApi::class)

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Card.kt
@@ -239,9 +239,11 @@ private val LemonadeCardHeadingStyle.textStyle: LemonadeTextStyle
         }
     }
 
-// The overline's own line box is only 16dp, so a header titled with just an overline would
-// sit tighter than one with a default heading. Holding the text box to a minimum of size500
-// evens that out. The default heading is already taller, so it keeps wrapping its own text.
+// The overline's own line box is 16sp against the default heading's 24sp, so a header titled
+// with just an overline would sit tighter than one with a default heading. Holding the text box
+// to a minimum of size500 evens that out. The floor is in dp while the line box is in sp, so at
+// large font scales the line box outgrows the floor and wins — which is what we want, since the
+// text must never be clipped to keep the box at 20.
 private val LemonadeCardHeadingStyle.minTextBoxHeight: Dp
     @Composable get() {
         return when (this) {

--- a/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeCard.swift
@@ -56,6 +56,16 @@ public enum LemonadeCardHeadingStyle {
         case .overline: return LemonadeTheme.colors.content.contentSecondary
         }
     }
+
+    /// The overline's own line box is only 16pt, so a header titled with just an overline would
+    /// sit tighter than one with a default heading. Holding the text box to a minimum of size500
+    /// evens that out. The default heading is already taller, so it keeps wrapping its own text.
+    var minTextBoxHeight: CGFloat? {
+        switch self {
+        case .default: return nil
+        case .overline: return LemonadeTheme.sizes.size500
+        }
+    }
 }
 
 // MARK: - Card Header Config
@@ -262,7 +272,13 @@ private struct LemonadeCardHeader<LeadingContent: View, TrailingContent: View>: 
                     )
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // The vertical half of the alignment is load-bearing: it is what centres an
+            // overline inside the taller box its minimum height opens up.
+            .frame(
+                maxWidth: .infinity,
+                minHeight: config.headingStyle.minTextBoxHeight,
+                alignment: Alignment(horizontal: .leading, vertical: .center)
+            )
 
             if let trailingSlot = config.trailingSlot {
                 trailingSlot()
@@ -278,7 +294,7 @@ private struct LemonadeCardHeader<LeadingContent: View, TrailingContent: View>: 
             }
         }
         .padding(.horizontal, LemonadeTheme.spaces.spacing400)
-        .padding(.top, LemonadeTheme.spaces.spacing400)
+        .padding(.top, LemonadeTheme.spaces.spacing300)
     }
 }
 


### PR DESCRIPTION
# Summary

Two adjustments to the card header, both platforms.

**Top padding** moves from `spacing400` (16) to `spacing300` (12).

**The overline heading now renders in a minimum 20pt line box.** `bodyXSmallOverline` carries `lineHeight400` = 16, against the 24 that `headingXXSmall` gives the default heading — so a card titled with just an overline sat noticeably tighter than one with a default heading. The title/subtitle box now has a minimum height of `size500` (20) in the overline variant, with the text centred inside it. The default variant is untouched.

It is a *minimum*, not a fixed height: an overline with a subtitle already exceeds 20 (16 + 20) and is left alone. The floor only changes the layout when nothing else in the header row is taller than it — no subtitle, no trailing slot.

**What's in here**

- `LemonadeCardHeadingStyle.minTextBoxHeight` added alongside the existing `textStyle` / `color` (KMP) and `textStyle` / `textColor` (SwiftUI) extension properties, returning `size500` for the overline and `Dp.Unspecified` / `nil` for the default — the platforms' respective "no constraint" sentinels, so the default variant costs nothing.
- KMP applies it with `Modifier.defaultMinSize(minHeight = …)` plus `verticalArrangement = Arrangement.Center`, matching `ListItem`, `Tile`, `Chip` and `SegmentedControl`.
- SwiftUI folds `minHeight:` into the frame the box already had rather than chaining a second one, so no extra view enters the hierarchy. The alignment is spelled `Alignment(horizontal: .leading, vertical: .center)` rather than the equivalent `.leading` — the vertical half is what does the centring, and it is worth it being visible next to the Compose `Arrangement.Center`.
- New `CardOverlineHeadingPreview` on the Compose side. The previews already covered overline-with-subtitle-and-tag, but not the one configuration where the floor actually binds; SwiftUI's previews already had it.

**Verified by measurement, not by eye.** I rendered the variants in isolation on both platforms and measured the pixels:

| | Compose | SwiftUI |
|---|---|---|
| overline card height | 88.00pt | 87.67pt |
| default card height | 92.00pt | 91.67pt |
| ink above / below inside the 20pt box | 5.67 / 5.67pt | 5.33 / 6.00pt |

The overline height decomposes exactly as `12 + 20 + 16 + 24 + 16 = 88`, and the 4pt gap against the default variant confirms the box is held at 20 rather than its natural 16. SwiftUI's slight asymmetry is cap-height ink sitting above the line box's visual centre, not a layout difference.

## Figma component

[Card Heading](https://www.figma.com/design/91S16rhVrl5wivqV66fNjm/%F0%9F%8D%8B-Lemonade-DS---Components?node-id=15115-987&t=oqxxlSGXttSEE7zu-11)

## Evidences
<img width="300" src="https://github.com/user-attachments/assets/f29214f6-8a0e-4e0d-a91e-9a81c4281da6" />

## API Dump

**Verdict:** ADDITIONS_ONLY

**Changes that are not a concern, and why:**

```
+	public final fun getLambda$-1863766657$ui_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1863766657$ui ()Lkotlin/jvm/functions/Function3;
```

Both lines are the same thing on the two targets: the name-mangled `ComposableSingletons$CardKt` lambda for the `content = {}` of the new `CardOverlineHeadingPreview`. Internal, never consumer-visible, and additive — nothing existing moved or changed descriptor. `minTextBoxHeight` is `private` on both platforms and reaches no baseline.

**Genuine breaking changes (if any):**

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [ ] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
- [ ] Did I add/update translations?
- [ ] I have considered whether my changes affect E2E tests
- [ ] If these changes rely on a feature flag, does it have the correct value for staging and production?
- [ ] If these changes use a new version of an API, is that new version on staging and production?
