### PR TITLE
fix(tabs): render nothing for an empty list instead of crashing the host

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tabs.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Tabs.kt
@@ -90,8 +90,10 @@ public enum class TabsItemSize {
  * )
  * ```
  *
- * @param tabs A list of [TabItem] instances to display.
- * @param selectedIndex The index of the currently selected tab.
+ * @param tabs A list of [TabItem] instances to display. An empty list renders nothing, so a host
+ *   whose tabs are still loading can pass one straight through.
+ * @param selectedIndex The index of the currently selected tab. Clamped into [tabs]' indices — an
+ *   index left over from a longer list selects the nearest tab instead of failing.
  * @param onTabSelected A callback invoked when a tab is selected with the tab index.
  * @param modifier The [Modifier] to be applied to the root container of the component.
  * @param itemsSize The sizing strategy for tab items, defaults to [TabsItemSize.Hug].
@@ -124,15 +126,19 @@ internal fun CoreTabs(
     modifier: Modifier = Modifier,
     itemsSize: TabsItemSize = TabsItemSize.Hug,
 ) {
-    require(
-        value = tabs.isNotEmpty(),
-        lazyMessage = { "Tabs list should not be empty." },
-    )
-    require(
-        value = selectedIndex in tabs.indices,
-        lazyMessage = {
-            "Selected index ($selectedIndex) is out of bounds for tabs list of size ${tabs.size}."
-        },
+    // Nothing to draw, not even the separator — a bare rule under an empty strip reads as a
+    // rendering glitch. Hosts routinely pass an empty list for a frame while the tabs they are
+    // derived from load, and a composable body re-runs on every recomposition, so throwing here
+    // would turn that transient state into a crash of the host app.
+    if (tabs.isEmpty()) {
+        return
+    }
+
+    // A stale index outlives its list whenever the two are held apart — the list shrinks, and the
+    // index catches up a frame later. Clamp rather than throw, matching CoreSegmentedControl.
+    val resolvedIndex = selectedIndex.coerceIn(
+        minimumValue = 0,
+        maximumValue = tabs.lastIndex,
     )
 
     val density = LocalDensity.current
@@ -154,25 +160,25 @@ internal fun CoreTabs(
         tween<Dp>(durationMillis = 0)
     }
 
-    LaunchedEffect(key1 = contentWidths[selectedIndex]) {
-        if (contentWidths[selectedIndex] != null && !hasInitialMeasurement) {
+    LaunchedEffect(key1 = contentWidths[resolvedIndex]) {
+        if (contentWidths[resolvedIndex] != null && !hasInitialMeasurement) {
             hasInitialMeasurement = true
         }
     }
 
     // Indicator width = content wrapper width (text + icon only)
     val indicatorWidth by animateDpAsState(
-        targetValue = contentWidths[selectedIndex]
-            ?: tabWidths[selectedIndex]
+        targetValue = contentWidths[resolvedIndex]
+            ?: tabWidths[resolvedIndex]
             ?: 0.dp,
         animationSpec = animationSpec,
     )
     // Indicator offset = tab offset + centering within the tab
-    val selectedTabWidth = tabWidths[selectedIndex]
+    val selectedTabWidth = tabWidths[resolvedIndex]
         ?: 0.dp
-    val selectedContentWidth = contentWidths[selectedIndex]
+    val selectedContentWidth = contentWidths[resolvedIndex]
         ?: selectedTabWidth
-    val selectedTabOffset = tabOffsets[selectedIndex]
+    val selectedTabOffset = tabOffsets[resolvedIndex]
         ?: 0.dp
     val indicatorOffset by animateDpAsState(
         targetValue = selectedTabOffset + (selectedTabWidth - selectedContentWidth) / 2,
@@ -191,7 +197,7 @@ internal fun CoreTabs(
             TabsItemSize.Hug -> {
                 HugModeTabs(
                     tabs = tabs,
-                    selectedIndex = selectedIndex,
+                    selectedIndex = resolvedIndex,
                     onTabSelected = onTabSelected,
                     density = density,
                     tabWidths = tabWidths,
@@ -207,7 +213,7 @@ internal fun CoreTabs(
             TabsItemSize.Stretch -> {
                 StretchModeTabs(
                     tabs = tabs,
-                    selectedIndex = selectedIndex,
+                    selectedIndex = resolvedIndex,
                     onTabSelected = onTabSelected,
                     density = density,
                     tabWidths = tabWidths,


### PR DESCRIPTION
# Summary

`CoreTabs` opened with two `require`s — one on a non-empty list, one on `selectedIndex` being in bounds. A composable body re-runs on every recomposition, so either guard turns a host's transient state into an `IllegalArgumentException` that kills the app.

That is exactly what happened in the Teya app's Sales tab:

```
java.lang.IllegalArgumentException
  at com.teya.lemonade.TabsKt.CoreTabs (Tabs.kt:127)
  at com.teya.lemonade.TabsKt.Tabs (Tabs.kt:107)
  at com.teya.acquiring.ui.sales.SalesScreenKt.SalesTabChainsawContent$lambda$12$0$0$1 (SalesScreen.kt:150)
  …
