### PR TITLE
fix(button): keep the label inside the fill when the text size grows (SwiftUI + KMP)

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -24,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
@@ -86,29 +89,13 @@ public fun LemonadeUi.Button(
         trailingSlot = null,
         expandContents = false,
         contentSlot = {
-            if (leadingIcon != null) {
-                LemonadeUi.Icon(
-                    icon = leadingIcon,
-                    tint = colors.contentColor,
-                    contentDescription = null,
-                )
-            }
-
-            LemonadeUi.Text(
-                text = label,
+            ButtonAdaptiveContent(
+                label = label,
                 textStyle = size.contentData.textStyle,
-                color = colors.contentColor,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+                contentColor = colors.contentColor,
+                leadingIcon = leadingIcon,
+                trailingIcon = trailingIcon,
             )
-
-            if (trailingIcon != null) {
-                LemonadeUi.Icon(
-                    icon = trailingIcon,
-                    tint = colors.contentColor,
-                    contentDescription = null,
-                )
-            }
         },
     )
 }
@@ -167,6 +154,8 @@ public fun LemonadeUi.Button(
                 textStyle = size.contentData.textStyle,
                 color = colors.contentColor,
                 textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
             )
         },
@@ -409,12 +398,18 @@ private fun CoreButton(
     } else {
         Modifier
     }
