### PR TITLE
perf(list-item): cut the remaining per-row cost (indication node, wrapper collapse, measure policy, draw paths)

### DIFF
--- a/kmp/ui/api/android/ui.api
+++ b/kmp/ui/api/android/ui.api
@@ -128,7 +128,6 @@ public final class com/teya/lemonade/ComposableSingletons$ListItemKt {
 	public final fun getLambda$-1242978266$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-1808195552$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-965205749$ui_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1280770520$ui_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$787311865$ui_release ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/kmp/ui/api/desktop/ui.api
+++ b/kmp/ui/api/desktop/ui.api
@@ -128,7 +128,6 @@ public final class com/teya/lemonade/ComposableSingletons$ListItemKt {
 	public final fun getLambda$-1242978266$ui ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-1808195552$ui ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-965205749$ui ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1280770520$ui ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$787311865$ui ()Lkotlin/jvm/functions/Function3;
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -2,11 +2,8 @@
 
 package com.teya.lemonade
 
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -21,14 +18,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -870,12 +864,12 @@ private fun CoreListItem(
             modifier = Modifier
                 .then(
                     other = if (onListItemClick != null) {
-                        Modifier.interactiveBackground(
-                            interactionSource = interactionSource,
-                            voice = voice,
+                        Modifier.clickable(
                             enabled = enabled,
                             role = role,
                             onClick = onListItemClick,
+                            interactionSource = interactionSource,
+                            indication = ListItemHighlightIndication(voice = voice),
                         )
                     } else {
                         Modifier
@@ -1007,63 +1001,6 @@ private fun RowScope.ListItemTrailingContent(
     }
 }
 
-/**
- * Applies click handling and the animated press/hover highlight for interactive rows.
- *
- * Only used for clickable rows: a row without an `onListItemClick` can never be pressed or
- * hovered, so it needs none of this apparatus and is left untouched.
- *
- * The highlight is painted directly in the draw phase via [drawWithCache], reading the animated
- * colour at draw time (not composition time) and using the row's rounded [androidx.compose.ui.graphics.Shape]
- * outline instead of a [androidx.compose.ui.draw.clip] graphics layer. During a scroll the colour is fully
- * transparent, so the row draws nothing and pays no clip/background cost — this removes the
- * per-row draw floor seen in the scroll-jank profiling. The click indication is `null` (no
- * ripple); press feedback is the animated fill, mirroring the iOS `ListItemButtonStyle`.
- */
-@Composable
-private fun Modifier.interactiveBackground(
-    interactionSource: MutableInteractionSource,
-    voice: LemonadeListItemVoice,
-    enabled: Boolean,
-    role: Role?,
-    onClick: () -> Unit,
-): Modifier {
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val isHovering by interactionSource.collectIsHoveredAsState()
-
-    val highlightShape = LocalShapes.current.radius500
-    val transparentColor = voice.interactionBackground.copy(
-        alpha = LocalOpacities.current.base.opacity0,
-    )
-    val highlightColor by animateColorAsState(
-        targetValue = if (isHovering || isPressed) {
-            voice.interactionBackground
-        } else {
-            transparentColor
-        },
-    )
-
-    return this
-        .clickable(
-            enabled = enabled,
-            role = role,
-            onClick = onClick,
-            interactionSource = interactionSource,
-            indication = null,
-        ).drawWithCache {
-            val outline = highlightShape.createOutline(
-                size = size,
-                layoutDirection = layoutDirection,
-                density = this,
-            )
-            onDrawBehind {
-                if (highlightColor.alpha > 0f) {
-                    drawOutline(outline = outline, color = highlightColor)
-                }
-            }
-        }
-}
-
 @Composable
 private fun SafeArea(
     modifier: Modifier = Modifier,
@@ -1094,14 +1031,6 @@ private fun SafeArea(
         )
     }
 }
-
-private val LemonadeListItemVoice.interactionBackground: Color
-    @Composable get() {
-        return when (this) {
-            LemonadeListItemVoice.Neutral -> LocalColors.current.interaction.bgSubtleInteractive
-            LemonadeListItemVoice.Critical -> LocalColors.current.interaction.bgCriticalSubtleInteractive
-        }
-    }
 
 private val LemonadeListItemVoice.contentColor: Color
     @Composable get() {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -181,7 +181,6 @@ public fun LemonadeUi.ActionListItem(
     showDivider: Boolean = false,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
-    @Suppress("DEPRECATION")
     ActionListItem(
         label = label,
         modifier = modifier,
@@ -415,7 +414,6 @@ public fun LemonadeUi.ActionListItem(
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     leadingVerticalAlignment: Alignment.Vertical = Alignment.Top,
 ) {
-    @Suppress("DEPRECATION")
     ActionListItem(
         label = label,
         modifier = modifier,
@@ -465,7 +463,6 @@ public fun LemonadeUi.ListItem(
     slotContent: (@Composable ColumnScope.() -> Unit)? = null,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
-    @Suppress("DEPRECATION")
     ListItem(
         label = label,
         modifier = modifier,
@@ -726,7 +723,6 @@ public fun LemonadeUi.ListItem(
     trailingSlot: (@Composable RowScope.() -> Unit)? = null,
     trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
 ) {
-    @Suppress("DEPRECATION")
     ListItem(
         contentSlot = contentSlot,
         modifier = modifier,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Measurable
@@ -929,90 +931,89 @@ private fun CoreListItem(
     leadingVerticalAlignment: Alignment.Vertical,
     priority: LemonadeListItemPriority,
 ) {
-    SafeArea(modifier = modifier, showDivider = showDivider) { rowModifier ->
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = rowModifier
-                .then(
-                    other = if (onListItemClick != null) {
-                        Modifier.clickable(
-                            enabled = enabled,
-                            role = role,
-                            onClick = onListItemClick,
-                            interactionSource = interactionSource,
-                            indication = ListItemHighlightIndication(voice = voice),
-                        )
-                    } else {
-                        Modifier
-                    },
-                ).defaultMinSize(minHeight = LocalSizes.current.size1200)
-                .padding(
-                    horizontal = LocalSpaces.current.spacing300,
-                    vertical = LocalSpaces.current.spacing300,
-                ),
-        ) {
-            if (leadingSlot != null) {
-                Row(
-                    modifier = Modifier
-                        .align(leadingVerticalAlignment)
-                        .padding(end = LocalSpaces.current.spacing300)
-                        .padding(vertical = LocalSpaces.current.spacing50)
-                        .then(
-                            other = if (!enabled) {
-                                Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                            } else {
-                                Modifier
-                            },
-                        ),
-                ) {
-                    leadingSlot()
-                }
-            }
-
-            val contentAlpha: Modifier = if (!enabled) {
-                Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-            } else {
-                Modifier
-            }
-
-            val hasTrailingContent = trailingSlot != null || navigationIndicator
-            if (!hasTrailingContent) {
-                // With nothing trailing there is no width contention, so the content column sits
-                // directly in the row. A filling weight reproduces the Trailing-priority forced
-                // width; Label priority lets the column wrap inside the remaining space.
-                Column(
-                    content = contentSlot,
-                    modifier = Modifier
-                        .weight(
-                            weight = 1f,
-                            fill = priority == LemonadeListItemPriority.Trailing,
-                        ).then(other = contentAlpha),
-                )
-            } else {
-                Layout(
-                    modifier = Modifier.weight(weight = 1f),
-                    measurePolicy = ListItemBodyMeasurePolicy(
-                        priority = priority,
-                        trailingAlignment = trailingVerticalAlignment,
-                        trailingGap = LocalSpaces.current.spacing300,
-                        trailingFloor = LocalSizes.current.size2000,
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .listItemSafeArea(showDivider = showDivider)
+            .then(
+                other = if (onListItemClick != null) {
+                    Modifier.clickable(
+                        enabled = enabled,
+                        role = role,
+                        onClick = onListItemClick,
+                        interactionSource = interactionSource,
+                        indication = ListItemHighlightIndication(voice = voice),
+                    )
+                } else {
+                    Modifier
+                },
+            ).defaultMinSize(minHeight = LocalSizes.current.size1200)
+            .padding(
+                horizontal = LocalSpaces.current.spacing300,
+                vertical = LocalSpaces.current.spacing300,
+            ),
+    ) {
+        if (leadingSlot != null) {
+            Row(
+                modifier = Modifier
+                    .align(leadingVerticalAlignment)
+                    .padding(end = LocalSpaces.current.spacing300)
+                    .padding(vertical = LocalSpaces.current.spacing50)
+                    .then(
+                        other = if (!enabled) {
+                            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+                        } else {
+                            Modifier
+                        },
                     ),
-                    content = {
-                        Column(
-                            content = contentSlot,
-                            modifier = contentAlpha,
-                        )
-
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            ListItemTrailingContent(
-                                trailingSlot = trailingSlot,
-                                navigationIndicator = navigationIndicator,
-                                enabled = enabled,
-                            )
-                        }
-                    },
-                )
+            ) {
+                leadingSlot()
             }
+        }
+
+        val contentAlpha: Modifier = if (!enabled) {
+            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+        } else {
+            Modifier
+        }
+
+        val hasTrailingContent = trailingSlot != null || navigationIndicator
+        if (!hasTrailingContent) {
+            // With nothing trailing there is no width contention, so the content column sits
+            // directly in the row. A filling weight reproduces the Trailing-priority forced
+            // width; Label priority lets the column wrap inside the remaining space.
+            Column(
+                content = contentSlot,
+                modifier = Modifier
+                    .weight(
+                        weight = 1f,
+                        fill = priority == LemonadeListItemPriority.Trailing,
+                    ).then(other = contentAlpha),
+            )
+        } else {
+            Layout(
+                modifier = Modifier.weight(weight = 1f),
+                measurePolicy = ListItemBodyMeasurePolicy(
+                    priority = priority,
+                    trailingAlignment = trailingVerticalAlignment,
+                    trailingGap = LocalSpaces.current.spacing300,
+                    trailingFloor = LocalSizes.current.size2000,
+                ),
+                content = {
+                    Column(
+                        content = contentSlot,
+                        modifier = contentAlpha,
+                    )
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        ListItemTrailingContent(
+                            trailingSlot = trailingSlot,
+                            navigationIndicator = navigationIndicator,
+                            enabled = enabled,
+                        )
+                    }
+                },
+            )
         }
     }
 }
@@ -1154,31 +1155,41 @@ private fun RowScope.ListItemTrailingContent(
 }
 
 /**
- * Wraps a list-item row in its outer gutter padding and, when requested, the divider below it.
- * Inline, and in the no-divider case it emits no wrapper node at all: the gutter padding is handed
- * to [content] to apply on the row itself.
+ * The outer treatment of a list-item row: the optional divider below it and the gutter padding
+ * around it. Pure modifiers, so a row composes no wrapper node for either.
  */
 @Composable
-private inline fun SafeArea(
-    modifier: Modifier,
-    showDivider: Boolean,
-    content: @Composable (rowModifier: Modifier) -> Unit,
-) {
-    if (!showDivider) {
-        content(modifier.padding(all = LocalSpaces.current.spacing100))
-        return
+private fun Modifier.listItemSafeArea(showDivider: Boolean): Modifier {
+    val withDivider = if (showDivider) {
+        listItemDivider()
+    } else {
+        this
     }
+    return withDivider.padding(all = LocalSpaces.current.spacing100)
+}
 
-    Column(
-        verticalArrangement = Arrangement.Center,
-        modifier = modifier,
-    ) {
-        content(Modifier.padding(all = LocalSpaces.current.spacing100))
-
-        LemonadeUi.HorizontalDivider(
-            modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing400),
-        )
-    }
+/**
+ * Draws the row divider the way [LemonadeUi.HorizontalDivider] renders its solid variant — same
+ * thickness, colour and horizontal insets — while reserving the divider's height with padding so
+ * the row's total height matches the former divider sibling.
+ */
+@Composable
+private fun Modifier.listItemDivider(): Modifier {
+    val thickness = LocalBorderWidths.current.base.border25
+    val inset = LocalSpaces.current.spacing400
+    val color = LocalColors.current.border.borderNeutralLow
+    return this
+        .drawBehind {
+            val reserved = thickness.roundToPx()
+            val insetPx = inset.roundToPx().toFloat()
+            val centerY = size.height - reserved / 2f
+            drawLine(
+                color = color,
+                start = Offset(x = insetPx, y = centerY),
+                end = Offset(x = size.width - insetPx, y = centerY),
+                strokeWidth = thickness.toPx(),
+            )
+        }.padding(bottom = thickness)
 }
 
 private val LemonadeListItemVoice.contentColor: Color
@@ -1194,45 +1205,44 @@ private fun ListItemSkeleton(
     modifier: Modifier = Modifier,
     showDivider: Boolean = false,
 ) {
-    SafeArea(modifier = modifier, showDivider = showDivider) { rowModifier ->
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .listItemSafeArea(showDivider = showDivider)
+            .padding(
+                horizontal = LocalSpaces.current.spacing300,
+                vertical = LocalSpaces.current.spacing300,
+            ),
+    ) {
+        LemonadeUi.CircleSkeleton(
+            size = LemonadeSkeletonSize.XLarge,
+            modifier = Modifier.padding(end = LocalSpaces.current.spacing300),
+        )
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = rowModifier
-                .padding(
-                    horizontal = LocalSpaces.current.spacing300,
-                    vertical = LocalSpaces.current.spacing300,
-                ),
+            modifier = Modifier.weight(weight = 1f),
         ) {
-            LemonadeUi.CircleSkeleton(
-                size = LemonadeSkeletonSize.XLarge,
-                modifier = Modifier.padding(end = LocalSpaces.current.spacing300),
-            )
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            Column(
+                verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
                 modifier = Modifier.weight(weight = 1f),
             ) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(space = LocalSpaces.current.spacing100),
-                    modifier = Modifier.weight(weight = 1f),
-                ) {
-                    LemonadeUi.LineSkeleton(
-                        size = LemonadeSkeletonSize.Medium,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    LemonadeUi.LineSkeleton(
-                        size = LemonadeSkeletonSize.Small,
-                        modifier = Modifier.fillMaxWidth(fraction = 0.6f),
-                    )
-                }
-
                 LemonadeUi.LineSkeleton(
                     size = LemonadeSkeletonSize.Medium,
-                    modifier = Modifier
-                        .padding(start = LocalSpaces.current.spacing300)
-                        .width(width = 54.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                LemonadeUi.LineSkeleton(
+                    size = LemonadeSkeletonSize.Small,
+                    modifier = Modifier.fillMaxWidth(fraction = 0.6f),
                 )
             }
+
+            LemonadeUi.LineSkeleton(
+                size = LemonadeSkeletonSize.Medium,
+                modifier = Modifier
+                    .padding(start = LocalSpaces.current.spacing300)
+                    .width(width = 54.dp),
+            )
         }
     }
 }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -967,19 +967,26 @@ private fun CoreListItem(
                 Modifier
             }
 
-            if (priority == LemonadeListItemPriority.Label) {
+            val hasTrailingContent = trailingSlot != null || navigationIndicator
+            if (!hasTrailingContent) {
+                // With nothing trailing there is no width contention, so the content column sits
+                // directly in the row. A filling weight reproduces the Trailing-priority forced
+                // width; Label priority lets the column wrap inside the remaining space.
+                Column(
+                    content = contentSlot,
+                    modifier = Modifier
+                        .weight(
+                            weight = 1f,
+                            fill = priority == LemonadeListItemPriority.Trailing,
+                        ).then(other = contentAlpha),
+                )
+            } else if (priority == LemonadeListItemPriority.Label) {
                 // Content keeps its width; the trailing slot yields and truncates. The content is
-                // capped so the trailing slot always retains a readable floor instead of vanishing —
-                // but only when there is trailing content to keep visible.
-                val hasTrailingContent = trailingSlot != null || navigationIndicator
+                // capped so the trailing slot always retains a readable floor instead of vanishing.
                 BoxWithConstraints(modifier = Modifier.weight(weight = 1f)) {
                     val trailingFloor = LocalSizes.current.size2000
                     val gap = LocalSpaces.current.spacing300
-                    val contentMaxWidth = if (hasTrailingContent) {
-                        (maxWidth - trailingFloor - gap).coerceAtLeast(0.dp)
-                    } else {
-                        maxWidth
-                    }
+                    val contentMaxWidth = (maxWidth - trailingFloor - gap).coerceAtLeast(0.dp)
 
                     Row(verticalAlignment = trailingVerticalAlignment) {
                         Column(
@@ -989,20 +996,18 @@ private fun CoreListItem(
                                 .then(other = contentAlpha),
                         )
 
-                        if (hasTrailingContent) {
-                            Row(
-                                horizontalArrangement = Arrangement.End,
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier
-                                    .weight(weight = 1f)
-                                    .padding(start = gap),
-                            ) {
-                                ListItemTrailingContent(
-                                    trailingSlot = trailingSlot,
-                                    navigationIndicator = navigationIndicator,
-                                    enabled = enabled,
-                                )
-                            }
+                        Row(
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .weight(weight = 1f)
+                                .padding(start = gap),
+                        ) {
+                            ListItemTrailingContent(
+                                trailingSlot = trailingSlot,
+                                navigationIndicator = navigationIndicator,
+                                enabled = enabled,
+                            )
                         }
                     }
                 }
@@ -1019,16 +1024,14 @@ private fun CoreListItem(
                             .then(other = contentAlpha),
                     )
 
-                    if (trailingSlot != null || navigationIndicator) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            ListItemTrailingContent(
-                                trailingSlot = trailingSlot,
-                                navigationIndicator = navigationIndicator,
-                                enabled = enabled,
-                            )
-                        }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ListItemTrailingContent(
+                            trailingSlot = trailingSlot,
+                            navigationIndicator = navigationIndicator,
+                            enabled = enabled,
+                        )
                     }
                 }
             }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -81,10 +81,28 @@ public fun LemonadeUi.ResourceListItem(
     supportText: String? = null,
     showDivider: Boolean = false,
 ) {
-    LemonadeUi.ListItem(
-        label = label,
-        supportText = supportText,
-        isLoading = isLoading,
+    if (isLoading) {
+        ListItemSkeleton(
+            modifier = modifier,
+            showDivider = showDivider,
+        )
+        return
+    }
+
+    CoreListItem(
+        contentSlot = {
+            ListItemTextContent(
+                label = label,
+                topLabel = null,
+                supportText = supportText,
+                voice = LemonadeListItemVoice.Neutral,
+                labelMaxLines = Int.MAX_VALUE,
+                labelOverflow = TextOverflow.Clip,
+                supportTextMaxLines = Int.MAX_VALUE,
+                supportTextOverflow = TextOverflow.Clip,
+                slotContent = null,
+            )
+        },
         leadingSlot = {
             Box(
                 content = leadingSlot,
@@ -117,6 +135,8 @@ public fun LemonadeUi.ResourceListItem(
                 }
             }
         },
+        voice = LemonadeListItemVoice.Neutral,
+        navigationIndicator = false,
         onListItemClick = onItemClicked,
         role = null,
         enabled = enabled,
@@ -126,6 +146,11 @@ public fun LemonadeUi.ResourceListItem(
         // Keep the value top-aligned with the label's first line: the label can wrap (no maxLines cap),
         // and the outer Row already centers a single-line row, so this handles both without extra logic.
         trailingVerticalAlignment = Alignment.Top,
+        leadingVerticalAlignment = singleLineLeadingAlignment(
+            topLabel = null,
+            supportText = supportText,
+        ),
+        priority = LemonadeListItemPriority.Trailing,
     )
 }
 
@@ -308,45 +333,57 @@ public fun LemonadeUi.ActionListItem(
     supportTextMaxLines: Int = Int.MAX_VALUE,
     supportTextOverflow: TextOverflow = TextOverflow.Clip,
 ) {
-    LemonadeUi.ListItem(
-        label = label,
-        topLabel = topLabel,
-        supportText = supportText,
-        isLoading = isLoading,
-        labelMaxLines = labelMaxLines,
-        labelOverflow = labelOverflow,
-        supportTextMaxLines = supportTextMaxLines,
-        supportTextOverflow = supportTextOverflow,
-        leadingSlot = leadingSlot,
-        trailingSlot = if (trailingSlot != null) {
-            {
-                Row(
-                    modifier = Modifier.then(
-                        other = if (enabled) {
-                            Modifier
-                        } else {
-                            Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
-                        },
-                    ),
-                ) {
-                    trailingSlot()
+    if (isLoading) {
+        ListItemSkeleton(
+            modifier = modifier,
+            showDivider = showDivider,
+        )
+    } else {
+        CoreListItem(
+            contentSlot = {
+                ListItemTextContent(
+                    label = label,
+                    topLabel = topLabel,
+                    supportText = supportText,
+                    voice = voice,
+                    labelMaxLines = labelMaxLines,
+                    labelOverflow = labelOverflow,
+                    supportTextMaxLines = supportTextMaxLines,
+                    supportTextOverflow = supportTextOverflow,
+                    slotContent = slotContent,
+                )
+            },
+            leadingSlot = leadingSlot,
+            trailingSlot = if (trailingSlot != null) {
+                {
+                    Row(
+                        modifier = Modifier.then(
+                            other = if (enabled) {
+                                Modifier
+                            } else {
+                                Modifier.alpha(alpha = LocalOpacities.current.state.opacityDisabled)
+                            },
+                        ),
+                    ) {
+                        trailingSlot()
+                    }
                 }
-            }
-        } else {
-            null
-        },
-        slotContent = slotContent,
-        navigationIndicator = showNavigationIndicator,
-        voice = voice,
-        onListItemClick = onItemClicked,
-        role = role,
-        enabled = enabled,
-        modifier = modifier,
-        showDivider = showDivider,
-        interactionSource = interactionSource,
-        leadingVerticalAlignment = leadingVerticalAlignment,
-        trailingVerticalAlignment = trailingVerticalAlignment,
-    )
+            } else {
+                null
+            },
+            voice = voice,
+            navigationIndicator = showNavigationIndicator,
+            onListItemClick = onItemClicked,
+            role = role,
+            enabled = enabled,
+            modifier = modifier,
+            showDivider = showDivider,
+            interactionSource = interactionSource,
+            leadingVerticalAlignment = leadingVerticalAlignment,
+            trailingVerticalAlignment = trailingVerticalAlignment,
+            priority = LemonadeListItemPriority.Trailing,
+        )
+    }
 }
 
 @Deprecated(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -16,18 +15,27 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
 import com.teya.lemonade.core.LemonadeAssetSize
 import com.teya.lemonade.core.LemonadeIcons
@@ -980,62 +988,140 @@ private fun CoreListItem(
                             fill = priority == LemonadeListItemPriority.Trailing,
                         ).then(other = contentAlpha),
                 )
-            } else if (priority == LemonadeListItemPriority.Label) {
-                // Content keeps its width; the trailing slot yields and truncates. The content is
-                // capped so the trailing slot always retains a readable floor instead of vanishing.
-                BoxWithConstraints(modifier = Modifier.weight(weight = 1f)) {
-                    val trailingFloor = LocalSizes.current.size2000
-                    val gap = LocalSpaces.current.spacing300
-                    val contentMaxWidth = (maxWidth - trailingFloor - gap).coerceAtLeast(0.dp)
-
-                    Row(verticalAlignment = trailingVerticalAlignment) {
+            } else {
+                Layout(
+                    modifier = Modifier.weight(weight = 1f),
+                    measurePolicy = ListItemBodyMeasurePolicy(
+                        priority = priority,
+                        trailingAlignment = trailingVerticalAlignment,
+                        trailingGap = LocalSpaces.current.spacing300,
+                        trailingFloor = LocalSizes.current.size2000,
+                    ),
+                    content = {
                         Column(
                             content = contentSlot,
-                            modifier = Modifier
-                                .widthIn(max = contentMaxWidth)
-                                .then(other = contentAlpha),
+                            modifier = contentAlpha,
                         )
 
-                        Row(
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .weight(weight = 1f)
-                                .padding(start = gap),
-                        ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
                             ListItemTrailingContent(
                                 trailingSlot = trailingSlot,
                                 navigationIndicator = navigationIndicator,
                                 enabled = enabled,
                             )
                         }
-                    }
-                }
-            } else {
-                // Default: the trailing slot keeps its width; the content column truncates to fit.
-                Row(
-                    modifier = Modifier.weight(weight = 1f),
-                    verticalAlignment = trailingVerticalAlignment,
-                ) {
-                    Column(
-                        content = contentSlot,
-                        modifier = Modifier
-                            .weight(weight = 1f)
-                            .then(other = contentAlpha),
-                    )
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        ListItemTrailingContent(
-                            trailingSlot = trailingSlot,
-                            navigationIndicator = navigationIndicator,
-                            enabled = enabled,
-                        )
-                    }
-                }
+                    },
+                )
             }
         }
+    }
+}
+
+/**
+ * Measures the list-item body — the content column and the trailing content — without the
+ * subcomposition a `BoxWithConstraints` would cost per row. Exactly two measurables: the content
+ * at index 0 and the trailing content at index 1.
+ *
+ * [LemonadeListItemPriority.Trailing] measures the trailing content at its natural width and
+ * forces the content to exactly the remainder, matching the former weighted content column.
+ * [LemonadeListItemPriority.Label] caps the content so the trailing content always retains a
+ * [trailingFloor] of readable space, then lets the trailing content wrap into what is left after
+ * [trailingGap]; the trailing content is placed end-anchored either way.
+ *
+ * Children's alignment lines propagate through placement, and the default derived intrinsics
+ * re-run this measurement — which also gives Label-priority rows working intrinsic sizes, where
+ * the previous subcomposition threw on intrinsic measurement.
+ */
+private data class ListItemBodyMeasurePolicy(
+    private val priority: LemonadeListItemPriority,
+    private val trailingAlignment: Alignment.Vertical,
+    private val trailingGap: Dp,
+    private val trailingFloor: Dp,
+) : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        val loose = constraints.copy(minWidth = 0, minHeight = 0)
+        val gapPx = trailingGap.roundToPx()
+        val content: Placeable
+        val trailing: Placeable
+        if (priority == LemonadeListItemPriority.Label) {
+            content = measureLabelPriorityContent(
+                measurable = measurables[0],
+                loose = loose,
+                gapPx = gapPx,
+                floorPx = trailingFloor.roundToPx(),
+            )
+            trailing = measureLabelPriorityTrailing(
+                measurable = measurables[1],
+                loose = loose,
+                gapPx = gapPx,
+                contentWidth = content.width,
+            )
+        } else {
+            trailing = measurables[1].measure(constraints = loose)
+            content = measureTrailingPriorityContent(
+                measurable = measurables[0],
+                loose = loose,
+                trailingWidth = trailing.width,
+            )
+        }
+        val gapUsed = if (priority == LemonadeListItemPriority.Label) gapPx else 0
+        val width = constraints.constrainWidth(width = content.width + gapUsed + trailing.width)
+        val height = constraints.constrainHeight(height = maxOf(content.height, trailing.height))
+        return layout(width = width, height = height) {
+            content.placeRelative(
+                x = 0,
+                y = trailingAlignment.align(size = content.height, space = height),
+            )
+            trailing.placeRelative(
+                x = width - trailing.width,
+                y = trailingAlignment.align(size = trailing.height, space = height),
+            )
+        }
+    }
+
+    private fun measureLabelPriorityContent(
+        measurable: Measurable,
+        loose: Constraints,
+        gapPx: Int,
+        floorPx: Int,
+    ): Placeable {
+        val capped = if (loose.hasBoundedWidth) {
+            loose.copy(maxWidth = (loose.maxWidth - floorPx - gapPx).coerceAtLeast(0))
+        } else {
+            loose
+        }
+        return measurable.measure(constraints = capped)
+    }
+
+    private fun measureLabelPriorityTrailing(
+        measurable: Measurable,
+        loose: Constraints,
+        gapPx: Int,
+        contentWidth: Int,
+    ): Placeable {
+        val leftover = if (loose.hasBoundedWidth) {
+            loose.copy(maxWidth = (loose.maxWidth - contentWidth - gapPx).coerceAtLeast(0))
+        } else {
+            loose
+        }
+        return measurable.measure(constraints = leftover)
+    }
+
+    private fun measureTrailingPriorityContent(
+        measurable: Measurable,
+        loose: Constraints,
+        trailingWidth: Int,
+    ): Placeable {
+        val remainder = if (loose.hasBoundedWidth) {
+            val contentWidth = (loose.maxWidth - trailingWidth).coerceAtLeast(0)
+            loose.copy(minWidth = contentWidth, maxWidth = contentWidth)
+        } else {
+            loose
+        }
+        return measurable.measure(constraints = remainder)
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -921,10 +921,10 @@ private fun CoreListItem(
     leadingVerticalAlignment: Alignment.Vertical,
     priority: LemonadeListItemPriority,
 ) {
-    SafeArea(modifier = modifier, showDivider = showDivider) {
+    SafeArea(modifier = modifier, showDivider = showDivider) { rowModifier ->
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
+            modifier = rowModifier
                 .then(
                     other = if (onListItemClick != null) {
                         Modifier.clickable(
@@ -1064,18 +1064,19 @@ private fun RowScope.ListItemTrailingContent(
     }
 }
 
+/**
+ * Wraps a list-item row in its outer gutter padding and, when requested, the divider below it.
+ * Inline, and in the no-divider case it emits no wrapper node at all: the gutter padding is handed
+ * to [content] to apply on the row itself.
+ */
 @Composable
-private fun SafeArea(
-    modifier: Modifier = Modifier,
+private inline fun SafeArea(
+    modifier: Modifier,
     showDivider: Boolean,
-    content: @Composable ColumnScope.() -> Unit,
+    content: @Composable (rowModifier: Modifier) -> Unit,
 ) {
     if (!showDivider) {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            modifier = modifier.padding(all = LocalSpaces.current.spacing100),
-            content = content,
-        )
+        content(modifier.padding(all = LocalSpaces.current.spacing100))
         return
     }
 
@@ -1083,11 +1084,7 @@ private fun SafeArea(
         verticalArrangement = Arrangement.Center,
         modifier = modifier,
     ) {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.padding(all = LocalSpaces.current.spacing100),
-            content = content,
-        )
+        content(Modifier.padding(all = LocalSpaces.current.spacing100))
 
         LemonadeUi.HorizontalDivider(
             modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing400),
@@ -1108,10 +1105,10 @@ private fun ListItemSkeleton(
     modifier: Modifier = Modifier,
     showDivider: Boolean = false,
 ) {
-    SafeArea(modifier = modifier, showDivider = showDivider) {
+    SafeArea(modifier = modifier, showDivider = showDivider) { rowModifier ->
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
+            modifier = rowModifier
                 .padding(
                     horizontal = LocalSpaces.current.spacing300,
                     vertical = LocalSpaces.current.spacing300,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -634,7 +634,20 @@ public fun LemonadeUi.ListItem(
             showDivider = showDivider,
         )
     } else {
-        LemonadeUi.ListItem(
+        CoreListItem(
+            contentSlot = {
+                ListItemTextContent(
+                    label = label,
+                    topLabel = topLabel,
+                    supportText = supportText,
+                    voice = voice,
+                    labelMaxLines = labelMaxLines,
+                    labelOverflow = labelOverflow,
+                    supportTextMaxLines = supportTextMaxLines,
+                    supportTextOverflow = supportTextOverflow,
+                    slotContent = slotContent,
+                )
+            },
             leadingSlot = leadingSlot,
             trailingSlot = trailingSlot,
             voice = voice,
@@ -648,37 +661,6 @@ public fun LemonadeUi.ListItem(
             leadingVerticalAlignment = leadingVerticalAlignment,
             trailingVerticalAlignment = trailingVerticalAlignment,
             priority = priority,
-            contentSlot = {
-                if (topLabel != null) {
-                    LemonadeUi.Text(
-                        text = topLabel,
-                        textStyle = LocalTypographies.current.bodySmallRegular,
-                        color = LocalColors.current.content.contentSecondary,
-                    )
-                }
-
-                LemonadeUi.Text(
-                    text = label,
-                    textStyle = LocalTypographies.current.bodyMediumMedium,
-                    color = voice.contentColor,
-                    maxLines = labelMaxLines,
-                    overflow = labelOverflow,
-                )
-
-                if (supportText != null) {
-                    LemonadeUi.Text(
-                        text = supportText,
-                        textStyle = LocalTypographies.current.bodySmallRegular,
-                        color = LocalColors.current.content.contentSecondary,
-                        maxLines = supportTextMaxLines,
-                        overflow = supportTextOverflow,
-                    )
-                }
-
-                if (slotContent != null) {
-                    slotContent()
-                }
-            },
         )
     }
 }
@@ -841,22 +823,70 @@ private fun singleLineLeadingAlignment(
         Alignment.Top
     }
 
+/**
+ * The text stack shared by the string-based overloads: optional top label, the label itself, the
+ * optional support text and the optional [slotContent] below them. Inline, so it adds no
+ * restartable scope on top of the content slot it is called from.
+ */
+@Composable
+private inline fun ColumnScope.ListItemTextContent(
+    label: String,
+    topLabel: String?,
+    supportText: String?,
+    voice: LemonadeListItemVoice,
+    labelMaxLines: Int,
+    labelOverflow: TextOverflow,
+    supportTextMaxLines: Int,
+    supportTextOverflow: TextOverflow,
+    noinline slotContent: (@Composable ColumnScope.() -> Unit)?,
+) {
+    if (topLabel != null) {
+        LemonadeUi.Text(
+            text = topLabel,
+            textStyle = LocalTypographies.current.bodySmallRegular,
+            color = LocalColors.current.content.contentSecondary,
+        )
+    }
+
+    LemonadeUi.Text(
+        text = label,
+        textStyle = LocalTypographies.current.bodyMediumMedium,
+        color = voice.contentColor,
+        maxLines = labelMaxLines,
+        overflow = labelOverflow,
+    )
+
+    if (supportText != null) {
+        LemonadeUi.Text(
+            text = supportText,
+            textStyle = LocalTypographies.current.bodySmallRegular,
+            color = LocalColors.current.content.contentSecondary,
+            maxLines = supportTextMaxLines,
+            overflow = supportTextOverflow,
+        )
+    }
+
+    if (slotContent != null) {
+        slotContent()
+    }
+}
+
 @Composable
 private fun CoreListItem(
     contentSlot: @Composable ColumnScope.() -> Unit,
     leadingSlot: (@Composable RowScope.() -> Unit)?,
     trailingSlot: (@Composable RowScope.() -> Unit)?,
-    voice: LemonadeListItemVoice = LemonadeListItemVoice.Neutral,
-    navigationIndicator: Boolean = false,
+    voice: LemonadeListItemVoice,
+    navigationIndicator: Boolean,
     onListItemClick: (() -> Unit)?,
     role: Role?,
     enabled: Boolean,
-    modifier: Modifier = Modifier,
+    modifier: Modifier,
     showDivider: Boolean,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    trailingVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    leadingVerticalAlignment: Alignment.Vertical = Alignment.Top,
-    priority: LemonadeListItemPriority = LemonadeListItemPriority.Trailing,
+    interactionSource: MutableInteractionSource,
+    trailingVerticalAlignment: Alignment.Vertical,
+    leadingVerticalAlignment: Alignment.Vertical,
+    priority: LemonadeListItemPriority,
 ) {
     SafeArea(modifier = modifier, showDivider = showDivider) {
         Row(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItem.kt
@@ -866,11 +866,7 @@ private fun singleLineLeadingAlignment(
         Alignment.Top
     }
 
-/**
- * The text stack shared by the string-based overloads: optional top label, the label itself, the
- * optional support text and the optional [slotContent] below them. Inline, so it adds no
- * restartable scope on top of the content slot it is called from.
- */
+/** The text stack shared by the string-based overloads. */
 @Composable
 private inline fun ColumnScope.ListItemTextContent(
     label: String,
@@ -979,9 +975,6 @@ private fun CoreListItem(
 
         val hasTrailingContent = trailingSlot != null || navigationIndicator
         if (!hasTrailingContent) {
-            // With nothing trailing there is no width contention, so the content column sits
-            // directly in the row. A filling weight reproduces the Trailing-priority forced
-            // width; Label priority lets the column wrap inside the remaining space.
             Column(
                 content = contentSlot,
                 modifier = Modifier
@@ -1018,21 +1011,7 @@ private fun CoreListItem(
     }
 }
 
-/**
- * Measures the list-item body — the content column and the trailing content — without the
- * subcomposition a `BoxWithConstraints` would cost per row. Exactly two measurables: the content
- * at index 0 and the trailing content at index 1.
- *
- * [LemonadeListItemPriority.Trailing] measures the trailing content at its natural width and
- * forces the content to exactly the remainder, matching the former weighted content column.
- * [LemonadeListItemPriority.Label] caps the content so the trailing content always retains a
- * [trailingFloor] of readable space, then lets the trailing content wrap into what is left after
- * [trailingGap]; the trailing content is placed end-anchored either way.
- *
- * Children's alignment lines propagate through placement, and the default derived intrinsics
- * re-run this measurement — which also gives Label-priority rows working intrinsic sizes, where
- * the previous subcomposition threw on intrinsic measurement.
- */
+/** Measures the list-item body: the content column at index 0 and the trailing content at index 1. */
 private data class ListItemBodyMeasurePolicy(
     private val priority: LemonadeListItemPriority,
     private val trailingAlignment: Alignment.Vertical,
@@ -1154,10 +1133,7 @@ private fun RowScope.ListItemTrailingContent(
     }
 }
 
-/**
- * The outer treatment of a list-item row: the optional divider below it and the gutter padding
- * around it. Pure modifiers, so a row composes no wrapper node for either.
- */
+/** The outer treatment of a list-item row: the gutter padding and the optional divider below it. */
 @Composable
 private fun Modifier.listItemSafeArea(showDivider: Boolean): Modifier {
     val withDivider = if (showDivider) {
@@ -1168,11 +1144,7 @@ private fun Modifier.listItemSafeArea(showDivider: Boolean): Modifier {
     return withDivider.padding(all = LocalSpaces.current.spacing100)
 }
 
-/**
- * Draws the row divider the way [LemonadeUi.HorizontalDivider] renders its solid variant — same
- * thickness, colour and horizontal insets — while reserving the divider's height with padding so
- * the row's total height matches the former divider sibling.
- */
+/** Draws the solid [LemonadeUi.HorizontalDivider] line, reserving its height with bottom padding. */
 @Composable
 private fun Modifier.listItemDivider(): Modifier {
     val thickness = LocalBorderWidths.current.base.border25

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
@@ -1,0 +1,175 @@
+package com.teya.lemonade
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.IndicationNodeFactory
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.unit.LayoutDirection
+import com.teya.lemonade.core.LemonadeListItemVoice
+import kotlinx.coroutines.launch
+
+/**
+ * Matches the default spring of `animateColorAsState`, which the highlight previously used. The
+ * node animates a 0..1 fraction and scales the theme colour's alpha at draw time; for a same-RGB
+ * alpha fade this is trajectory-identical to animating the [Color] itself, since springs act on
+ * each vector dimension independently.
+ */
+private val HighlightAnimationSpec: SpringSpec<Float> = spring()
+
+/**
+ * Press/hover indication for interactive list items.
+ *
+ * The highlight is painted directly in the draw phase, reading the theme colour and shape at draw
+ * time (not composition time) and using the row's rounded [Shape] outline instead of a
+ * [androidx.compose.ui.draw.clip] graphics layer. While a row is idle or scrolling the fraction is
+ * zero, so the row draws nothing and pays no clip/background cost. There is no platform ripple;
+ * press feedback is the animated fill, mirroring the iOS `ListItemButtonStyle`.
+ *
+ * Interaction tracking lives inside the indication [Modifier.Node] rather than in composition, so
+ * pressing or hovering a row never recomposes it — the animation only invalidates draw. Rows that
+ * are never touched allocate no animation state at all.
+ */
+internal data class ListItemHighlightIndication(
+    private val voice: LemonadeListItemVoice,
+) : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode =
+        ListItemHighlightNode(
+            interactionSource = interactionSource,
+            voice = voice,
+        )
+}
+
+private class ListItemHighlightNode(
+    private val interactionSource: InteractionSource,
+    private val voice: LemonadeListItemVoice,
+) : Modifier.Node(),
+    DrawModifierNode,
+    CompositionLocalConsumerModifierNode {
+    private val pressInteractions = mutableListOf<PressInteraction.Press>()
+    private val hoverInteractions = mutableListOf<HoverInteraction.Enter>()
+
+    private var highlightFraction: Animatable<Float, AnimationVector1D>? = null
+
+    private var cachedOutline: Outline? = null
+    private var cachedSize: Size = Size.Unspecified
+    private var cachedLayoutDirection: LayoutDirection? = null
+    private var cachedShape: Shape? = null
+
+    override fun onAttach() {
+        coroutineScope.launch {
+            interactionSource.interactions.collect { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> pressInteractions.add(interaction)
+                    is PressInteraction.Release -> pressInteractions.remove(interaction.press)
+                    is PressInteraction.Cancel -> pressInteractions.remove(interaction.press)
+                    is HoverInteraction.Enter -> hoverInteractions.add(interaction)
+                    is HoverInteraction.Exit -> hoverInteractions.remove(interaction.enter)
+                    else -> return@collect
+                }
+                animateHighlight()
+            }
+        }
+    }
+
+    override fun onDetach() {
+        pressInteractions.clear()
+        hoverInteractions.clear()
+        highlightFraction = null
+        cachedOutline = null
+        cachedSize = Size.Unspecified
+        cachedLayoutDirection = null
+        cachedShape = null
+    }
+
+    private fun animateHighlight() {
+        val active = pressInteractions.isNotEmpty() || hoverInteractions.isNotEmpty()
+        val target = if (active) 1f else 0f
+        val animatable = highlightFraction
+            ?: if (active) {
+                Animatable(initialValue = 0f).also { created ->
+                    highlightFraction = created
+                }
+            } else {
+                return
+            }
+        if (animatable.targetValue == target) {
+            return
+        }
+        coroutineScope.launch {
+            animatable.animateTo(
+                targetValue = target,
+                animationSpec = HighlightAnimationSpec,
+            ) {
+                invalidateDraw()
+            }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        drawHighlight()
+        drawContent()
+    }
+
+    private fun ContentDrawScope.drawHighlight() {
+        val fraction = highlightFraction?.value
+            ?: return
+        if (fraction <= 0f) {
+            return
+        }
+        val baseColor = highlightColor()
+        val alpha = baseColor.alpha * fraction
+        if (alpha <= 0f) {
+            return
+        }
+        drawOutline(
+            outline = obtainOutline(),
+            color = baseColor.copy(alpha = alpha),
+        )
+    }
+
+    private fun highlightColor(): Color {
+        val interactionColors = currentValueOf(LocalColors).interaction
+        return when (voice) {
+            LemonadeListItemVoice.Neutral -> interactionColors.bgSubtleInteractive
+            LemonadeListItemVoice.Critical -> interactionColors.bgCriticalSubtleInteractive
+        }
+    }
+
+    private fun ContentDrawScope.obtainOutline(): Outline {
+        val shape = currentValueOf(LocalShapes).radius500
+        val existing = cachedOutline
+        if (existing != null &&
+            cachedSize == size &&
+            cachedLayoutDirection == layoutDirection &&
+            cachedShape == shape
+        ) {
+            return existing
+        }
+        val outline = shape.createOutline(
+            size = size,
+            layoutDirection = layoutDirection,
+            density = this,
+        )
+        cachedOutline = outline
+        cachedSize = size
+        cachedLayoutDirection = layoutDirection
+        cachedShape = shape
+        return outline
+    }
+}

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
@@ -154,11 +154,10 @@ private class ListItemHighlightNode(
     private fun ContentDrawScope.obtainOutline(): Outline {
         val shape = currentValueOf(LocalShapes).radius500
         val existing = cachedOutline
-        if (existing != null &&
-            cachedSize == size &&
+        val cacheValid = cachedSize == size &&
             cachedLayoutDirection == layoutDirection &&
             cachedShape == shape
-        ) {
+        if (existing != null && cacheValid) {
             return existing
         }
         val outline = shape.createOutline(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
@@ -24,27 +24,10 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.teya.lemonade.core.LemonadeListItemVoice
 import kotlinx.coroutines.launch
 
-/**
- * Matches the default spring of `animateColorAsState`, which the highlight previously used. The
- * node animates a 0..1 fraction and scales the theme colour's alpha at draw time; for a same-RGB
- * alpha fade this is trajectory-identical to animating the [Color] itself, since springs act on
- * each vector dimension independently.
- */
+/** The default spring of `animateColorAsState`, which the highlight previously animated with. */
 private val HighlightAnimationSpec: SpringSpec<Float> = spring()
 
-/**
- * Press/hover indication for interactive list items.
- *
- * The highlight is painted directly in the draw phase, reading the theme colour and shape at draw
- * time (not composition time) and using the row's rounded [Shape] outline instead of a
- * [androidx.compose.ui.draw.clip] graphics layer. While a row is idle or scrolling the fraction is
- * zero, so the row draws nothing and pays no clip/background cost. There is no platform ripple;
- * press feedback is the animated fill, mirroring the iOS `ListItemButtonStyle`.
- *
- * Interaction tracking lives inside the indication [Modifier.Node] rather than in composition, so
- * pressing or hovering a row never recomposes it — the animation only invalidates draw. Rows that
- * are never touched allocate no animation state at all.
- */
+/** Press/hover fill indication for interactive list items, handled entirely in the draw phase. */
 internal data class ListItemHighlightIndication(
     private val voice: LemonadeListItemVoice,
 ) : IndicationNodeFactory {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
@@ -65,12 +65,10 @@ public fun Modifier.clickable(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     role: Role? = null,
 ): Modifier =
-    composed {
-        clickable(
-            enabled = enabled,
-            onClick = onClick,
-            interactionSource = interactionSource,
-            role = role,
-            indication = LocalEffects.current.interactionIndication,
-        )
-    }
+    clickable(
+        enabled = enabled,
+        onClick = onClick,
+        interactionSource = interactionSource,
+        role = role,
+        indication = LocalEffects.current.interactionIndication,
+    )

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SelectListItem.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SelectListItem.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -420,9 +419,10 @@ private fun OutlinedSelectListItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .clip(shape = shapes.radius500)
-            .background(color = animatedBackgroundColor)
-            .border(
+            .background(
+                color = animatedBackgroundColor,
+                shape = shapes.radius500,
+            ).border(
                 width = borderWidth,
                 color = animatedBorderColor,
                 shape = shapes.radius500,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Skeleton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Skeleton.kt
@@ -9,8 +9,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -18,11 +16,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
@@ -218,35 +218,43 @@ private fun CoreSkeleton(
     val skeletonSize = size.toSkeletonSizeDimensions(variant = variant)
     val variantData = variant.variantData
 
+    // The gradient brush and the resolved corner radius are cached per size; each shimmer frame
+    // only pans the cached shader by translating the canvas while offsetting the rounded rect
+    // back, which samples the gradient over exactly the span the former per-frame brush covered.
     Box(
         modifier = modifier
             .height(height = skeletonSize.height)
             .width(width = skeletonSize.width)
-            .padding(vertical = variantData.verticalSpacing),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxHeight()
-                .fillMaxWidth()
-                .clip(shape = variantData.radius)
-                .drawBehind {
-                    val width = this.size.width
-                    drawRect(
-                        brush = Brush.linearGradient(
-                            colors = listOf(baseColor, highlightColor, baseColor),
-                            start = Offset(
-                                x = width * (shimmerOffset - 0.5f),
-                                y = 0f,
-                            ),
-                            end = Offset(
-                                x = width * (shimmerOffset + 0.5f),
-                                y = 0f,
-                            ),
-                        ),
-                    )
-                },
-        )
-    }
+            .padding(vertical = variantData.verticalSpacing)
+            .drawWithCache {
+                val drawSize = this.size
+                val outline = variantData.radius.createOutline(
+                    size = drawSize,
+                    layoutDirection = layoutDirection,
+                    density = this,
+                )
+                val cornerRadius = (outline as? Outline.Rounded)
+                    ?.roundRect
+                    ?.topLeftCornerRadius
+                    ?: CornerRadius.Zero
+                val brush = Brush.linearGradient(
+                    colors = listOf(baseColor, highlightColor, baseColor),
+                    start = Offset(x = -drawSize.width / 2f, y = 0f),
+                    end = Offset(x = drawSize.width / 2f, y = 0f),
+                )
+                onDrawBehind {
+                    val panX = drawSize.width * shimmerOffset
+                    translate(left = panX) {
+                        drawRoundRect(
+                            brush = brush,
+                            topLeft = Offset(x = -panX, y = 0f),
+                            size = drawSize,
+                            cornerRadius = cornerRadius,
+                        )
+                    }
+                }
+            },
+    )
 }
 
 private val LemonadeAssetSize.dp: Dp

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Skeleton.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Skeleton.kt
@@ -218,9 +218,6 @@ private fun CoreSkeleton(
     val skeletonSize = size.toSkeletonSizeDimensions(variant = variant)
     val variantData = variant.variantData
 
-    // The gradient brush and the resolved corner radius are cached per size; each shimmer frame
-    // only pans the cached shader by translating the canvas while offsetting the rounded rect
-    // back, which samples the gradient over exactly the span the former per-frame brush covered.
     Box(
         modifier = modifier
             .height(height = skeletonSize.height)

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -63,12 +61,13 @@ public fun LemonadeUi.SymbolContainer(
         voice = voice,
         size = size,
         shape = shape,
+        clipContent = false,
         modifier = modifier,
         badgeSlot = badgeSlot,
-        contentSlot = {
+        contentSlot = { dimensions ->
             LemonadeUi.Icon(
                 icon = icon,
-                size = LocalSymbolContainerPlatformDimensions.current.lemonadeIconSize,
+                size = dimensions.lemonadeIconSize,
                 contentDescription = contentDescription,
                 tint = voice.tintColor,
             )
@@ -108,13 +107,14 @@ public fun LemonadeUi.SymbolContainer(
         voice = voice,
         size = size,
         shape = shape,
+        clipContent = false,
         modifier = modifier,
         badgeSlot = badgeSlot,
-        contentSlot = {
+        contentSlot = { dimensions ->
             LemonadeUi.Text(
                 text = text,
                 color = voice.tintColor,
-                textStyle = LocalSymbolContainerPlatformDimensions.current.textStyle,
+                textStyle = dimensions.textStyle,
             )
         },
     )
@@ -159,9 +159,10 @@ public fun LemonadeUi.SymbolContainer(
         voice = voice,
         size = size,
         shape = shape,
+        clipContent = fill,
         modifier = modifier,
         badgeSlot = badgeSlot,
-        contentSlot = {
+        contentSlot = { dimensions ->
             Image(
                 painter = painter,
                 contentDescription = contentDescription,
@@ -175,9 +176,7 @@ public fun LemonadeUi.SymbolContainer(
                     if (fill) {
                         Modifier.matchParentSize()
                     } else {
-                        Modifier.requiredSize(
-                            size = LocalSymbolContainerPlatformDimensions.current.contentSize,
-                        )
+                        Modifier.requiredSize(size = dimensions.contentSize)
                     },
                 ),
             )
@@ -222,15 +221,14 @@ public fun LemonadeUi.SymbolContainer(
         voice = voice,
         size = size,
         shape = shape,
+        clipContent = true,
         modifier = modifier,
         badgeSlot = badgeSlot,
-        contentSlot = {
+        contentSlot = { dimensions ->
             Box(
                 content = contentSlot,
                 contentAlignment = Alignment.Center,
-                modifier = Modifier.requiredSize(
-                    size = LocalSymbolContainerPlatformDimensions.current.contentSize,
-                ),
+                modifier = Modifier.requiredSize(size = dimensions.contentSize),
             )
         },
     )
@@ -238,69 +236,91 @@ public fun LemonadeUi.SymbolContainer(
 
 @Composable
 private fun CoreSymbolContainer(
-    contentSlot: @Composable BoxScope.() -> Unit,
+    contentSlot: @Composable BoxScope.(dimensions: SymbolContainerPlatformDimensions) -> Unit,
     voice: SymbolContainerVoice,
     size: SymbolContainerSize,
     shape: SymbolContainerShape,
+    clipContent: Boolean,
     modifier: Modifier = Modifier,
     badgeSlot: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     val dimensions = size.defaultSymbolContainerPlatformDimensions()
     val resolvedShape = shape.resolveShape(size)
-    CompositionLocalProvider(LocalSymbolContainerPlatformDimensions provides dimensions) {
-        if (badgeSlot != null) {
-            val density = LocalDensity.current
-            val spaces = LocalSpaces.current
-            LemonadeBadgeBox(
-                modifier = modifier,
-                badgeOffset = { badgeSize ->
-                    val startingHeight = with(density) {
-                        badgeSize.height.toDp() - dimensions.containerSize
-                    }
-                    DpOffset(
-                        x = spaces.spacing100,
-                        y = startingHeight - spaces.spacing100,
-                    )
-                },
-                badge = badgeSlot,
-                content = {
-                    Box(
-                        content = contentSlot,
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .clip(shape = resolvedShape)
-                            .background(
-                                color = voice.containerColor,
-                            ).border(
-                                width = LocalBorderWidths.current.base.border25,
-                                color = voice.borderColor,
-                                shape = resolvedShape,
-                            ).requiredSize(size = dimensions.containerSize),
-                    )
-                },
-            )
-        } else {
-            Box(
-                content = contentSlot,
-                contentAlignment = Alignment.Center,
-                modifier = modifier
-                    .clip(shape = resolvedShape)
-                    .background(
-                        color = voice.containerColor,
-                    ).border(
-                        width = LocalBorderWidths.current.base.border25,
-                        color = voice.borderColor,
-                        shape = resolvedShape,
-                    ).requiredSize(size = dimensions.containerSize),
-            )
+    if (badgeSlot != null) {
+        val density = LocalDensity.current
+        val spaces = LocalSpaces.current
+        LemonadeBadgeBox(
+            modifier = modifier,
+            badgeOffset = { badgeSize ->
+                val startingHeight = with(density) {
+                    badgeSize.height.toDp() - dimensions.containerSize
+                }
+                DpOffset(
+                    x = spaces.spacing100,
+                    y = startingHeight - spaces.spacing100,
+                )
+            },
+            badge = badgeSlot,
+            content = {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.symbolContainerSurface(
+                        voice = voice,
+                        resolvedShape = resolvedShape,
+                        containerSize = dimensions.containerSize,
+                        clipContent = clipContent,
+                    ),
+                ) {
+                    contentSlot(dimensions)
+                }
+            },
+        )
+    } else {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier.symbolContainerSurface(
+                voice = voice,
+                resolvedShape = resolvedShape,
+                containerSize = dimensions.containerSize,
+                clipContent = clipContent,
+            ),
+        ) {
+            contentSlot(dimensions)
         }
     }
 }
 
-private val LocalSymbolContainerPlatformDimensions =
-    staticCompositionLocalOf<SymbolContainerPlatformDimensions> {
-        error("Local Symbol container platform dimensions not initialized")
+/**
+ * The container's fill, border and size. The fill is drawn with the shape directly instead of
+ * clipping the container, so a symbol costs no clip layer; [clipContent] opts back into the clip
+ * for the variants whose content genuinely overflows the container (fill-scaled images and
+ * arbitrary content slots). [Modifier.border] draws its stroke fully inside the shape either way,
+ * so the border geometry is identical in both branches.
+ */
+@Composable
+private fun Modifier.symbolContainerSurface(
+    voice: SymbolContainerVoice,
+    resolvedShape: Shape,
+    containerSize: Dp,
+    clipContent: Boolean,
+): Modifier {
+    val surface = if (clipContent) {
+        this
+            .clip(shape = resolvedShape)
+            .background(color = voice.containerColor)
+    } else {
+        this.background(
+            color = voice.containerColor,
+            shape = resolvedShape,
+        )
     }
+    return surface
+        .border(
+            width = LocalBorderWidths.current.base.border25,
+            color = voice.borderColor,
+            shape = resolvedShape,
+        ).requiredSize(size = containerSize)
+}
 
 private val SymbolContainerVoice.tintColor: Color
     @Composable get() {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SymbolContainer.kt
@@ -290,13 +290,7 @@ private fun CoreSymbolContainer(
     }
 }
 
-/**
- * The container's fill, border and size. The fill is drawn with the shape directly instead of
- * clipping the container, so a symbol costs no clip layer; [clipContent] opts back into the clip
- * for the variants whose content genuinely overflows the container (fill-scaled images and
- * arbitrary content slots). [Modifier.border] draws its stroke fully inside the shape either way,
- * so the border geometry is identical in both branches.
- */
+/** The container's fill, border and size; [clipContent] keeps the clip for content that overflows. */
 @Composable
 private fun Modifier.symbolContainerSurface(
     voice: SymbolContainerVoice,


### PR DESCRIPTION
Refs #196.

PR #197 removed the headline draw floor (persistent clip + animated background). This PR takes the levers that remained, plus the same class of cost in the row's usual neighbours (SymbolContainer leading icons, skeletons, the outlined SelectListItem, the theme `clickable`). Every public signature is untouched; the entire restructure is in private/internal code.

## What changed (one commit per lever, safest first within each area)

**ListItem**
- **Interaction machinery → `IndicationNodeFactory`** (`ListItemHighlight.kt`, new): the press/hover fill used to be a `@Composable` modifier factory running two interaction collectors + `animateColorAsState` per clickable row (3 coroutines, eager `Animatable`, recomposition on every press/hover flip, modifier chain rebuilt each recomposition). It is now a `Modifier.Node` indication handed to `clickable`: one collector in the node's scope, a fraction `Animatable` created lazily on first interaction, theme colour/shape read at draw time, and only `invalidateDraw()` ever fires — interaction never recomposes the row. Animation is `spring()` on a 0→1 fraction scaling the colour's alpha, trajectory-identical to the previous same-RGB colour fade.
- **Overload chain collapsed**: `ActionListItem`/`ResourceListItem`/string-`ListItem` now call the private `CoreListItem` directly (shared text stack extracted into an inline `ListItemTextContent`). ActionListItem's path drops from 7 restartable scopes per row to 3. The 8 `@Deprecated(HIDDEN)` shims are untouched (they already bind to live overloads; four vestigial `@Suppress("DEPRECATION")` removed).
- **SafeArea → modifiers**: the wrapper Column(s) around every row are gone; gutter padding and the divider are plain modifiers on the row itself. Divider rows draw the line in `drawBehind` with its height reserved as bottom padding, mirroring `CoreHorizontalDivider`'s solid-variant tokens and stroke maths exactly (−3 nodes, −2 composable frames per divider row).
- **Body `Row` + `BoxWithConstraints` → one `MeasurePolicy`**: `priority = Label` no longer pays a per-row SubcomposeLayout (composition during measure); both priorities are one two-child measure policy (content forced to the remainder for Trailing; content capped to preserve the `size2000` trailing floor for Label, trailing end-anchored). `placeRelative` throughout, so RTL mirrors as before. Side effect: `IntrinsicSize` on a Label-priority row used to **crash** (SubcomposeLayout throws on intrinsics) and now works. Rows with no trailing content skip the body wrapper entirely.
- Node math per row (no divider): label-only 4 → 2 layout nodes; label+icon 5 → 3; full row with divider 8 → 5; Label-priority full row also loses the per-row subcomposition.

**Neighbours**
- **SymbolContainer**: the container fill is drawn with the shape (`background(color, shape) + border` — the Chip idiom, and what SwiftUI's SymbolContainer already does) instead of clipping every symbol, so icons/text/fit-painters cost no clip layer. Fill-painters and `contentSlot` keep the clip (content genuinely overflows). The per-instance `CompositionLocalProvider` for platform dimensions is gone — dimensions are a slot parameter now.
- **Skeleton**: the shimmer allocated a fresh gradient `Brush` every frame and clipped an inner Box. Now one Box with `drawWithCache`: brush + corner radius cached per size, each frame pans the cached shader via canvas translate (identical gradient span), zero per-frame allocation, no clip.
- **Theme `clickable`** (`Modifier.kt`): dropped the redundant `composed {}` — the function is already `@Composable`, so it reads `LocalEffects` directly. Body-only change.
- **Outlined SelectListItem**: `clip + background + border` → `background(color, shape) + border` (no clip layer per row). Selection animation untouched. (A draw-phase selected-surface node replacing the two `animateColorAsState` was considered and deferred — the recompose-on-toggle is inherent to selection, and the clip removal was the measurable win.)

## Measurements

Debug builds, emulator SP-2 (Android 16, 720×1280), a local 400-row stress screen (not committed) of full transaction-style rows (leading `SymbolContainer`, support text, trailing text, chevron, divider, clickable), 12 scripted identical flings, atrace slice totals normalised per drawn frame — the same phase metric as the issue. Two alternating runs per side.

| Per-frame phase | before | after | Δ |
|---|---|---|---|
| **Trailing priority** — `Record View#draw()` | 0.84 ms | 0.69 ms | **−18%** |
| **Trailing** — `Compose:recompose` | 0.88 ms | 0.76 ms | **−14%** |
| **Trailing** — `measureAndLayout` | 1.71 ms | 1.71 ms | ~0% (text-measurement-dominated; node savings within emulator noise) |
| **Label priority** — `measureAndLayout` | 1.86 ms | 1.30 ms | **−30%** |
| **Label** — `Record View#draw()` | 0.75 ms | 0.62 ms | **−17%** |
| **Label** — `Compose:recompose` | 0.73 ms | 0.57 ms | **−21%** (recompose slice count 485 → 267, the measure-time subcompositions are gone; reproduced exactly across runs) |

Happy to re-run the numbers on a physical device or share the raw traces; @caiqueslp, your Perfetto A/B on the Transactions list would be the definitive check.

## Visual parity

Screenshot pixel-diffs (before vs after builds, status bar cropped):
- Stress rows, both priorities: identical except ≤4/255 anti-aliasing deltas on the symbol-circle edge (clip-layer AA vs shape-fill AA), ~0.2% of pixels.
- Press highlight (mid-long-press capture): identical bounds, identical changed-pixel count (157,102 both sides), identical fill colour.
- `ResourceListItemDisplay` (the Top-aligned trailing / two-level alignment-box case): identical except the same symbol-edge AA.
- `SkeletonDisplay`: ≤2/255.
- `SelectListItemDisplay`: Plain sections byte-identical; Outlined sections differ only in ≤6/255 corner AA plus scattered single pixels (max 51/255) along the selected item's curved border — same AA class.

## Behaviour notes (documented divergences, all edge-case)

- A caller forcing a ListItem taller than natural: the row now stretches (no divider) / the divider pins to the bottom (with divider) instead of the old Column centring. No such caller exists in the repo.
- The divider now renders in unbounded-width contexts (it previously collapsed to zero width via `fillMaxWidth` under an infinite max) — arguably a fix.
- Changing `voice` mid-press resets the highlight animation (indication factory inequality swaps the node) instead of retargeting its colour.
- In expressive themes, the outlined SelectListItem's ripple is no longer rounded by a clip — the same behaviour Chip already ships.
- `contentSlot` SymbolContainers still clip (SwiftUI does not) — kept conservative; relaxing it is a cheap follow-up.

## API Dump

**Verdict: `ADDITIONS_ONLY`** (verified with `bcv-check.sh --ci`; klib dumps unchanged).

The only baseline delta is one removed line in the android + desktop JVM dumps:

```
- public final fun getLambda$1280770520$ui_release ()Lkotlin/jvm/functions/Function3;
```

This is a `ComposableSingletons$ListItemKt` lambda getter — a hash-named, module-internal implementation detail of a composable body that no consumer can reference across modules; collapsing the overload chain removed the non-capturing lambda it backed. Not consumer-visible; the classifier counts it as additive. All 12 public `ListItemKt` overloads (4 live + 8 HIDDEN shims), `SymbolContainer`, `SelectListItem`, and the theme `clickable` keep their exact signatures.
