### PR TITLE
fix(button): keep the label to a single line with an end ellipsis

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/Button.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
@@ -103,6 +104,8 @@ public fun LemonadeUi.Button(
                     textStyle = size.contentData.textStyle,
                     color = colors.contentColor,
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
                 )
 
@@ -177,6 +180,8 @@ public fun LemonadeUi.Button(
                     textStyle = size.contentData.textStyle,
                     color = colors.contentColor,
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(horizontal = LocalSpaces.current.spacing200),
                 )
             }

--- a/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeButton.swift
@@ -499,7 +499,8 @@ private struct LemonadeButtonView: View {
                     LemonadeUi.Text(
                         label,
                         textStyle: size.contentData.textStyle,
-                        color: colors.contentColor
+                        color: colors.contentColor,
+                        maxLines: 1
                     )
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, LemonadeTheme.spaces.spacing200)
@@ -549,7 +550,8 @@ private struct LemonadeSlotButtonView<LeadingSlot: View, TrailingSlot: View>: Vi
                     LemonadeUi.Text(
                         label,
                         textStyle: size.contentData.textStyle,
-                        color: colors.contentColor
+                        color: colors.contentColor,
+                        maxLines: 1
                     )
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, LemonadeTheme.spaces.spacing200)


### PR DESCRIPTION
# Summary
A long `Button` label used to wrap onto multiple lines, and since the button has a fixed `requiredHeight`, the extra lines were clipped by the container. Both public `Button` overloads now pass `maxLines = 1` and `overflow = TextOverflow.Ellipsis` to the label's `LemonadeUi.Text`, so an oversized label stays on one line and truncates with an ellipsis at the end.

The SwiftUI `Button` already rendered a single tail-truncated line — SwiftUI text truncates inside the fixed-height frame instead of overflowing like Compose — but only implicitly, so both label call sites now pass `maxLines: 1` to make the contract explicit and keep parity with KMP.

`IconButton` has no label and `RadioButton`'s label wraps intentionally, so neither is touched.

## API Dump
No public API changes.

https://claude.ai/code/session_01V2rKVytVxq9f7aC5TWiDzB