+    val slotHeightModifier = if (leadingSlot != null || trailingSlot != null) {
+        Modifier.height(intrinsicSize = IntrinsicSize.Min)
+    } else {
+        Modifier
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
         modifier = modifier
             .defaultMinSize(minWidth = size.contentData.minWidth)
-            .requiredHeight(height = size.contentData.requiredHeight)
+            .requiredHeightIn(min = size.contentData.requiredHeight)
+            .then(other = slotHeightModifier)
             .clip(shape = size.contentData.shape)
             .then(other = disabledModifier)
             .clickable(
@@ -440,8 +435,6 @@ private fun CoreButton(
                         horizontal = size.contentData.horizontalPadding,
                     ),
             ) {
-                // Keep the content in the layout while loading so the button holds its size; the
-                // spinner draws over it.
                 Row(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
@@ -85,34 +86,28 @@ public fun LemonadeUi.Button(
         trailingSlot = null,
         expandContents = false,
         contentSlot = {
-            if (loading) {
-                LemonadeUi.Spinner(
+            if (leadingIcon != null) {
+                LemonadeUi.Icon(
+                    icon = leadingIcon,
                     tint = colors.contentColor,
+                    contentDescription = null,
                 )
-            } else {
-                if (leadingIcon != null) {
-                    LemonadeUi.Icon(
-                        icon = leadingIcon,
-                        tint = colors.contentColor,
-                        contentDescription = null,
-                    )
-                }
+            }
 
-                LemonadeUi.Text(
-                    text = label,
-                    textStyle = size.contentData.textStyle,
-                    color = colors.contentColor,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+            LemonadeUi.Text(
+                text = label,
+                textStyle = size.contentData.textStyle,
+                color = colors.contentColor,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+            )
+
+            if (trailingIcon != null) {
+                LemonadeUi.Icon(
+                    icon = trailingIcon,
+                    tint = colors.contentColor,
+                    contentDescription = null,
                 )
-
-                if (trailingIcon != null) {
-                    LemonadeUi.Icon(
-                        icon = trailingIcon,
-                        tint = colors.contentColor,
-                        contentDescription = null,
-                    )
-                }
             }
         },
     )
@@ -167,19 +162,13 @@ public fun LemonadeUi.Button(
         trailingSlot = trailingSlot.takeIf { !loading },
         expandContents = expandContents,
         contentSlot = {
-            if (loading) {
-                LemonadeUi.Spinner(
-                    tint = colors.contentColor,
-                )
-            } else {
-                LemonadeUi.Text(
-                    text = label,
-                    textStyle = size.contentData.textStyle,
-                    color = colors.contentColor,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
-                )
-            }
+            LemonadeUi.Text(
+                text = label,
+                textStyle = size.contentData.textStyle,
+                color = colors.contentColor,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+            )
         },
     )
 }
@@ -437,10 +426,8 @@ private fun CoreButton(
             ).background(color = animatedBackgroundColor),
         content = {
             leadingSlot?.invoke(this, colors)
-            Row(
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-                content = contentSlot,
+            Box(
+                contentAlignment = Alignment.Center,
                 modifier = Modifier
                     .then(
                         other = if (expandContents) {
@@ -452,7 +439,21 @@ private fun CoreButton(
                         vertical = size.contentData.verticalPadding,
                         horizontal = size.contentData.horizontalPadding,
                     ),
-            )
+            ) {
+                // Keep the content in the layout while loading so the button holds its size; the
+                // spinner draws over it.
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                    content = contentSlot,
+                    modifier = Modifier.alpha(alpha = if (loading) 0f else 1f),
+                )
+                if (loading) {
+                    LemonadeUi.Spinner(
+                        tint = colors.contentColor,
+                    )
+                }
+            }
             trailingSlot?.invoke(this, colors)
         },
     )

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ButtonContent.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ButtonContent.kt
@@ -1,0 +1,184 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.MultiContentMeasurePolicy
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
+import com.teya.lemonade.core.LemonadeIcons
+import com.teya.lemonade.core.LemonadeTextStyle
+
+/**
+ * The labeled button's content: the label, with optional leading and trailing icons that track
+ * the reader's text size and stack over and under the label once it runs out of width beside
+ * them.
+ */
+@Composable
+internal fun ButtonAdaptiveContent(
+    label: String,
+    textStyle: LemonadeTextStyle,
+    contentColor: Color,
+    leadingIcon: LemonadeIcons?,
+    trailingIcon: LemonadeIcons?,
+    modifier: Modifier = Modifier,
+) {
+    val stackedGapPx = with(LocalDensity.current) {
+        LocalSpaces.current.spacing200.roundToPx()
+    }
+    Layout(
+        contents = listOf(
+            {
+                if (leadingIcon != null) {
+                    LemonadeUi.TextTrackedIcon(
+                        icon = leadingIcon,
+                        tint = contentColor,
+                        contentDescription = null,
+                    )
+                }
+            },
+            {
+                LemonadeUi.Text(
+                    text = label,
+                    textStyle = textStyle,
+                    color = contentColor,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
+                )
+            },
+            {
+                if (trailingIcon != null) {
+                    LemonadeUi.TextTrackedIcon(
+                        icon = trailingIcon,
+                        tint = contentColor,
+                        contentDescription = null,
+                    )
+                }
+            },
+        ),
+        modifier = modifier,
+        measurePolicy = ButtonContentMeasurePolicy(stackedGapPx = stackedGapPx),
+    )
+}
+
+/** Measures the icons and the label, then places them beside each other or stacked. */
+internal class ButtonContentMeasurePolicy(
+    private val stackedGapPx: Int,
+) : MultiContentMeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<List<Measurable>>,
+        constraints: Constraints,
+    ): MeasureResult {
+        val leading = measurables[0].firstOrNull()?.measure(Constraints())
+        val trailing = measurables[2].firstOrNull()?.measure(Constraints())
+        val labelMeasurable = measurables[1].first()
+        val iconsWidth = (leading?.width ?: 0) + (trailing?.width ?: 0)
+
+        val labelMinWidth = if (constraints.hasBoundedWidth && iconsWidth > 0) {
+            labelMeasurable.minIntrinsicWidth(height = constraints.maxHeight)
+        } else {
+            0
+        }
+        val stacked = shouldStackButtonContent(
+            hasBoundedWidth = constraints.hasBoundedWidth,
+            availableWidthPx = constraints.maxWidth,
+            iconsWidthPx = iconsWidth,
+            labelMinIntrinsicWidthPx = labelMinWidth,
+        )
+
+        val label = labelMeasurable.measure(
+            if (!stacked && constraints.hasBoundedWidth) {
+                constraints.copy(
+                    minWidth = 0,
+                    maxWidth = (constraints.maxWidth - iconsWidth).coerceAtLeast(0),
+                )
+            } else {
+                constraints.copy(minWidth = 0)
+            },
+        )
+
+        return if (stacked) {
+            placeStacked(
+                leading = leading,
+                label = label,
+                trailing = trailing,
+                constraints = constraints,
+            )
+        } else {
+            placeRow(
+                leading = leading,
+                label = label,
+                trailing = trailing,
+                constraints = constraints,
+            )
+        }
+    }
+
+    private fun MeasureScope.placeRow(
+        leading: Placeable?,
+        label: Placeable,
+        trailing: Placeable?,
+        constraints: Constraints,
+    ): MeasureResult {
+        val children = listOfNotNull(leading, label, trailing)
+        val width = constraints.constrainWidth(width = children.sumOf { child -> child.width })
+        val height = constraints.constrainHeight(height = children.maxOf { child -> child.height })
+        return layout(width = width, height = height) {
+            var x = 0
+            children.forEach { child ->
+                child.placeRelative(
+                    x = x,
+                    y = Alignment.CenterVertically.align(size = child.height, space = height),
+                )
+                x += child.width
+            }
+        }
+    }
+
+    private fun MeasureScope.placeStacked(
+        leading: Placeable?,
+        label: Placeable,
+        trailing: Placeable?,
+        constraints: Constraints,
+    ): MeasureResult {
+        val children = listOfNotNull(leading, label, trailing)
+        val contentHeight = children.sumOf { child -> child.height } +
+            stackedGapPx * (children.size - 1)
+        val width = constraints.constrainWidth(width = children.maxOf { child -> child.width })
+        val height = constraints.constrainHeight(height = contentHeight)
+        return layout(width = width, height = height) {
+            var y = 0
+            children.forEach { child ->
+                child.placeRelative(
+                    x = (width - child.width) / 2,
+                    y = y,
+                )
+                y += child.height + stackedGapPx
+            }
+        }
+    }
+}
+
+/** True when the label no longer has room for its longest unbreakable word beside the icons. */
+internal fun shouldStackButtonContent(
+    hasBoundedWidth: Boolean,
+    availableWidthPx: Int,
+    iconsWidthPx: Int,
+    labelMinIntrinsicWidthPx: Int,
+): Boolean =
+    hasBoundedWidth &&
+        iconsWidthPx > 0 &&
+        availableWidthPx - iconsWidthPx < labelMinIntrinsicWidthPx

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Icon.kt
@@ -10,8 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
 
@@ -51,17 +54,38 @@ public fun LemonadeUi.Icon(
         painter = rememberAssetPainter(resource = icon.drawableResource),
         contentDescription = contentDescription,
         tint = tint,
-        size = size,
+        size = size.dp,
         modifier = modifier,
     )
 }
+
+/** An icon whose rendered size tracks the reader's text size, for icons beside sp-sized text. */
+@Composable
+internal fun LemonadeUi.TextTrackedIcon(
+    icon: LemonadeIcons,
+    contentDescription: String?,
+    size: LemonadeAssetSize = LemonadeAssetSize.Medium,
+    tint: Color = LocalColors.current.content.contentPrimary,
+    modifier: Modifier = Modifier,
+) {
+    CoreIcon(
+        painter = rememberAssetPainter(resource = icon.drawableResource),
+        contentDescription = contentDescription,
+        tint = tint,
+        size = LocalDensity.current.textTrackedSize(base = size.dp),
+        modifier = modifier,
+    )
+}
+
+/** The size an sp value numerically equal to [base] resolves to at the current text size. */
+internal fun Density.textTrackedSize(base: Dp): Dp = base.value.sp.toDp()
 
 @Composable
 private fun CoreIcon(
     painter: Painter,
     contentDescription: String?,
     tint: Color,
-    size: LemonadeAssetSize,
+    size: Dp,
     modifier: Modifier = Modifier,
 ) {
     Image(
@@ -70,7 +94,7 @@ private fun CoreIcon(
         colorFilter = ColorFilter
             .tint(color = tint)
             .takeIf { tint != Color.Unspecified },
-        modifier = modifier.requiredSize(size = size.dp),
+        modifier = modifier.requiredSize(size = size),
     )
 }
 

--- a/kmp/ui/src/commonTest/kotlin/com/teya/lemonade/ButtonContentStackingTest.kt
+++ b/kmp/ui/src/commonTest/kotlin/com/teya/lemonade/ButtonContentStackingTest.kt
@@ -1,0 +1,97 @@
+package com.teya.lemonade
+
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ButtonContentStackingTest {
+    @Test
+    fun `a label with no icons never stacks, however tight the width`() {
+        assertFalse(
+            actual = shouldStackButtonContent(
+                hasBoundedWidth = true,
+                availableWidthPx = 10,
+                iconsWidthPx = 0,
+                labelMinIntrinsicWidthPx = 200,
+            ),
+        )
+    }
+
+    @Test
+    fun `an unbounded width never stacks`() {
+        assertFalse(
+            actual = shouldStackButtonContent(
+                hasBoundedWidth = false,
+                availableWidthPx = Int.MAX_VALUE,
+                iconsWidthPx = 40,
+                labelMinIntrinsicWidthPx = 200,
+            ),
+        )
+    }
+
+    @Test
+    fun `the label beside the icons stays a row while its longest word fits`() {
+        assertFalse(
+            actual = shouldStackButtonContent(
+                hasBoundedWidth = true,
+                availableWidthPx = 300,
+                iconsWidthPx = 80,
+                labelMinIntrinsicWidthPx = 200,
+            ),
+        )
+    }
+
+    @Test
+    fun `the icons stack once the label's longest word no longer fits beside them`() {
+        assertTrue(
+            actual = shouldStackButtonContent(
+                hasBoundedWidth = true,
+                availableWidthPx = 300,
+                iconsWidthPx = 120,
+                labelMinIntrinsicWidthPx = 200,
+            ),
+        )
+    }
+
+    @Test
+    fun `an exact fit stays a row`() {
+        assertFalse(
+            actual = shouldStackButtonContent(
+                hasBoundedWidth = true,
+                availableWidthPx = 280,
+                iconsWidthPx = 80,
+                labelMinIntrinsicWidthPx = 200,
+            ),
+        )
+    }
+
+    @Test
+    fun `a text-tracked size is the base size at the default text size`() {
+        val density = Density(density = 1f)
+        assertEquals(
+            expected = 20.dp,
+            actual = density.textTrackedSize(base = 20.dp),
+        )
+    }
+
+    @Test
+    fun `a text-tracked size ignores the screen density`() {
+        val density = Density(density = 3f)
+        assertEquals(
+            expected = 20.dp,
+            actual = density.textTrackedSize(base = 20.dp),
+        )
+    }
+
+    @Test
+    fun `a text-tracked size grows with the font scale`() {
+        val density = Density(density = 1f, fontScale = 2f)
+        assertEquals(
+            expected = 40.dp,
+            actual = density.textTrackedSize(base = 20.dp),
+        )
+    }
+}

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -378,10 +378,14 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
 
     @Environment(\.lemonadeButtonFullShape) private var isFullShape
     @State private var isPressed = false
+    @LemonadeScale private var scale: LemonadeScaleFactors
 
     private var cornerRadius: CGFloat {
-        isFullShape ? LemonadeTheme.radius.radiusFull : size.contentData.cornerRadius
+        isFullShape ? LemonadeTheme.radius.radiusFull : size.contentData.cornerRadius * scale.container
     }
+
+    /// Whether the reader asked for text larger than the size the tokens were drawn for.
+    private var growsWithText: Bool { scale.content > 1 }
 
     var body: some View {
         let colors = resolveButtonColors(variant: variant, type: type)
@@ -424,8 +428,8 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                     }
                     Spacer(minLength: 0)
                 }
-                .padding(.vertical, size.contentData.verticalPadding)
-                .padding(.horizontal, size.contentData.horizontalPadding)
+                .padding(.vertical, size.contentData.verticalPadding * scale.container)
+                .padding(.horizontal, size.contentData.horizontalPadding * scale.container)
                 .if(expandContents) { view in
                     view.frame(maxWidth: .infinity)
                 }
@@ -434,8 +438,19 @@ private struct LemonadeCoreButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                     trailingSlot(colors)
                 }
             }
