### PR TITLE
fix(topbar): make the integrated search dismissible on legacy Android

### DIFF
--- a/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SearchFieldDisplay.kt
+++ b/kmp/composeApp/src/commonMain/kotlin/com/teya/lemonade/SearchFieldDisplay.kt
@@ -108,8 +108,8 @@ internal fun SearchFieldDisplay() {
                     )
 
                     LemonadeUi.Text(
-                        text = "Cancelling drops the focus, hides the keyboard and empties the field. " +
-                            "onCancel then runs for whatever the query was driving.",
+                        text = "Cancelling drops the focus and hides the keyboard; the input stays " +
+                            "as typed. onCancel then runs for whatever the query was driving.",
                         textStyle = LemonadeTheme.typography.bodySmallRegular,
                         color = LemonadeTheme.colors.content.contentSecondary,
                     )

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
@@ -2,9 +2,6 @@ package com.teya.lemonade
 
 import android.os.Build
 
-// androidx.core emulates the IME inset type from API 23 in windows that resize for the keyboard,
-// and it reports correctly on the API 27 PAX terminals this was verified on — in the activity
-// window and inside a ModalBottomSheet window alike. Where a window genuinely never reports IME
-// insets the value stays 0 and clearFocusOnKeyboardDismiss degrades to a no-op, so the floor is
-// the compat minimum rather than 29.
+// The compat minimum: androidx.core emulates the IME inset type from API 23. Where a window never
+// reports it the value stays 0 and clearFocusOnKeyboardDismiss degrades to a no-op.
 internal actual fun supportsImeInsets(): Boolean = Build.VERSION.SDK_INT >= 23

--- a/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
+++ b/kmp/ui/src/androidMain/kotlin/com/teya/lemonade/Platform.kt
@@ -2,4 +2,9 @@ package com.teya.lemonade
 
 import android.os.Build
 
