### PR TITLE
perf(swiftui): resolve row fonts once and stop rebuilding the shimmer ramp

### DIFF
--- a/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeListItem.swift
@@ -382,7 +382,6 @@ struct ListItemSafeArea<Content: View>: View {
                     .padding(.horizontal, LemonadeTheme.spaces.spacing400)
             }
         }
-        .background(Color.clear)
     }
 }
 

--- a/swiftui/Sources/Lemonade/Components/LemonadeSkeleton.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeSkeleton.swift
@@ -102,6 +102,19 @@ private struct SkeletonView: View {
 
     @State private var shimmerOffset: CGFloat = -1
 
+    /// The shimmer ramp, built once rather than per body evaluation.
+    ///
+    /// Only the gradient's start and end points move, so the colour ramp itself is invariant.
+    /// Holding it here is safe for appearance changes: the theme's colours are asset-catalog
+    /// colours that resolve per trait at render time.
+    private static let shimmerRamp = Gradient(
+        colors: [
+            LemonadeTheme.colors.background.bgElevated,
+            LemonadeTheme.colors.background.bgElevatedHigh,
+            LemonadeTheme.colors.background.bgElevated
+        ]
+    )
+
     var body: some View {
         skeletonShape
             .onAppear {
@@ -116,10 +129,8 @@ private struct SkeletonView: View {
 
     @ViewBuilder
     private var skeletonShape: some View {
-        let baseColor = LemonadeTheme.colors.background.bgElevated
-        let highlightColor = LemonadeTheme.colors.background.bgElevatedHigh
         let gradient = LinearGradient(
-            gradient: Gradient(colors: [baseColor, highlightColor, baseColor]),
+            gradient: Self.shimmerRamp,
             startPoint: UnitPoint(x: shimmerOffset - 0.5, y: 0.5),
             endPoint: UnitPoint(x: shimmerOffset + 0.5, y: 0.5)
         )

--- a/swiftui/Sources/Lemonade/Components/LemonadeText.swift
+++ b/swiftui/Sources/Lemonade/Components/LemonadeText.swift
@@ -167,8 +167,13 @@ private struct LemonadeTextView: View {
             return .body
         }
 
-        let size = fontSize ?? style.fontSize
-        return .custom(LemonadeTypography.fontFamily, size: size).weight(style.fontWeight)
+        // Only a caller-supplied size override has to build a font here; the style already
+        // carries the one it resolves to, so the common path is a stored-property load.
+        if let fontSize = fontSize {
+            return .custom(LemonadeTypography.fontFamily, size: fontSize).weight(style.fontWeight)
+        }
+
+        return style.weightedFont
     }
 }
 
@@ -319,7 +324,7 @@ private struct LemonadeAttributedTextView: View {
             return .body
         }
 
-        return .custom(style.fontName, size: style.fontSize, relativeTo: .body)
+        return style.font
     }
 }
 

--- a/swiftui/Sources/Lemonade/LemonadeTypography.swift
+++ b/swiftui/Sources/Lemonade/LemonadeTypography.swift
@@ -40,9 +40,15 @@ public struct LemonadeTextStyle: Sendable {
         self.fontWeight = fontWeight
         self.letterSpacing = letterSpacing
 
+        let resolvedName = Self.fontName(for: fontWeight)
+        self.fontName = resolvedName
+        self.font = .custom(resolvedName, size: fontSize, relativeTo: .body)
+        self.weightedFont = .custom(LemonadeTypography.fontFamily, size: fontSize)
+            .weight(fontWeight)
+
 #if canImport(UIKit)
         let naturalLineHeight = Self.resolvedUIFont(
-            name: Self.fontName(for: fontWeight),
+            name: resolvedName,
             size: fontSize
         ).lineHeight
 #else
@@ -69,14 +75,18 @@ public struct LemonadeTextStyle: Sendable {
     }
 
     /// The font name based on the weight
-    public var fontName: String {
-        Self.fontName(for: fontWeight)
-    }
+    public let fontName: String
 
-    /// Returns a SwiftUI Font based on this text style
-    public var font: Font {
-        .custom(fontName, size: fontSize, relativeTo: .body)
-    }
+    /// Returns a SwiftUI Font based on this text style.
+    ///
+    /// Stored for the same reason as ``lineSpacing``: it is read from inside `body`, and
+    /// `Font.custom(_:size:relativeTo:)` boxes a new font provider on every call.
+    public let font: Font
+
+    /// The face asked for by the family name plus a weight modifier, which is how the string
+    /// overloads of ``LemonadeUi/Text(_:)`` resolve their font — a different expression from
+    /// ``font``, kept as-is here so this stays a pure caching change. Stored for the same reason.
+    let weightedFont: Font
 
 #if canImport(UIKit)
     /// The single place a text style turns into a concrete face.


### PR DESCRIPTION
# Summary

Three per-body-evaluation costs on the paths a list row walks: font resolution in
`LemonadeUi.Text`, the shimmer gradient in `SkeletonView`, and a no-op background
layer on every `ListItem`. All internal — no public declaration is added or removed.

This is the iOS-side counterpart to #323 (williankl's ListItem work on Compose),
though it is deliberately a much smaller set. Most of what that PR does has no
counterpart here, because SwiftUI already had it: `SymbolContainer` already draws a
shaped background instead of clipping (#323 ports *that* to Compose), the outlined
`SelectListItem` already uses background + `strokeBorder`, the divider became one
`Shape` in #302, and the press highlight is already confined to a `ButtonStyle` body.

## Figma component

N/A — no visual change intended.

## Screenshot

No screenshot attached; this is meant to be a visual no-op. Verified on an
iPhone 17 Pro simulator instead — the ListItem layout-priority screen renders
identically, and the Skeleton screen was checked in both light and dark with the
shimmer still animating (three consecutive captures differ). Step 3 under "How to
test" reproduces it.

## API Dump

**Verdict:** NO_CHANGES

No public API changes. No `kmp/<module>/api/*.api` or `*.klib.api` file is touched —
this PR is SwiftUI-only. `.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci`
confirms `NO_CHANGES`.

Worth noting for reviewers, since the SwiftUI side has no Binary Compatibility
Validator to prove it mechanically: `fontName` and `font` on `LemonadeTextStyle`
change from computed `var` to stored `let`. That is the same storage-kind conversion
the 274 colour tokens took in #302 — source-compatible for readers, and both are
still `public`.

## What changed

- **`LemonadeTextStyle` resolves its fonts once, in `init`.** `resolveFont()` was
  building `Font.custom(family, size:).weight(_:)` on every body evaluation — two
  provider boxes per call, two or three calls per row. The style now stores both
  the font the string overloads ask for (`weightedFont`, internal) and the one the
  AttributedString overload asks for (`font`, already public), next to the
  `lineSpacing` metric cached there for exactly the same reason in #302. A
  caller-supplied `fontSize` override still builds its font inline.
- **The shimmer ramp is hoisted out of `SkeletonView.body`.** A three-colour
  `Gradient` was rebuilt per evaluation while only the gradient's start and end
  points move. Appearance changes are unaffected: the theme's colours are
  asset-catalog colours that resolve per trait at render time.
- **`ListItemSafeArea` loses its `.background(Color.clear)`** — one layer per row
  for no visual result.

## Behaviour changes to be aware of

**None intended.** One thing deliberately *not* changed, though, because it is a
behaviour question rather than a caching one:

The two `Text` overload families resolve their font differently — the string ones
via `.custom("Figtree", size:).weight(...)` (no `relativeTo:`, so no Dynamic Type
scaling), the AttributedString one via `.custom("Figtree-Medium", size:, relativeTo: .body)`
(which does scale). This PR caches each expression exactly as it was rather than
picking a winner, since unifying them changes the rendered size of essentially
every screen. Filed as #333 and pointed at the text-scaling work already in flight
(#299, #300, #305).

## On measurements

There are none, and the PR does not claim any. Every change here deletes work that
the code demonstrably repeats per body evaluation, which is why it is being proposed
without a trace — but unlike #323, which has atrace numbers behind each lever, the
size of the win on iOS is unmeasured. If a reviewer wants it quantified before
merge, the font path is the one worth a microbenchmark; it is the same shape as the
`lineSpacing` measurement in #302 (~1085 ns → ~0.5 ns per read).

## How to test

1. `cd swiftui && ./scripts/generate-ios-project.sh`, then build and run
   `LemonadeSampleApp`.
2. **Text** — open Typography and a few component screens. Every style should
   render at the same size, weight and line height as `main`. ListItem is the
   densest check: open ListItem and compare all four layout-priority sections.
3. **Skeleton** — open Skeleton. All three variants should shimmer as before, and
   the shimmer should still animate. Flip appearance via the gear → Settings and
   confirm the skeletons follow into dark (this is the one change that could
   plausibly have frozen a colour).
4. **ListItem** — open ListItem and ContentListItem; rows, dividers and the press
   highlight should be unchanged.
5. `swift test` — 32 tests, unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
- [ ] Did I add/update translations?
- [ ] I have considered whether my changes affect E2E tests
- [ ] If these changes rely on a feature flag, does it have the correct value for staging and production?
- [ ] If these changes use a new version of an API, is that new version on staging and production?