```

`SalesPresenterImpl` builds its tab list purely from feature gates and bails with an empty model when none are granted (`if (tabs.isEmpty()) return SalesModel()`). The screen only early-returns for the registration upsell, so that empty model reached `LemonadeUi.Tabs` and `Tabs.kt:127` — `require(tabs.isNotEmpty())` — threw.

Both rejected inputs have an unambiguous rendering, so the component now degrades instead of throwing:

- **Empty list** → renders nothing, not even the separator. A bare rule under an empty strip reads as a rendering glitch.
- **Out-of-range `selectedIndex`** → clamped with `coerceIn(0, tabs.lastIndex)`. A stale index outlives its list whenever the two are held apart: the list shrinks, and the index catches up a frame later.

Clamping is what the siblings already do — `CoreSegmentedControl` coerces `selectedTab`, `CoreBottomTabBar` coerces via `roundToInt().coerceIn`. `Tabs` was the outlier that threw on both.

It also brings KMP in line with SwiftUI, where `LemonadeTabs` never had a precondition: it compares `index == selectedIndex` while iterating, so an empty list already rendered nothing there.

The KDoc on `LemonadeUi.Tabs` now documents both behaviours, which the old code never did (`BottomTabBar`'s KDoc says "non-empty"; `Tabs`' did not).

### Not covered here

This removes the crash, but the "user has no tabs" state is still the host's call — after this, that Sales model renders a TopBar with a title and nothing under it. `teya-business-app` needs a matching branch in `SalesTabChainsawContent`. Worth checking there whether `session.features` emits an empty initial value before the real data lands, which would put *every* user through the empty path on the first frame.

`BottomTabBar` and `SegmentedControl` still throw on empty input. Left alone deliberately — no reported crash, and both are published. Happy to follow up if reviewers want the same treatment.

## Figma component

N/A — behavioural fix, no visual change to a populated tab strip.

## Screenshot

N/A — the only new visual state is "nothing rendered", which previously crashed.

## Testing

`ui` has no Compose UI test harness (only pure-logic tests, e.g. `TooltipPositioningTest`), so this is unverified by an automated test. Covering it would mean pulling `compose-ui-test` into the module — a separate infra decision, flagged rather than done here.

Ran the full CI set locally, all green:

| Task | Result |
|---|---|
| `detektMetadataCommonMain` | ✅ |
| `ktlintCheck` | ✅ |
| `apiCheck` | ✅ |
| `compileKotlinMetadata`, `compileKotlinDesktop`, `:ui:compileDebugKotlinAndroid` | ✅ |

## API Dump

**Verdict:** NO_CHANGES

No public API changes — the fix only replaces two `require` calls inside an `internal` function body. `bcv-check.sh --ci` reports `NO_CHANGES — public API is identical`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