-            .frame(height: size.contentData.requiredHeight)
-            .frame(minWidth: size.contentData.minWidth)
+            // The height is fixed at the default text size and a floor above it.
+            //
+            // A fixed height is also what holds the label to a single line: given no room to
+            // wrap, the label truncates instead. That is the treatment every button in the
+            // library ships with today, so keep it while the reader is at the size the tokens
+            // were drawn for. Once the reader asks for larger text, the same fixed height leaves
+            // the label to overflow the fill, which is drawn at the height of the frame, so let
+            // the button grow with it.
+            .frame(
+                minHeight: size.contentData.requiredHeight * scale.container,
+                maxHeight: growsWithText ? nil : size.contentData.requiredHeight * scale.container
+            )
+            .frame(minWidth: size.contentData.minWidth * scale.container)
             .background(buttonShape.fill(colors.backgroundColor.opacity(disabledFillScale)))
             // Keep the rounded hit target the removed .clipShape used to provide, without
             // reintroducing its offscreen pass.
@@ -486,37 +501,77 @@ private struct LemonadeButtonView: View {
             loading: loading,
             expandContents: false,
             contentSlot: { colors in
-                AnyView(HStack(spacing: 0) {
-                    if let leadingIcon = leadingIcon {
-                        LemonadeUi.Icon(
-                            icon: leadingIcon,
-                            contentDescription: nil,
-                            size: .medium,
-                            tint: colors.contentColor
-                        )
-                    }
-
-                    LemonadeUi.Text(
-                        label,
+                AnyView(
+                    LemonadeButtonLabelContent(
+                        label: label,
+                        leadingIcon: leadingIcon,
+                        trailingIcon: trailingIcon,
                         textStyle: size.contentData.textStyle,
-                        color: colors.contentColor
+                        colors: colors
                     )
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, LemonadeTheme.spaces.spacing200)
-
-                    if let trailingIcon = trailingIcon {
-                        LemonadeUi.Icon(
-                            icon: trailingIcon,
-                            contentDescription: nil,
-                            size: .medium,
-                            tint: colors.contentColor
-                        )
-                    }
-                })
+                )
             },
             leadingSlot: nil as ((LemonadeButtonColors) -> EmptyView)?,
             trailingSlot: nil as ((LemonadeButtonColors) -> EmptyView)?
         )
