### PR TITLE
feat(tokens): update the xsmall shadow offset and blur values

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeShadowsSequence.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeShadowsSequence.kt
@@ -20,10 +20,10 @@ internal val LemonadeShadow.shadowDataSequence: Sequence<LemonadeShadowData>
     get() = when (this) {
         LemonadeShadow.Xsmall -> sequenceOf(
             LemonadeShadowData(
-                blur = 2.0f,
+                blur = 1.0f,
                 spread = 0.0f,
                 offsetX = 0.0f,
-                offsetY = 1.0f,
+                offsetY = 0.5f,
             ),
         )
         LemonadeShadow.Small -> sequenceOf(

--- a/swiftui/Sources/Lemonade/LemonadeShadow.swift
+++ b/swiftui/Sources/Lemonade/LemonadeShadow.swift
@@ -58,7 +58,7 @@ public enum LemonadeShadow: CaseIterable, Sendable {
         switch self {
         case .xsmall:
             return [
-                LemonadeShadowData(blur: 2.0, spread: 0.0, offsetX: 0.0, offsetY: 1.0, color: Color("lemonade-shadow-shadow-default", bundle: .lemonade)),
+                LemonadeShadowData(blur: 1.0, spread: 0.0, offsetX: 0.0, offsetY: 0.5, color: Color("lemonade-shadow-shadow-default", bundle: .lemonade)),
             ]
         case .small:
             return [

--- a/swiftui/Tests/LemonadeTests/LemonadeTokenTests.swift
+++ b/swiftui/Tests/LemonadeTests/LemonadeTokenTests.swift
@@ -42,10 +42,10 @@ final class LemonadeTokenTests: XCTestCase {
 
     func testShadowLayerValues() {
         let xsmall = LemonadeShadow.xsmall.shadowLayers[0]
-        XCTAssertEqual(xsmall.blur, 2)
+        XCTAssertEqual(xsmall.blur, 1)
         XCTAssertEqual(xsmall.spread, 0)
         XCTAssertEqual(xsmall.offsetX, 0)
-        XCTAssertEqual(xsmall.offsetY, 1)
+        XCTAssertEqual(xsmall.offsetY, 0.5)
 
         let xlarge0 = LemonadeShadow.xlarge.shadowLayers[0]
         XCTAssertEqual(xlarge0.blur, 10)

--- a/tokens/shadow.tokens.json
+++ b/tokens/shadow.tokens.json
@@ -39,7 +39,7 @@
         },
         "sd-xs-lv1-offset-y": {
           "$type": "number",
-          "$value": 1,
+          "$value": 0.5,
           "$extensions": {
             "com.figma.variableId": "VariableID:3145:2345",
             "com.figma.scopes": [
@@ -49,7 +49,7 @@
         },
         "sd-xs-lv1-blur": {
           "$type": "number",
-          "$value": 2,
+          "$value": 1,
           "$extensions": {
             "com.figma.variableId": "VariableID:3145:2346",
             "com.figma.scopes": [


### PR DESCRIPTION
# Summary

Syncs the `sd-xs-lv1` shadow token from the Figma native export — offset-y `1` → `0.5` and blur `2` → `1` — and regenerates the platform shadow sources from it. Only the `Xsmall` / `.xsmall` shadow changes; every other level is untouched.

## Figma component
<!-- Shadow foundation, .Shadow variable collection -->

## Screenshot
<!-- Value-only token change; no new UI to capture. -->

## API Dump

**Verdict:** NO_CHANGES

**Changes that are not a concern, and why:**

- No `api/*.api` or `*.klib.api` file changed. The only Kotlin edit is inside the body of the `internal val LemonadeShadow.shadowDataSequence` getter in `LemonadeShadowsSequence.kt`, which is not part of the published surface. `bcv-check.sh --ci` reports `NO_CHANGES — public API is identical`.

**Genuine breaking changes (if any):**

None.
