### PR TITLE
fix(tokens): use white for border-selected in the dark theme

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeDarkTheme.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/LemonadeDarkTheme.kt
@@ -89,7 +89,7 @@ public object LemonadeDarkTheme : LemonadeSemanticColors {
             override val borderNeutralHigh = LemonadePrimitiveColors.Solid.White.white300
             override val borderNeutralLow = LemonadePrimitiveColors.Solid.White.white100
             override val borderNeutralMedium = LemonadePrimitiveColors.Solid.White.white200
-            override val borderSelected = LemonadePrimitiveColors.Solid.YellowLime.yellowLime500
+            override val borderSelected = LemonadePrimitiveColors.Solid.White.white900
         }
     override val content: LemonadeSemanticColors.ContentColors =
         object : LemonadeSemanticColors.ContentColors {

--- a/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-border-selected.colorset/Contents.json
+++ b/swiftui/Sources/Lemonade/Resources/Assets.xcassets/Colors/lemonade-border-border-selected.colorset/Contents.json
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.100",
-          "green" : "0.900",
-          "red" : "0.882"
+          "alpha" : "0.900",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/tokens/theme-colors.dark.tokens.json
+++ b/tokens/theme-colors.dark.tokens.json
@@ -2220,12 +2220,12 @@
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.8820960521697998,
-          0.8995633125305176,
-          0.10043667256832123
+          1,
+          1,
+          1
         ],
-        "alpha": 1,
-        "hex": "#E1E51A"
+        "alpha": 0.8999999761581421,
+        "hex": "#FFFFFF"
       },
       "$description": "Use to indicate a selected or active state on components.",
       "$extensions": {
@@ -2240,8 +2240,8 @@
           "iOS": "LemonadeTheme.colors.border.borderSelected"
         },
         "com.figma.aliasData": {
-          "targetVariableId": "VariableID:108bd7e242693fc88285aa40fbffaacb28702a24/74:87",
-          "targetVariableName": "yellow-lime/500",
+          "targetVariableId": "VariableID:1cde25931e5330368f430707ddecf5da880df6d6/109:32",
+          "targetVariableName": "white/900",
           "targetVariableSetId": "VariableCollectionId:f53610b1131d0ba179f2a0753cd90fbfc7d21a3a/5:785",
           "targetVariableSetName": "Colors"
         }


### PR DESCRIPTION
# Summary
Dark `border-selected` aliased `yellow-lime/500`, so selected tiles, radio buttons, checkboxes and focused text fields drew a lime outline on dark surfaces. Light uses `yellow-lime/900` (the primary ink), so the dark counterpart should be the inverse primary: `white/900`, the same value `border-selected-inverse` already resolves to.

Raised in the terminal dark-mode design review (item 5, "Card selection borders should be rendered in white as the inverse correspondent, not lime"). Consumers affected in the terminal app: Sales Overview currency tiles, plus the focused state of Wi-Fi password / payment reference fields.

- `tokens/theme-colors.dark.tokens.json`: `border-selected` value + `com.figma.aliasData` → `white/900`
- Regenerated via `generate-tokens` (`LemonadeDarkTheme.kt`, SwiftUI colorset)

The Figma variable (`Border/border-selected`, dark mode) still points at `yellow-lime/500` and needs updating by design so the next export doesn't revert this.

## Figma component
Variable `Border/border-selected` (VariableID:3037:2025), Dark mode.

## Screenshot
Terminal dark-mode gallery (internal) shows Sessions Content before/after; tile outline goes from lime to white.

## API Dump
No public API changes — `bcv-check.sh --ci` verdict: NO_CHANGES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGeB1yZSCtmtaWb585rJ1b