+    }
+}
+
+// MARK: - Internal Button Label Content
+
+/// The icon-and-label row of a labeled button.
+private struct LemonadeButtonLabelContent: View {
+    let label: String
+    let leadingIcon: LemonadeIcon?
+    let trailingIcon: LemonadeIcon?
+    let textStyle: LemonadeTextStyle
+    let colors: LemonadeButtonColors
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @LemonadeScale private var scale: LemonadeScaleFactors
+
+    var body: some View {
+        // At the accessibility text sizes an icon beside the label leaves the label too little
+        // width to render: the row asks for more than the button has, and the label is what gives
+        // way. Stacking the icons over the label hands the whole width back to the text, which is
+        // the treatment the Human Interface Guidelines ask for at these sizes.
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(spacing: LemonadeTheme.spaces.spacing200 * scale.container) {
+                    icon(leadingIcon)
+                    text
+                    icon(trailingIcon)
+                }
+            } else {
+                HStack(spacing: 0) {
+                    icon(leadingIcon)
+                    text.padding(.horizontal, LemonadeTheme.spaces.spacing200 * scale.container)
+                    icon(trailingIcon)
+                }
+            }
+        }
+        .environment(\.lemonadeIconScaling, true)
+    }
+
+    private var text: some View {
+        LemonadeUi.Text(
+            label,
+            textStyle: textStyle,
+            color: colors.contentColor
+        )
+        .multilineTextAlignment(.center)
+    }
+
+    @ViewBuilder
+    private func icon(_ icon: LemonadeIcon?) -> some View {
+        if let icon = icon {
+            LemonadeUi.Icon(
+                icon: icon,
+                contentDescription: nil,
+                size: .medium,
+                tint: colors.contentColor
+            )
+        }
     }
 }
 