-internal actual fun supportsImeInsets(): Boolean = Build.VERSION.SDK_INT >= 29
+// androidx.core emulates the IME inset type from API 23 in windows that resize for the keyboard,
+// and it reports correctly on the API 27 PAX terminals this was verified on — in the activity
+// window and inside a ModalBottomSheet window alike. Where a window genuinely never reports IME
+// insets the value stays 0 and clearFocusOnKeyboardDismiss degrades to a no-op, so the floor is
+// the compat minimum rather than 29.
+internal actual fun supportsImeInsets(): Boolean = Build.VERSION.SDK_INT >= 23

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
@@ -32,10 +32,8 @@ internal fun Modifier.modifyIf(
 internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier = clearFocusOnKeyboardDismiss(onKeyboardDismissed = null)
 
 /**
- * [onKeyboardDismissed] replaces the default `clearFocus` reaction. Android 8.1 and below undo a
- * plain clear by re-assigning focus to the previously focused node within the same frame, so hosts
- * that must unfocus reliably there hand focus to a harmless target instead — see the TopBar
- * search's focus decoy.
+ * [onKeyboardDismissed] replaces the default `clearFocus` reaction — hosts that must unfocus
+ * reliably on legacy Android hand focus to a [SearchFocusDecoy] instead.
  */
 internal fun Modifier.clearFocusOnKeyboardDismiss(onKeyboardDismissed: (() -> Unit)?): Modifier {
     if (!supportsImeInsets()) {

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Modifier.kt
@@ -29,7 +29,15 @@ internal fun Modifier.modifyIf(
         },
     )
 
-internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier {
+internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier = clearFocusOnKeyboardDismiss(onKeyboardDismissed = null)
+
+/**
+ * [onKeyboardDismissed] replaces the default `clearFocus` reaction. Android 8.1 and below undo a
+ * plain clear by re-assigning focus to the previously focused node within the same frame, so hosts
+ * that must unfocus reliably there hand focus to a harmless target instead — see the TopBar
+ * search's focus decoy.
+ */
+internal fun Modifier.clearFocusOnKeyboardDismiss(onKeyboardDismissed: (() -> Unit)?): Modifier {
     if (!supportsImeInsets()) {
         return this
     }
@@ -43,7 +51,8 @@ internal fun Modifier.clearFocusOnKeyboardDismiss(): Modifier {
 
             LaunchedEffect(imeIsVisible) {
                 when {
-                    keyboardAppearedSinceLastFocused -> focusManager.clearFocus()
+                    keyboardAppearedSinceLastFocused ->
+                        onKeyboardDismissed?.invoke() ?: focusManager.clearFocus()
                     imeIsVisible -> keyboardAppearedSinceLastFocused = true
                 }
             }

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -94,9 +94,9 @@ private val SEARCH_FIELD_MIN_WIDTH = 240.dp
  * @param placeholder - optional [String] to be displayed as the component's placeholder text.
  * @param onInputClear - Callback to be invoked when the user request the input to be cleared.
  * @param dismissible - [Boolean] flag controlling the trailing cancel button, on by default. The
- * button shows up as soon as there is something to dismiss (the field is focused or holds input),
- * and tapping it hides the keyboard and clears the focus, leaving the input untouched. Turn it off
- * for hosts that already provide their own dismissal affordance.
+ * button shows while the field is focused, and tapping it hides the keyboard and clears the focus,
+ * leaving the input untouched. Turn it off for hosts that already provide their own dismissal
+ * affordance.
  * @param onCancel - Callback to be invoked after the search has been dismissed through the cancel
  * button. The input is left as typed — clearing it stays with the inner clear icon and
  * [onInputClear] — so use this to react to the dismissal itself, such as collapsing a results
@@ -156,7 +156,6 @@ public fun LemonadeUi.SearchField(
 
         if (dismissible) {
             SearchCancelButton(
-                input = input,
                 onDismiss = {
                     keyboardController?.hide()
                     dismissRequester.requestFocus()
@@ -175,7 +174,6 @@ public fun LemonadeUi.SearchField(
 // the field is not dismissible, so opting out costs no collector and no transition.
 @Composable
 private fun SearchCancelButton(
-    input: String,
     onDismiss: () -> Unit,
     onCancel: () -> Unit,
     contentDescription: String?,
@@ -184,11 +182,10 @@ private fun SearchCancelButton(
 ) {
     val isFocused by interactionSource.collectIsFocusedAsState()
 
-    // The cancel button only earns its space once there is something to dismiss: an active focus or
-    // a query already typed in. That mirrors the Figma states, where the resting empty field is the
-    // only one without it.
+    // Dismissal only drops the focus, so the button only earns its space while there is focus to
+    // drop.
     AnimatedVisibility(
-        visible = enabled && (isFocused || input.isNotEmpty()),
+        visible = enabled && isFocused,
         enter = fadeIn(animationSpec = SearchFieldFadeSpec) +
             scaleIn(
                 animationSpec = SearchFieldFadeSpec,
@@ -458,12 +455,7 @@ private fun SearchFieldIconTarget(
 private data class SearchFieldPreviewData(
     val withContent: Boolean,
     val enabled: Boolean,
-) {
-    // Previews never hold focus, so the cancel button is only on screen for the enabled-with-content
-    // case. Turning it on elsewhere would render a duplicate of an existing variant, so this is
-    // derived rather than a third axis.
-    val dismissible: Boolean get() = withContent && enabled
-}
+)
 
 private class SearchFieldPreviewProvider : PreviewParameterProvider<SearchFieldPreviewData> {
     override val values: Sequence<SearchFieldPreviewData> = buildAllVariants()
@@ -494,7 +486,6 @@ private fun LemonadeSearchFieldPreview(
         onInputChanged = { /* Nothing */ },
         placeholder = "This is a placeholder",
         enabled = previewData.enabled,
-        dismissible = previewData.dismissible,
         cancelContentDescription = "Cancel search",
         input = if (previewData.withContent) {
             "Sample text"

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -37,9 +37,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -94,13 +95,12 @@ private val SEARCH_FIELD_MIN_WIDTH = 240.dp
  * @param onInputClear - Callback to be invoked when the user request the input to be cleared.
  * @param dismissible - [Boolean] flag controlling the trailing cancel button, on by default. The
  * button shows up as soon as there is something to dismiss (the field is focused or holds input),
- * and tapping it hides the keyboard, clears the focus and empties the input. Turn it off for hosts
- * that already provide their own dismissal affordance.
+ * and tapping it hides the keyboard and clears the focus, leaving the input untouched. Turn it off
+ * for hosts that already provide their own dismissal affordance.
  * @param onCancel - Callback to be invoked after the search has been dismissed through the cancel
- * button. The input has already been emptied by the time this runs, so use it to drop whatever the
- * query was driving, such as results or a filter. Note that the order in which this and
- * [onInputChanged] fire is not guaranteed — SwiftUI delivers the input change through the view
- * update, so do not depend on one having run when the other does.
+ * button. The input is left as typed — clearing it stays with the inner clear icon and
+ * [onInputClear] — so use this to react to the dismissal itself, such as collapsing a results
+ * overlay.
  * @param cancelContentDescription - optional [String] content description for the cancel button, for
  * accessibility. The component leaves it unset by default so the label can be localised by the
  * consumer; supply one whenever the field is [dismissible].
@@ -127,10 +127,18 @@ public fun LemonadeUi.SearchField(
     enabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val dismissRequester = remember { FocusRequester() }
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
+        SearchFocusDecoy(
+            focusRequester = dismissRequester,
+            claimFocusOnEntry = false,
+        )
+
         CoreSearchField(
             input = input,
             onInputChanged = onInputChanged,
@@ -143,13 +151,16 @@ public fun LemonadeUi.SearchField(
             modifier = Modifier
                 .defaultMinSize(minWidth = SEARCH_FIELD_MIN_WIDTH)
                 .weight(weight = 1f, fill = false)
-                .clearFocusOnKeyboardDismiss(),
+                .clearFocusOnKeyboardDismiss { dismissRequester.requestFocus() },
         )
 
         if (dismissible) {
             SearchCancelButton(
                 input = input,
-                onInputChanged = onInputChanged,
+                onDismiss = {
+                    keyboardController?.hide()
+                    dismissRequester.requestFocus()
+                },
                 onCancel = onCancel,
                 contentDescription = cancelContentDescription,
                 interactionSource = interactionSource,
@@ -165,14 +176,13 @@ public fun LemonadeUi.SearchField(
 @Composable
 private fun SearchCancelButton(
     input: String,
-    onInputChanged: (String) -> Unit,
+    onDismiss: () -> Unit,
     onCancel: () -> Unit,
     contentDescription: String?,
     interactionSource: MutableInteractionSource,
     enabled: Boolean,
 ) {
     val isFocused by interactionSource.collectIsFocusedAsState()
-    val focusManager = LocalFocusManager.current
 
     // The cancel button only earns its space once there is something to dismiss: an active focus or
     // a query already typed in. That mirrors the Figma states, where the resting empty field is the
@@ -194,13 +204,10 @@ private fun SearchCancelButton(
             icon = LemonadeIcons.Times,
             contentDescription = contentDescription,
             onClick = {
-                // `clearFocus` is what dismisses the keyboard too — it is the single dismissal
-                // idiom this module already uses (see the TopBar search leading icon).
-                focusManager.clearFocus()
-                // Deliberately not routed through `onInputClear`: that callback belongs to the
-                // inner clear icon, and a consumer who overrides it to only log would otherwise
-                // stop cancel from emptying the field.
-                onInputChanged("")
+                // Dismissal hands focus to the decoy rather than clearing it (see
+                // [SearchFocusDecoy]) and never touches the input — clearing stays with the
+                // inner clear icon.
+                onDismiss()
                 onCancel()
             },
             variant = LemonadeButtonVariant.Neutral,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -35,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.style.TextOverflow
@@ -372,23 +375,19 @@ private fun CoreSearchFieldDecorationBox(
                 )
             },
         ) { icon ->
-            LemonadeUi.Icon(
-                icon = icon,
-                tint = LocalColors.current.content.contentPrimary,
-                contentDescription = null,
-                modifier = Modifier
-                    .then(
-                        other = if (onLeadingIconClicked != null) {
-                            Modifier.clickable(
-                                onClick = onLeadingIconClicked,
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = LocalEffects.current.interactionIndication,
-                            )
-                        } else {
-                            Modifier
-                        },
-                    ),
-            )
+            if (onLeadingIconClicked != null) {
+                SearchFieldIconTarget(
+                    icon = icon,
+                    tint = LocalColors.current.content.contentPrimary,
+                    onClick = onLeadingIconClicked,
+                )
+            } else {
+                LemonadeUi.Icon(
+                    icon = icon,
+                    tint = LocalColors.current.content.contentPrimary,
+                    contentDescription = null,
+                )
+            }
         }
 
         Box(modifier = Modifier.weight(weight = 1f)) {
@@ -410,18 +409,47 @@ private fun CoreSearchFieldDecorationBox(
             enter = fadeIn(animationSpec = SearchFieldFadeSpec),
             exit = fadeOut(animationSpec = SearchFieldFadeSpec),
         ) {
-            LemonadeUi.Icon(
+            SearchFieldIconTarget(
                 icon = LemonadeIcons.CircleXSolid,
                 tint = LocalColors.current.content.contentSecondary,
-                contentDescription = null,
-                modifier = Modifier
-                    .clickable(
-                        onClick = onInputClear,
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = LocalEffects.current.interactionIndication,
-                    ),
+                onClick = onInputClear,
             )
         }
+    }
+}
+
+// The icon keeps its regular footprint in the row, but its tap area is stretched to the field's
+// full height: the inner box deliberately violates the outer box's fixed constraints, so it
+// centers over the icon and overflows into the field's padding without moving any layout. A bare
+// icon-sized clickable is nearly impossible to hit with a finger on a terminal touchscreen, and a
+// missed tap lands on the text field and focuses it instead.
+@Composable
+private fun SearchFieldIconTarget(
+    icon: LemonadeIcons,
+    tint: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.size(size = LocalSizes.current.size500),
+    ) {
+        Box(
+            modifier = Modifier
+                .requiredSize(size = LocalSizes.current.size1100)
+                .clip(shape = LocalShapes.current.radiusFull)
+                .clickable(
+                    onClick = onClick,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = LocalEffects.current.interactionIndication,
+                ),
+        )
+
+        LemonadeUi.Icon(
+            icon = icon,
+            tint = tint,
+            contentDescription = null,
+        )
     }
 }
 

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchField.kt
@@ -204,9 +204,6 @@ private fun SearchCancelButton(
             icon = LemonadeIcons.Times,
             contentDescription = contentDescription,
             onClick = {
-                // Dismissal hands focus to the decoy rather than clearing it (see
-                // [SearchFocusDecoy]) and never touches the input — clearing stays with the
-                // inner clear icon.
                 onDismiss()
                 onCancel()
             },
@@ -425,11 +422,9 @@ private fun CoreSearchFieldDecorationBox(
     }
 }
 
-// The icon keeps its regular footprint in the row, but its tap area is stretched to the field's
-// full height: the inner box deliberately violates the outer box's fixed constraints, so it
-// centers over the icon and overflows into the field's padding without moving any layout. A bare
-// icon-sized clickable is nearly impossible to hit with a finger on a terminal touchscreen, and a
-// missed tap lands on the text field and focuses it instead.
+// Stretches the icon's tap area to the field's full height without moving any layout: the inner
+// box deliberately overflows the fixed outer box. A bare icon-sized clickable is nearly
+// impossible to hit with a finger.
 @Composable
 private fun SearchFieldIconTarget(
     icon: LemonadeIcons,

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchFocusDecoy.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchFocusDecoy.kt
@@ -9,17 +9,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 
 /**
- * On Android 8.1 and below the framework re-assigns focus whenever a window's focus is cleared —
- * even in touch mode, aiming at the previously focused rect — so `clearFocus` on a search or text
- * field is undone within the same frame and the field cannot be dismissed. Dismissal therefore
- * MOVES focus onto this zero-sized target instead of clearing it: the window never loses focus and
- * the legacy re-assign never runs. It draws nothing and taps are unaffected.
- *
- * The same versions also grant focus to the first focusable when a window opens, which lands on
- * the field and pops the keyboard unasked — being zero-sized, the decoy is invisible to that focus
- * search, so with [claimFocusOnEntry] it claims the grant back explicitly as soon as it enters
- * composition. Hosts whose surrounding screen legitimately assigns its own initial focus pass
- * `false` and keep the decoy as a dismissal target only.
+ * Invisible focus target for dismissing text fields on Android 8.1 and below, where the framework
+ * undoes `clearFocus` within the same frame and focuses the first field when a window opens.
+ * Dismissal moves focus here instead of clearing it, and [claimFocusOnEntry] absorbs the
+ * window-open grant.
  */
 @Composable
 internal fun SearchFocusDecoy(

--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchFocusDecoy.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/SearchFocusDecoy.kt
@@ -1,0 +1,41 @@
+package com.teya.lemonade
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+
+/**
+ * On Android 8.1 and below the framework re-assigns focus whenever a window's focus is cleared —
+ * even in touch mode, aiming at the previously focused rect — so `clearFocus` on a search or text
+ * field is undone within the same frame and the field cannot be dismissed. Dismissal therefore
+ * MOVES focus onto this zero-sized target instead of clearing it: the window never loses focus and
+ * the legacy re-assign never runs. It draws nothing and taps are unaffected.
+ *
+ * The same versions also grant focus to the first focusable when a window opens, which lands on
+ * the field and pops the keyboard unasked — being zero-sized, the decoy is invisible to that focus
+ * search, so with [claimFocusOnEntry] it claims the grant back explicitly as soon as it enters
+ * composition. Hosts whose surrounding screen legitimately assigns its own initial focus pass
+ * `false` and keep the decoy as a dismissal target only.
+ */
+@Composable
+internal fun SearchFocusDecoy(
+    focusRequester: FocusRequester,
+    claimFocusOnEntry: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .focusRequester(focusRequester = focusRequester)
+            .focusable(),
+    )
+
+    if (claimFocusOnEntry) {
+        LaunchedEffect(Unit) {
+            focusRequester.requestFocus()
+        }
+    }
+}

--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -30,6 +31,7 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -42,6 +44,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -50,7 +54,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -634,7 +638,8 @@ public fun LemonadeUi.TopBar(
     trailingSlot: @Composable (RowScope.() -> Unit)? = null,
     bottomSlot: @Composable (BoxScope.() -> Unit)? = null,
 ) {
-    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val searchDismissRequester = remember { FocusRequester() }
     var isSearchFocused by remember {
         mutableStateOf(false)
     }
@@ -688,6 +693,8 @@ public fun LemonadeUi.TopBar(
                         bottom = LocalSpaces.current.spacing200,
                     ),
             ) {
+                SearchFocusDecoy(focusRequester = searchDismissRequester)
+
                 AnimatedContent(
                     targetState = expandedLabel != null && !isSearchFocused,
                     transitionSpec = { expandVertically() togetherWith shrinkVertically() + fadeOut() },
@@ -727,14 +734,27 @@ public fun LemonadeUi.TopBar(
                     } else {
                         LemonadeIcons.Search
                     },
-                    onLeadingIconClicked = focusManager::clearFocus,
-                    modifier = Modifier.onFocusChanged { focusState ->
-                        isSearchFocused = focusState.isFocused
-                        state.setAnimationGesturesLock(locked = focusState.isFocused)
-                        if (focusState.isFocused) {
-                            state.expand()
+                    // Clickable only while focused: the back arrow must dismiss, but the resting
+                    // magnifier has to stay tap-through so a tap on it focuses the field. The
+                    // explicit keyboard hide covers devices where IME-inset tracking is
+                    // unsupported and the focus hand-off alone leaves the keyboard up.
+                    onLeadingIconClicked = if (isSearchFocused) {
+                        {
+                            keyboardController?.hide()
+                            searchDismissRequester.requestFocus()
                         }
+                    } else {
+                        null
                     },
+                    modifier = Modifier
+                        .clearFocusOnKeyboardDismiss { searchDismissRequester.requestFocus() }
+                        .onFocusChanged { focusState ->
+                            isSearchFocused = focusState.isFocused
+                            state.setAnimationGesturesLock(locked = focusState.isFocused)
+                            if (focusState.isFocused) {
+                                state.expand()
+                            }
+                        },
                 )
             }
         },
@@ -1059,7 +1079,8 @@ public fun LemonadeUi.TopBar(
     searchPlaceholder: String? = null,
     trailingSlot: @Composable (RowScope.() -> Unit)? = null,
 ) {
-    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val searchDismissRequester = remember { FocusRequester() }
     var isSearchFocused by remember {
         mutableStateOf(false)
     }
@@ -1090,31 +1111,71 @@ public fun LemonadeUi.TopBar(
             )
         },
         collapsableSlot = { collapsableSlotModifier ->
-            CoreSearchField(
-                input = searchInput,
-                onInputChanged = onSearchChanged,
-                placeholder = searchPlaceholder,
-                leadingIcon = if (isSearchFocused) {
-                    LemonadeIcons.ArrowLeft
-                } else {
-                    LemonadeIcons.Search
-                },
-                onLeadingIconClicked = focusManager::clearFocus,
-                modifier = collapsableSlotModifier
-                    .fillMaxWidth()
-                    .padding(horizontal = LocalSpaces.current.spacing400)
-                    .padding(vertical = LocalSpaces.current.spacing300)
-                    .onFocusChanged { focusState ->
-                        isSearchFocused = focusState.isFocused
-                        state.setAnimationGesturesLock(locked = focusState.isFocused)
-                        if (focusState.isFocused) {
-                            state.expand()
-                        }
+            Box(modifier = collapsableSlotModifier) {
+                SearchFocusDecoy(focusRequester = searchDismissRequester)
+
+                CoreSearchField(
+                    input = searchInput,
+                    onInputChanged = onSearchChanged,
+                    placeholder = searchPlaceholder,
+                    leadingIcon = if (isSearchFocused) {
+                        LemonadeIcons.ArrowLeft
+                    } else {
+                        LemonadeIcons.Search
                     },
-            )
+                    // Clickable only while focused: the back arrow must dismiss, but the resting
+                    // magnifier has to stay tap-through so a tap on it focuses the field. The
+                    // explicit keyboard hide covers devices where IME-inset tracking is
+                    // unsupported and the focus hand-off alone leaves the keyboard up.
+                    onLeadingIconClicked = if (isSearchFocused) {
+                        {
+                            keyboardController?.hide()
+                            searchDismissRequester.requestFocus()
+                        }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = LocalSpaces.current.spacing400)
+                        .padding(vertical = LocalSpaces.current.spacing300)
+                        .clearFocusOnKeyboardDismiss { searchDismissRequester.requestFocus() }
+                        .onFocusChanged { focusState ->
+                            isSearchFocused = focusState.isFocused
+                            state.setAnimationGesturesLock(locked = focusState.isFocused)
+                            if (focusState.isFocused) {
+                                state.expand()
+                            }
+                        },
+                )
+            }
         },
         bottomSlot = null,
     )
+}
+
+// On Android 8.1 and below the framework re-assigns focus whenever a window's focus is cleared —
+// even in touch mode, aiming at the previously focused rect — so `clearFocus` on the search field
+// is undone within the same frame and the field cannot be dismissed. Dismissal therefore MOVES
+// focus onto this zero-sized target instead of clearing it: the window never loses focus and the
+// legacy re-assign never runs. The same versions also grant focus to the first focusable when the
+// window opens, which lands on the field and pops the keyboard unasked — being zero-sized, the
+// decoy is invisible to that focus search, so it claims the grant back explicitly as soon as it
+// enters composition. It draws nothing and taps are unaffected.
+@Composable
+private fun SearchFocusDecoy(
+    focusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .focusRequester(focusRequester = focusRequester)
+            .focusable(),
+    )
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
 }
 
 @Deprecated(

--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -31,7 +30,6 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -45,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -693,7 +690,7 @@ public fun LemonadeUi.TopBar(
                         bottom = LocalSpaces.current.spacing200,
                     ),
             ) {
-                SearchFocusDecoy(focusRequester = searchDismissRequester)
+                SearchFocusDecoy(focusRequester = searchDismissRequester, claimFocusOnEntry = true)
 
                 AnimatedContent(
                     targetState = expandedLabel != null && !isSearchFocused,
@@ -1112,7 +1109,7 @@ public fun LemonadeUi.TopBar(
         },
         collapsableSlot = { collapsableSlotModifier ->
             Box(modifier = collapsableSlotModifier) {
-                SearchFocusDecoy(focusRequester = searchDismissRequester)
+                SearchFocusDecoy(focusRequester = searchDismissRequester, claimFocusOnEntry = true)
 
                 CoreSearchField(
                     input = searchInput,
@@ -1152,30 +1149,6 @@ public fun LemonadeUi.TopBar(
         },
         bottomSlot = null,
     )
-}
-
-// On Android 8.1 and below the framework re-assigns focus whenever a window's focus is cleared —
-// even in touch mode, aiming at the previously focused rect — so `clearFocus` on the search field
-// is undone within the same frame and the field cannot be dismissed. Dismissal therefore MOVES
-// focus onto this zero-sized target instead of clearing it: the window never loses focus and the
-// legacy re-assign never runs. The same versions also grant focus to the first focusable when the
-// window opens, which lands on the field and pops the keyboard unasked — being zero-sized, the
-// decoy is invisible to that focus search, so it claims the grant back explicitly as soon as it
-// enters composition. It draws nothing and taps are unaffected.
-@Composable
-private fun SearchFocusDecoy(
-    focusRequester: FocusRequester,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .focusRequester(focusRequester = focusRequester)
-            .focusable(),
-    )
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
 }
 
 @Deprecated(

--- a/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
+++ b/kmp/ui/src/mobileMain/kotlin/com/teya/lemonade/TopBar.mobile.kt
@@ -731,10 +731,8 @@ public fun LemonadeUi.TopBar(
                     } else {
                         LemonadeIcons.Search
                     },
-                    // Clickable only while focused: the back arrow must dismiss, but the resting
-                    // magnifier has to stay tap-through so a tap on it focuses the field. The
-                    // explicit keyboard hide covers devices where IME-inset tracking is
-                    // unsupported and the focus hand-off alone leaves the keyboard up.
+                    // Only the back arrow is clickable — the resting magnifier stays tap-through
+                    // so tapping it focuses the field.
                     onLeadingIconClicked = if (isSearchFocused) {
                         {
                             keyboardController?.hide()
@@ -1120,10 +1118,8 @@ public fun LemonadeUi.TopBar(
                     } else {
                         LemonadeIcons.Search
                     },
-                    // Clickable only while focused: the back arrow must dismiss, but the resting
-                    // magnifier has to stay tap-through so a tap on it focuses the field. The
-                    // explicit keyboard hide covers devices where IME-inset tracking is
-                    // unsupported and the focus hand-off alone leaves the keyboard up.
+                    // Only the back arrow is clickable — the resting magnifier stays tap-through
+                    // so tapping it focuses the field.
                     onLeadingIconClicked = if (isSearchFocused) {
                         {
                             keyboardController?.hide()

--- a/swiftui/SampleApp/SearchFieldDisplayView.swift
+++ b/swiftui/SampleApp/SearchFieldDisplayView.swift
@@ -60,7 +60,7 @@ struct SearchFieldDisplayView: View {
                             cancelContentDescription: "Cancel search"
                         )
 
-                        Text("Cancelling drops the focus, hides the keyboard and empties the field. onCancel then runs for whatever the query was driving.")
+                        Text("Cancelling drops the focus and hides the keyboard; the input stays as typed. onCancel then runs for whatever the query was driving.")
                             .font(.caption)
                             .foregroundStyle(.content.contentSecondary)
                     }

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -120,8 +120,6 @@ private struct LemonadeSearchFieldView: View {
                     icon: .times,
                     contentDescription: cancelContentDescription,
                     onClick: {
-                        // Dismissal only drops the focus — clearing the input stays with the
-                        // inner clear icon.
                         isFocused = false
                         onCancel?()
                     },

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -21,14 +21,12 @@ public extension LemonadeUi {
     ///   - onInputClear: Callback when user requests input to be cleared
     ///   - dismissible: Flag controlling the trailing cancel button, on by default. The button shows
     ///     up as soon as there is something to dismiss (the field is focused or holds input), and
-    ///     tapping it dismisses the keyboard, drops the focus and empties the input. Turn it off for
-    ///     hosts that already provide their own dismissal affordance.
+    ///     tapping it dismisses the keyboard and drops the focus, leaving the input untouched. Turn
+    ///     it off for hosts that already provide their own dismissal affordance.
     ///   - onCancel: Callback invoked after the search has been dismissed through the cancel button.
-    ///     The binding has already been emptied by the time this runs, so use it to drop whatever
-    ///     the query was driving, such as results or a filter. Note that the order in which this and
-    ///     `onInputChanged` fire is not guaranteed — the input change is delivered through
-    ///     `onChange(of:)`, i.e. the view update — so do not depend on one having run when the other
-    ///     does.
+    ///     The input is left as typed — clearing it stays with the inner clear icon and
+    ///     `onInputClear` — so use this to react to the dismissal itself, or to reset the binding
+    ///     when the host wants dismissal to also drop the query.
     ///   - cancelContentDescription: Optional content description for the cancel button, for
     ///     accessibility. The component leaves it unset by default so the label can be localised by
     ///     the consumer; supply one whenever the field is `dismissible`.
@@ -122,11 +120,9 @@ private struct LemonadeSearchFieldView: View {
                     icon: .times,
                     contentDescription: cancelContentDescription,
                     onClick: {
+                        // Dismissal only drops the focus — clearing the input stays with the
+                        // inner clear icon.
                         isFocused = false
-                        // Deliberately not routed through `onInputClear`: that callback belongs to
-                        // the inner clear icon, and a consumer who overrides it to only log would
-                        // otherwise stop cancel from emptying the field.
-                        input = ""
                         onCancel?()
                     },
                     variant: .neutral,

--- a/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSearchField.swift
@@ -20,9 +20,9 @@ public extension LemonadeUi {
     ///   - placeholder: Optional placeholder text
     ///   - onInputClear: Callback when user requests input to be cleared
     ///   - dismissible: Flag controlling the trailing cancel button, on by default. The button shows
-    ///     up as soon as there is something to dismiss (the field is focused or holds input), and
-    ///     tapping it dismisses the keyboard and drops the focus, leaving the input untouched. Turn
-    ///     it off for hosts that already provide their own dismissal affordance.
+    ///     while the field is focused, and tapping it dismisses the keyboard and drops the focus,
+    ///     leaving the input untouched. Turn it off for hosts that already provide their own
+    ///     dismissal affordance.
     ///   - onCancel: Callback invoked after the search has been dismissed through the cancel button.
     ///     The input is left as typed — clearing it stays with the inner clear icon and
     ///     `onInputClear` — so use this to react to the dismissal itself, or to reset the binding
@@ -104,11 +104,10 @@ private struct LemonadeSearchFieldView: View {
             : .clear
     }
 
-    /// The cancel button only earns its space once there is something to dismiss: an active focus
-    /// or a query already typed in. That mirrors the Figma states, where the resting empty field is
-    /// the only one without it.
+    /// Dismissal only drops the focus, so the button only earns its space while there is focus to
+    /// drop.
     private var shouldShowCancel: Bool {
-        dismissible && enabled && (isFocused || !input.isEmpty)
+        dismissible && enabled && isFocused
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

On Android 8.1 and below the framework re-focuses a text field right after `clearFocus` and focuses it when a window opens — on the API 27 PAX terminals the search TopBar opened with the keyboard already up and could never be dismissed.

- Dismissal now moves focus to an invisible `SearchFocusDecoy` instead of clearing it, and the decoy absorbs the focus grant when a window opens.
- The TopBar arrow hides the keyboard explicitly and is only clickable while searching — the resting magnifier stays tap-through.
- The search field's leading/clear icons get a full-height touch target, with no layout change.
- `SearchField`'s cancel button only shows while focused and no longer clears the input (KMP + SwiftUI). Hosts that want dismissal to reset the query do it in `onCancel`.
- Dismissing the keyboard with system back also unfocuses the search TopBars; the IME-inset gate drops to the compat minimum of API 23.

## API Dump

No public API changes — `bcv-check.sh --ci` verdict: **NO_CHANGES**.

## Test plan

- [x] PAX A920Pro (API 27), sample app: search opens unfocused; arrow and cancel dismiss reliably; input kept on cancel; ~44dp icon taps land
- [x] API 34 emulator: no behaviour change
- [x] ktlint, detekt, Android + desktop compile, `swift build`