### PR TITLE
ci: ask teya-business-app to draw reviewers when a PR becomes reviewable

### DIFF
--- a/.github/workflows/request-teya-review.yml
+++ b/.github/workflows/request-teya-review.yml
@@ -1,0 +1,41 @@
+name: Request Teya Review
+
+# When a PR becomes reviewable, ask teya-business-app to draw reviewers from
+# the code-owning team, assign them here, and DM them on Slack. The member
+# list and every credential live in that (private) repo, so nothing personal
+# has to be published here. The only secret on this side is
+# TEYA_REVIEW_DISPATCH_TOKEN, a fine-grained PAT whose single permission is
+# Actions: write on teya-business-app — leaked, it can start or cancel CI
+# runs there, nothing else. It expires; when this job starts failing with
+# 401, rotate it.
+#
+# Security shape, deliberately rigid:
+#   * pull_request_target runs THIS file as it exists on the default branch.
+#     A fork PR that edits it changes nothing about what executes here.
+#   * nothing from the PR is checked out, built, or executed — the job has no
+#     checkout step at all.
+#   * the only event data read is the PR number (an integer) and the draft flag.
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    name: Dispatch reviewer draw
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fire the draw in teya-business-app
+        env:
+          GH_TOKEN: ${{ secrets.TEYA_REVIEW_DISPATCH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run lemonade-reviewer-request.yml \
+            --repo saltpay/teya-business-app \
+            --ref main \
+            -f pr="$PR" \
+            -f dry-run=false


### PR DESCRIPTION
When a PR here is opened or marked ready for review, this workflow asks teya-business-app to draw two reviewers from the owning team, assign them on the PR, and DM them on Slack. That picker already runs on teya-business-app's own PRs. The member list and the tokens it needs live there and cannot be published in an open source repo, so this side only sends the PR number. saltpay/teya-business-app#3519 is the receiving half and has to merge first, since the dispatch targets its workflow by file name on main.

Constraints this file is built around:

- `pull_request_target` runs this file as it exists on the default branch. A fork PR that edits it changes nothing about what executes here.
- There is no checkout step, so nothing from the PR is ever fetched or run.
- The only event data read is the PR number and the draft flag.
- The one secret, `TEYA_REVIEW_DISPATCH_TOKEN`, is a fine-grained PAT that can start and cancel workflow runs on teya-business-app. That is everything a leaked token could do. It expires, and a 401 in this job means it needs rotating.

Before merging, the token needs to exist as a secret in this repo.