@@ -533,6 +588,8 @@ private struct LemonadeSlotButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
     let expandContents: Bool
     let leadingSlot: ((LemonadeButtonColors) -> LeadingSlot)?
     let trailingSlot: ((LemonadeButtonColors) -> TrailingSlot)?
+
+    @LemonadeScale private var scale: LemonadeScaleFactors
 
     var body: some View {
         LemonadeCoreButtonView(
@@ -552,7 +609,7 @@ private struct LemonadeSlotButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                         color: colors.contentColor
                     )
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, LemonadeTheme.spaces.spacing200)
+                    .padding(.horizontal, LemonadeTheme.spaces.spacing200 * scale.container)
                 )
             },
             leadingSlot: leadingSlot,

--- a/swiftui/Sources/Lemonade/Components/LemonadeIcon.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeIcon.swift
@@ -77,11 +77,21 @@ private struct LemonadeIconView: View {
     let size: LemonadeUiIconSize
     let tint: Color
 
+    @Environment(\.lemonadeIconScaling) private var scalesWithText
+    @LemonadeScale private var scale: LemonadeScaleFactors
+
+    /// The rendered size. An icon paired with a label follows the reader's Dynamic Type setting
+    /// the way that label does, because a fixed size shrinks against a scaled label and breaks
+    /// the pair. The component opts in, since a larger icon needs a container that can carry it.
+    private var renderedSize: CGFloat {
+        scalesWithText ? size.value * scale.content : size.value
+    }
+
     var body: some View {
         icon.image
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .frame(width: size.value, height: size.value)
+            .frame(width: renderedSize, height: renderedSize)
             .foregroundStyle(tint)
             .accessibilityLabel(contentDescription ?? "")
             .accessibilityHidden(contentDescription == nil)

--- a/swiftui/Sources/Lemonade/Modifiers/LemonadeScale.swift
+++ b/swiftui/Sources/Lemonade/Modifiers/LemonadeScale.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+// MARK: - Icon Scaling Environment
+
+private struct LemonadeIconScalingKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    /// Whether ``LemonadeUi/Icon`` scales with the reader's Dynamic Type setting in this subtree.
+    ///
+    /// It is off by default, and a component turns it on for the icons it pairs with a label of
+    /// its own. Scaling every icon in the library instead would push a larger icon into every
+    /// container drawn at a fixed size, which clips it — the inline calendar loses the bottom
+    /// half of its day numbers that way. Opt a component in once its container can carry the
+    /// larger icon.
+    var lemonadeIconScaling: Bool {
+        get { self[LemonadeIconScalingKey.self] }
+        set { self[LemonadeIconScalingKey.self] = newValue }
+    }
+}
+
+// MARK: - Dynamic Type Scaling
+
+/// The factors that put a fixed design token in proportion with the reader's text size.
+///
+/// The geometry tokens — heights, paddings, icon sizes, radii — are authored in points against
+/// the default text size. The fonts already scale: `LemonadeTextStyle` resolves to
+/// `Font.custom(_:size:)`, which `UIFontMetrics` scales relative to the `body` text style. The
+/// tokens do not. Left unscaled, the label outgrows the fixed height of its container, and a
+/// fixed-size icon shrinks against the text it sits beside.
+///
+/// A single `@ScaledMetric` seeded with `1` returns the ratio `UIFontMetrics` applies to `body`,
+/// so one metric per view scales every token in it.
+///
+/// ```swift
+/// @LemonadeScale private var scale: LemonadeScaleFactors
+/// ...
+/// .frame(width: size.value * scale.content)
+/// .padding(.horizontal, spacing * scale.container)
+/// ```
+///
+/// `LemonadeScale` is a `DynamicProperty`. SwiftUI keeps it up to date only while a `View` holds
+/// it as a stored property. A copy held anywhere else reports the default text size.
+@propertyWrapper
+struct LemonadeScale: DynamicProperty {
+    @ScaledMetric(relativeTo: .body) private var unit: CGFloat = 1
+
+    var wrappedValue: LemonadeScaleFactors {
+        LemonadeScaleFactors(unit: unit)
+    }
+
+    init() {}
+}
+
+/// The two factors ``LemonadeScale`` reports. They differ above the largest non-accessibility
+/// text size. See ``container`` for the reason.
+struct LemonadeScaleFactors {
+    /// The ceiling on ``container``. It sits near the ratio `UIFontMetrics` reports for the
+    /// first accessibility text size.
+    ///
+    /// Past that point the reader gains far more from the text than from the box around it, and
+    /// a padding that keeps growing takes the width the label needs.
+    private static let containerCeiling: CGFloat = 1.6
+
+    private let unit: CGFloat
+
+    init(unit: CGFloat) {
+        self.unit = unit
+    }
+
+    /// The factor for content: icons, and the line metrics of the text they sit beside. It
+    /// tracks the reader's text size with no ceiling, the way the glyphs do.
+    var content: CGFloat { unit }
+
+    /// The factor for the box around the content: heights, paddings, radii. It tracks the
+    /// reader's text size from the default one up to ``containerCeiling``, and holds at both
+    /// ends.
+    ///
+    /// A container is sized from the content it holds, so it keeps growing past the ceiling.
+    /// What stops is the padding, which is a fixed inset that a growing label has to pay for
+    /// twice, on both sides, out of a width the label does not control.
+    ///
+    /// Below the default text size the factor holds at `1`. The tokens are the floor the design
+    /// draws for a touch target, and a reader who asks for smaller text is not asking for a
+    /// smaller button.
+    var container: CGFloat { min(max(unit, 1), Self.containerCeiling) }
+}


### PR DESCRIPTION
# Summary

The label of a labeled button scales with the reader's text size — Dynamic Type in SwiftUI, the system font scale in Compose — because both render through metrics that follow the system setting. The geometry around it does not: the height, the paddings and the icon are fixed point/dp tokens. At the larger text sizes the label outgrew the fixed height and overflowed the fill, which is drawn at the height of the frame, and the icon beside it stayed small and broke the pair. That is what the report of "the button alignment looks a bit off" describes.

This PR fixes it on both platforms with the same outcomes: the height stays fixed at the default text size — pixel-identical to today — and becomes a floor above it; icons track the text only where a component opts in, and only the labeled button does; and where icons beside the label leave it too little width, they stack over and under it. The mechanisms differ per platform on purpose. SwiftUI derives a pair of factors from `@ScaledMetric`, the platform's own channel for this. Compose gets no such scalar it can trust — Android 14 made font scaling non-linear and documents `fontScale` as informational only — so the KMP side reads no scale at all: icon sizes route through the sp system, and stacking is decided by measuring the label against the room it has (the contract proposed in #299).

## SwiftUI

**`LemonadeScale`** (new) is a property wrapper over a single `@ScaledMetric` seeded with `1`. It reports the ratio `UIFontMetrics` applies to `body`, as the two factors above. A padding is an inset the label pays for twice, out of a width it does not control, so `container` stops growing before the label runs out of room.

**`LemonadeButton`**

- The height stays fixed at the default text size and becomes a floor above it. The fixed height is also what holds the label to one line, so keeping it leaves every existing layout where it is.
- The paddings, the min width and the corner radius take `container`.
- At the accessibility text sizes the icons stack over the label. Beside it they leave the label too little width to render at all — the label disappeared entirely in the first version of this change.

**`LemonadeIcon`**

Icons scale only where a component opts in, through the new internal `\.lemonadeIconScaling` environment value, and only the labeled button does. Scaling every icon in the library pushes a larger icon into every container drawn at a fixed size: the inline calendar loses the bottom half of its day numbers that way.

## KMP

No `fontScale` reads anywhere — everything is measured or routed through the sp system, which Android resolves through its per-size non-linear curve.

**`Button.kt`**

- The fixed height becomes a floor: `requiredHeight` → `requiredHeightIn(min = …)` — the same force-against-parent-constraints semantics, with only the max clamp released. At the default text size the label's line height plus the existing paddings lands exactly on the token, so the geometry is unchanged; above it, the growing line height is what grows the fill.
- The label is held to one line (`maxLines = 1`, ellipsis). The fixed height always de-facto enforced a single line; making it explicit keeps layouts that starve the button of width from wrapping the label and growing the button, at any text size.
- A button with slot content resolves its height with `IntrinsicSize.Min`, so `fillMaxHeight` slot content — the dual-action divider and its touch area — has a real height to fill above the floor. Only slot buttons take this: the labeled button's adaptive content decides stacking during measurement, and an intrinsic pass would evaluate that decision at the wrong width.
- The loading state matches SwiftUI: the content stays in the layout at alpha `0` and the spinner draws over it, so the button holds its size when `loading` toggles.

**`ButtonContent.kt`** (new)

- The labeled button's content is a `Layout` with a `MultiContentMeasurePolicy`, the same shape as the ListItem reflow in #313: the icons sit beside the label while the label's longest unbreakable word fits in the leftover width; once it does not, the leading icon stacks above the label and the trailing below it, handing the width back. The decision is measured per layout pass — no thresholds.
- `shouldStackButtonContent` is a pure function with a `commonTest`.

**`Icon.kt`**

- The labeled button's icons render through `textTrackedSize`: the base dp value expressed as sp and converted back through `LocalDensity`, so a 20dp icon follows the exact curve of 20sp text — identity at the default size, the platform's non-linear curve on Android 14+, the linear fallback below. Internal and per call site — every icon outside the labeled button renders exactly as before.

Two deliberate deviations from the SwiftUI side: the paddings and min width are not scaled — with the height measured off the label there is nothing left for a container factor to do, and a scaled padding is exactly the arithmetic-on-`fontScale` the contract rules out — and the corner radius is not scaled, because it comes from a themed `Shape` token that `LemonadeTheme(shapes = …)` lets consumers replace with an arbitrary implementation.

# Verification

## SwiftUI

I rendered the 33 catalog screens of the sample app at three text sizes, on this branch and on `main`, and diffed them pixel by pixel. 198 captures. The noise floor comes from running the same build twice.

| Text size | Screens that change |
|---|---|
| `large` (default) | none — only animation noise: the skeleton shimmer, the icon button spinner, the home indicator |
| `xxxLarge` | 4: button, spinner, historyTimeline, divider |
| `AX5` | 4: button, spinner, historyTimeline, skeleton |

Every screen that changes at the larger sizes holds a labeled button. No other component moves at any size.

Example, historyTimeline at AX5: `Find a Pay…` truncated before; `Find a PayPoint` with the pin stacked above it now.

The 32 package tests pass. `swift test` and the sample app both build.

Three regressions turned up during that sweep and are fixed in this branch: the button wrapping its label at the default text size, the calendar clipping its day numbers, and the calendar header wrapping harder. The first came from letting the height float unconditionally, the other two from scaling text metrics and icons library-wide.

### Not covered

Light mode only, portrait only, iPhone 17 only. The harness compressed a 1600pt page into the window, so content below that was not captured. There is no snapshot test in the package, so CI does not guard this.

## KMP

Built this branch and `main` and compared the sample app's Button screen on an Android emulator (SP-2, 720×1280) at font scale 1.0, 1.3 and 2.0:

- **1.0** — pixel-identical to `main` outside the loading card: the significant diff is confined to the loading row, where the button now holds its full size instead of collapsing toward the spinner (by design), shifting its card neighbours; the spinner's animated arc accounts for the rest.
- **2.0** — on `main`, every label spills out of the bottom of its fill and the heart icon stays small beside the enlarged text; on this branch every fill grows around its label, the heart grows on the 20sp curve (~1.7×, not the 2.0 scalar), and the width-starved Trailing button stacks its chevron below the label. The dual-action consumer slots hold their boundary: the ellipsis icon renders unscaled and the divider spans the grown fill.
- **1.3** — intermediate growth, every label inside its fill.

`:ui:desktopTest` (including the new `ButtonContentStackingTest`), ktlint and detekt pass. Desktop is a structural no-op (`fontScale` is `1.0` there).

The sample catalog's `ButtonCard` rows are non-scrolling and already overflow at scale 1.0, so they starve some buttons of width — those labels now ellipsize honestly instead of spilling or letter-wrapping. Making the rows scroll is a `ButtonDisplay.kt` follow-up.

## Figma component

n/a — no visual spec change at the default text size.

## Screenshot

Captures are local. At the default text size the render is identical to `main` on both platforms, which is the point of the change; the difference is at `xxxLarge` / font scale 1.3 and above.

## API Dump

No public API changes. `bcv-check.sh --ci` reports `NO_CHANGES` — the `api/*.api` and `*.klib.api` baselines are untouched. `LemonadeScale`, `LemonadeScaleFactors` and `\.lemonadeIconScaling` on the SwiftUI side, and `ButtonAdaptiveContent`, `ButtonContentMeasurePolicy`, `shouldStackButtonContent`, `TextTrackedIcon` and `textTrackedSize` on the KMP side, are all internal.
