### PR TITLE
fix(list-item): stop the press highlight latching on fast taps

### DIFF
--- a/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
+++ b/kmp/ui/src/commonMain/kotlin/com/teya/lemonade/ListItemHighlight.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.unit.LayoutDirection
 import com.teya.lemonade.core.LemonadeListItemVoice
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /** The default spring of `animateColorAsState`, which the highlight previously animated with. */
@@ -48,6 +49,8 @@ private class ListItemHighlightNode(
     private val hoverInteractions = mutableListOf<HoverInteraction.Enter>()
 
     private var highlightFraction: Animatable<Float, AnimationVector1D>? = null
+    private var highlightTarget = 0f
+    private var animationJob: Job? = null
 
     private var cachedOutline: Outline? = null
     private var cachedSize: Size = Size.Unspecified
@@ -74,6 +77,8 @@ private class ListItemHighlightNode(
         pressInteractions.clear()
         hoverInteractions.clear()
         highlightFraction = null
+        highlightTarget = 0f
+        animationJob = null
         cachedOutline = null
         cachedSize = Size.Unspecified
         cachedLayoutDirection = null
@@ -83,18 +88,16 @@ private class ListItemHighlightNode(
     private fun animateHighlight() {
         val active = pressInteractions.isNotEmpty() || hoverInteractions.isNotEmpty()
         val target = if (active) 1f else 0f
-        val animatable = highlightFraction
-            ?: if (active) {
-                Animatable(initialValue = 0f).also { created ->
-                    highlightFraction = created
-                }
-            } else {
-                return
-            }
-        if (animatable.targetValue == target) {
+        if (target == highlightTarget) {
             return
         }
-        coroutineScope.launch {
+        highlightTarget = target
+        val animatable = highlightFraction
+            ?: Animatable(initialValue = 0f).also { created ->
+                highlightFraction = created
+            }
+        animationJob?.cancel()
+        animationJob = coroutineScope.launch {
             animatable.animateTo(
                 targetValue = target,
                 animationSpec = HighlightAnimationSpec,


### PR DESCRIPTION
# Summary

Fixes the press highlight latching on interactive list items — the row keeps its
`bgSubtleInteractive` fill after the finger lifts and never fades back out.

Regressed in #323, which replaced the `animateColorAsState` highlight with a
`Modifier.Node` indication.

### Root cause

`ListItemHighlightNode.animateHighlight()` decided whether to start an animation by
comparing against `Animatable.targetValue`:

```kotlin
if (animatable.targetValue == target) return
coroutineScope.launch { animatable.animateTo(target, …) }
```

`targetValue` is assigned **inside `mutatorMutex.mutate {}`** (`Animatable.kt:302`), so it
only updates once the launched coroutine has actually been dispatched. Until then it
still reports the previous target.

That breaks whenever both interactions arrive in one pass. For a tap that beats
`TapIndicationDelay` (100 ms), `AbstractClickableNode.handlePressInteractionRelease`
(`Clickable.kt:1678-1686`) emits `Press` **and** `Release` back-to-back inside a single
coroutine, and `MutableInteractionSource`'s buffered `SharedFlow`
(`extraBufferCapacity = 16`) hands both to the collector without a suspension in between:

1. `Press` → queues `animateTo(1f)`, which has not run
2. `Release` → reads stale `targetValue == 0f`, matches its own target of `0f`, **returns
   early — the fade-out is never scheduled**
3. The queued fade-in runs → the row stays highlighted permanently

`delayPressInteraction()` is `hasScrollableContainer() || isComposeRootInScrollableContainer()`,
so every row in a `LazyColumn`/`verticalScroll` takes that path. `SelectListItem` is the
most exposed caller because it deliberately shares one `interactionSource` between the row
and its `SelectionControl` (`SelectListItem.kt:339`+`:365`), putting two interaction
producers into the same buffer drain.

The same guard had an inverse failure: a re-tap arriving before a queued fade-out ran saw
a stale `targetValue == 1f` and returned early, so the fade-out then un-highlighted the
row while the finger was still down.

### Fix

The target now lives on the node and is assigned synchronously in the collector, mirroring
`StateLayer` in `material-ripple` — which guards on its own `currentInteraction` field,
never on `animatedAlpha.targetValue`. The previous animation job is cancelled explicitly
so ordering never depends on dispatcher FIFO or on `MutatorMutex` racing the queue.

`onDetach()` resets `highlightTarget` as well; without it a detached-then-reattached node
would keep a stale target of `1f` while `highlightFraction` is null and would never
highlight again.

Untouched rows still allocate no `Animatable`, so the per-row cost from #323 is unchanged.

### Behaviour note

Taps under 100 ms in a scrollable list now show effectively no highlight. That matches
pre-#323 behaviour — snapshot coalescing meant `collectIsPressedAsState` never observed
the transient press there either. Giving quick taps a guaranteed minimum visible flash
(the way Material's ripple does) would be a separate behaviour change and is not in scope
here.

## Figma component

n/a — behavioural fix, no design change.

## Screenshot

Verified on `emulator-5554`, sample app → Display Components → SelectListItem. Taps issued
with `adb shell input tap`, whose ~0 ms down/up gap deterministically hits the racing path.
Row pixels sampled clear of text and the control; an idle row is `(255,255,255)` and a
latched `bgSubtleInteractive` row is `(241,240,238)`.

| Case | Before | After |
| --- | --- | --- |
| 3 fast taps, +3 s | 3 rows latched `(241,240,238)` | all `(255,255,255)` |
| single fast tap, +8 s | still latched | — |
| 12 rapid taps on one row | — | clean |
| press-and-hold 2 s | — | highlights `(241,240,238)`, clears on release |
| scroll off-screen and back, then hold | — | still highlights, still clears |

The press-and-hold and scroll-off/on rows confirm the fix does not simply disable the
highlight, and that the `onDetach` reset works.

## API Dump

**Verdict:** NO_CHANGES

`.claude/skills/binary-compatibility/scripts/bcv-check.sh --ci` reports
`NO_CHANGES — public API is identical.` No `api/*.api` or `*.klib.api` file is touched:
`ListItemHighlightIndication` is `internal` with an unchanged shape, and
`ListItemHighlightNode` is private. `apiCheck`, `ktlintCheck` and `detektMetadataCommonMain`
all pass.

**Changes that are not a concern, and why:**

No public API changes.

**Genuine breaking changes (if any):**

None.

https://claude.ai/code/session_01WpDbS5jmqvvDg2QHE53Lgi
